### PR TITLE
ansible-requirements.yaml: fix a syntax error

### DIFF
--- a/ansible-requirements.yaml
+++ b/ansible-requirements.yaml
@@ -3,15 +3,16 @@
 
 # External Ansible roles and collections used by SEAPATH are described here.
 ---
-- name: "systemd_networkd"
-  src: "https://github.com/seapath/ansible-role-systemd-networkd"
-  scm: git
-  version: "3af47e369c7013782e0c4740638927955646471b"
+roles:
+    - name: "systemd_networkd"
+      src: "https://github.com/seapath/ansible-role-systemd-networkd"
+      scm: git
+      version: "3af47e369c7013782e0c4740638927955646471b"
 
-- name: "corosync"
-  src: "https://github.com/seapath/corosync-ansible"
-  scm: git
-  version: "master"
+    - name: "corosync"
+      src: "https://github.com/seapath/corosync-ansible"
+      scm: git
+      version: "master"
 
 collections:
     - name: "community.libvirt"


### PR DESCRIPTION
The **roles:** section header was missing. This header must be present if you mix roles and collections in the same Ansible galaxy requirements file.