### PR TITLE
playbooks: add playbooks to run PXE and DHCP server with the "pxe" container

### DIFF
--- a/playbooks/ci_boot_machine_from_pxe.yaml
+++ b/playbooks/ci_boot_machine_from_pxe.yaml
@@ -1,0 +1,51 @@
+# Copyright (C) 2021, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+# This Ansible playbook start machines and ensure the PXE flash image is
+# running on it.
+---
+- name: Launch PXE server on CI
+  hosts: localhost
+  tasks:
+      - name: Create PXE configuration file
+        template:
+            src: ../templates/pxe_extra_config.conf.j2
+            dest: "{{ playbook_dir }}/pxe_extra_config.conf"
+      - name: Start the PXE server
+        docker_container:
+            recreate: true
+            network_mode: host
+            volumes:
+                - "{{ playbook_dir }}/../pxe_images:/tftpboot/syslinux/images:ro"
+                - "{{ playbook_dir }}/pxe_extra_config.conf:/etc/dnsmasq.d/pxe_extra_config.conf:ro"
+            auto_remove: true
+            state: "started"
+            image: "seapath-pxe:latest"
+            name: "seapath_flash_pxe"
+            capabilities:
+                - "net_admin"
+                - "net_raw"
+            env:
+                DHCP_RANGE_BEGIN: "{{ dhcp_range_begin }}"
+                DHCP_RANGE_END: "{{ dhcp_range_end }}"
+                BIND_INTERFACE: "{{ dhcp_bind_interface }}"
+                SERVER_ADDRESS: "{{ pxe_server_address }}"
+                PXE: "bios"
+- import_playbook: ci_restart_machines.yaml
+  vars:
+      machines: pxe_machines
+- name: Check all machines have boot on the flash-pxe image
+  hosts: pxe_machines
+  tasks:
+      - name: "Check {{ inventory_hostname }} have boot on the flash-pxe image"
+        lineinfile:
+            path: /etc/os-release
+            state: present
+            line: NAME="Seapath Flash Yocto distribution"
+        check_mode: true
+- name: Stop the PXE server
+  hosts: localhost
+  tasks:
+      - name: Stop ci_pxe container
+        docker_container:
+            state: "stopped"
+            name: "seapath_flash_pxe"

--- a/playbooks/ci_enable_vms_dhcp.yaml
+++ b/playbooks/ci_enable_vms_dhcp.yaml
@@ -1,0 +1,28 @@
+# Copyright (C) 2021, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Prepare the CI
+  hosts: localhost
+  tasks:
+    - name: Create DHCP VMs configuration file
+      template:
+        src: ../templates/dhcp_vms_extra_config.conf.j2
+        dest: "{{ playbook_dir }}/dhcp_vms_extra_config.conf"
+    - name: Start the DHCP server
+      docker_container:
+        recreate: true
+        network_mode: host
+        auto_remove: true
+        state: "started"
+        volumes:
+          - "{{ playbook_dir }}/dhcp_vms_extra_config.conf:/etc/dnsmasq.d/dhcp_vms_extra_config.conf:ro"
+        image: "seapath-pxe:latest"
+        name: "seapath_vms_dhcp"
+        capabilities:
+          - "net_admin"
+          - "net_raw"
+        env:
+          DHCP_RANGE_BEGIN: "{{ dhcp_vm_range_begin }}"
+          DHCP_RANGE_END: "{{ dhcp_vm_range_end }}"
+          BIND_INTERFACE: "{{ dhcp_vm_bind_interface }}"

--- a/playbooks/tasks/deploy_vm_from_template.yaml
+++ b/playbooks/tasks/deploy_vm_from_template.yaml
@@ -1,0 +1,14 @@
+# Copyright (C) 2021, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+# Task to deploy a VM from a template
+
+---
+- name: "Create {{ item }}"
+  cluster_vm:
+    name: "{{ item }}"
+    command: clone
+    src_name: "{{ template }}"
+    force: true
+    xml: "{{ lookup('file', vms_config_directory + '/' + item + '.xml') }}"
+    pinned_host: "{{ hostvars[item].pinned_host | default('') }}"
+    preferred_host: "{{ hostvars[item].preferred_host | default('') }}"

--- a/templates/dhcp_vms_extra_config.conf.j2
+++ b/templates/dhcp_vms_extra_config.conf.j2
@@ -1,0 +1,5 @@
+{% for VM in groups['VMs'] %}
+{% if hostvars[VM].use_dhcp is defined and hostvars[VM].use_dhcp %}
+dhcp-host={{ hostvars[VM].mac_address }},{{ hostvars[VM].ansible_host }}
+{% endif %}
+{% endfor %}

--- a/templates/pxe_extra_config.conf.j2
+++ b/templates/pxe_extra_config.conf.j2
@@ -1,0 +1,3 @@
+{% for pxe_machine in groups['pxe_machines'] %}
+dhcp-host={{ hostvars[pxe_machine].mac_address }},{{ hostvars[pxe_machine].ansible_host }}
+{% endfor %}


### PR DESCRIPTION
Add the playbook "ci_enable_vms_dhcp.yaml" which starts a DHCP server to give an IP address to the VMs, using the new "pxe" container found in the "containers" repository.

 Add the playbook "ci_boot_machine_from_pxe.yaml" to boot machine from  PXE using the new "pxe" container found in the "containers" repository.

 With those playbooks, all the container configuration is done in playbooks, including the MAC address and the IP address link.