### PR TITLE
ansible-requirements.yaml: do not use corosync-ansible master reference

### DIFF
--- a/ansible-requirements.yaml
+++ b/ansible-requirements.yaml
@@ -12,7 +12,7 @@ roles:
     - name: "corosync"
       src: "https://github.com/seapath/corosync-ansible"
       scm: git
-      version: "master"
+      version: "893afb5e92a2b748d53ac7eabf428d5cf96fc4e5"
 
 collections:
     - name: "community.libvirt"


### PR DESCRIPTION
The master branch in corosync-ansible was renamed main. Update ansible-requirements.yaml to use a commit ID for corosync-ansible instead of the master branch.

Signed-off-by: Mathieu Dupré <mathieu.dupre@savoirfairelinux.com>