### PR TITLE
module_documentation_sources/requirements.txt: use latest Ansible 2.9

### DIFF
--- a/module_documentation_sources/requirements.txt
+++ b/module_documentation_sources/requirements.txt
@@ -4,4 +4,4 @@ rstcheck
 sphinx
 sphinx-notfound-page
 Pygments >= 2.4.0
-ansible == 2.9
+ansible >= 2.9,<2.10


### PR DESCRIPTION
Do no use Ansible 2.9.0 but the latest Ansible version in 2.9 branches.

Signed-off-by: Mathieu Dupré <mathieu.dupre@savoirfairelinux.com>