### PR TITLE
ceph-ansible-patches: do not check for distribution

### DIFF
--- a/src/ceph-ansible-patches/osd_no_package.diff
+++ b/src/ceph-ansible-patches/osd_no_package.diff
@@ -1,13 +1,28 @@
 diff --git a/roles/ceph-osd/tasks/main.yml b/roles/ceph-osd/tasks/main.yml
-index 18595055..28ba5743 100644
+index 18595055..ee298a10 100644
 --- a/roles/ceph-osd/tasks/main.yml
 +++ b/roles/ceph-osd/tasks/main.yml
-@@ -23,7 +23,7 @@
-   until: result is succeeded
-   when:
-     - not containerized_deployment | bool
--    - ansible_facts['os_family'] != 'ClearLinux'
-+    - ansible_os_family != 'ClearLinux' and ansible_os_family != 'Seapath Yocto distribution'
+@@ -15,16 +15,6 @@
+ - name: include_tasks system_tuning.yml
+   include_tasks: system_tuning.yml
  
+-- name: install dependencies
+-  package:
+-    name: parted
+-    state: present
+-  register: result
+-  until: result is succeeded
+-  when:
+-    - not containerized_deployment | bool
+-    - ansible_facts['os_family'] != 'ClearLinux'
+-
  - name: install numactl when needed
    package:
+     name: numactl
+@@ -129,4 +119,4 @@
+     - not rolling_update | default(False) | bool
+     - openstack_config | bool
+     - inventory_hostname == groups[osd_group_name] | last
+-  tags: wait_all_osds_up
+\ No newline at end of file
++  tags: wait_all_osds_up


### PR DESCRIPTION
Ceph-ansible tries to install the parted command with a package manager.
In SEAPATH we do not have package manager and parted is already installed, so ceph-ansible parted installation step failed.

To avoid this failure, we have appended "Seapath Yocto distribtion" to the distribtion list which is used to bypass the parted installation step.

Due to the SEAPAH Yocto distro refactoring the distribution is now not constant, and so the distribution list can no longer be used.

To avoid a failure on this step we now just remove this step.

Signed-off-by: Mathieu Dupré <mathieu.dupre@savoirfairelinux.com>