### PR TITLE
rbd hosts last

### DIFF
--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -62,7 +62,7 @@
       replace:
         path: /etc/hosts
         regexp: '^{{ cluster_ip_addr }} {{ inventory_hostname }}$'
-        replace: '{{ cluster_ip_addr }} rbd {{ inventory_hostname }}'
+        replace: '{{ cluster_ip_addr }} {{ inventory_hostname }} rbd'
       when: cluster_ip_addr is defined
 
 - name: Configure NTP


### PR DESCRIPTION
To avoid the system thinking "rbd" is the official hostname of the host.