### PR TITLE
playbooks/cluster_setup_ceph: add a variable to skip disk formatting

### DIFF
--- a/playbooks/cluster_setup_ceph.yaml
+++ b/playbooks/cluster_setup_ceph.yaml
@@ -31,6 +31,8 @@
       - name: Cleanup Ceph OSD disks with ceph-volume
         shell:
             cmd: "ceph-volume lvm zap {{ ceph_osd_disk }} --destroy"
+        when: skip_disk_format is undefined
+
 - import_playbook: ../ceph-ansible/site.yml
 
 # Ceph mgr module which is enabled by default is not supported by SEAPATH.


### PR DESCRIPTION
Add the Ansible variable skip_disk_format to avoid formatting the Ceph OSD disk.

This can be useful to re-run the Ceph setup a 2nd time, for example to enroll a new machine.