### PR TITLE
ansible.cfg: add ceph-ansible roles directory in roles path

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -12,7 +12,7 @@ action_plugins = ./ceph-ansible/plugins/actions
 callback_plugins = ./ceph-ansible/plugins/callback
 filter_plugins = ./ceph-ansible/plugins/filter
 log_path = ./ansible.log
-roles_path = ./roles
+roles_path = ./roles:ceph-ansible/roles
 forks = 20
 collections_paths = ./collections:~/.ansible/collections:/usr/share/ansible/collections
 


### PR DESCRIPTION
Adding ceph-ansible roles in roles path allow using ceph-ansible's playbooks in infrastructure-playbooks directory from the SEAPATH ansible root repository.

infrastructure-playbook directory contains useful playbooks to perform maintenance operation on a Ceph cluster.