### PR TITLE
playbooks/ci_realtime_tests: disable RT-Throttling for RT tests

### DIFF
--- a/playbooks/ci_realtime_tests.yaml
+++ b/playbooks/ci_realtime_tests.yaml
@@ -4,6 +4,14 @@
 # Ansible playbook that runs Cukinia realtime tests.
 
 ---
+
+- name: Disable RT-Throttling on host
+  hosts: hypervisors
+  tasks:
+    - name: Set sched_rt_period_us to -1 (Disabled)
+      shell:
+        cmd: "echo -1 > /proc/sys/kernel/sched_rt_period_us"
+
 - hosts: "{{ machines_tested | default('VMs') }}"
   name: Realtime tests
   tasks:


### PR DESCRIPTION
Before running RT tests, disable RT-Throttling (give all the CPU time for RT process).

Without disabling RT-Throttling in our setup, the VM will be throttling for 50 ms every second.

Signed-off-by: Mathieu Dupré <mathieu.dupre@savoirfairelinux.com>