### PR TITLE
[debian] consolevm: changes user from root to virtu

### DIFF
--- a/src/debian/consolevm.sh
+++ b/src/debian/consolevm.sh
@@ -12,6 +12,6 @@ else
     echo no hypervisor found for this vm
   else
     echo "$vm is running on $hyp, let's connect !"
-    virsh --connect qemu+ssh://root@$hyp/system console $vm
+    virsh --connect qemu+ssh://virtu@$hyp/system console $vm
   fi
 fi


### PR DESCRIPTION
Since the keys playbook allows root to connect the the other machines
with the virtu user, this changes the behavior of consolevm.sh so that
it also uses virtu as the user for its outgoing connection.

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>