### PR TITLE
[debian] networkd: link up for all interfaces

### DIFF
--- a/playbooks/cluster_setup_prerequisdebian.yaml
+++ b/playbooks/cluster_setup_prerequisdebian.yaml
@@ -234,6 +234,14 @@
         state: restarted
       when: sysfscpumask.changed
 
+    - name: Copy 80-wired networkd file
+      ansible.builtin.copy:
+        src: ../src/debian/80-wired.network
+        dest: /etc/systemd/network/80-wired.network
+        mode: '0640'
+        owner: root
+        group: systemd-network
+
     - name: Copy metricbeat conf file
       ansible.builtin.copy:
         src: ../src/debian/metricbeat.yml

--- a/src/debian/80-wired.network
+++ b/src/debian/80-wired.network
@@ -1,0 +1,11 @@
+[Match]
+Name=en* eth*
+KernelCommandLine=!nfsroot
+KernelCommandLine=!ip
+
+[Network]
+DHCP=no
+
+[Link]
+MTUBytes=1500
+


### PR DESCRIPTION
Yocto systemd recipe adds a networkd configuration to enable all
interfaces by default
(https://git.yoctoproject.org/poky/plain/meta/recipes-core/systemd/systemd-conf/wired.network)
This changes reproduces this behavior on debian

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>