### PR TITLE
[debian] corosync: wait for team0 to be up before starting

### DIFF
--- a/playbooks/cluster_setup_prerequisdebian.yaml
+++ b/playbooks/cluster_setup_prerequisdebian.yaml
@@ -116,6 +116,21 @@
         group: root
         mode: 0644
       notify: daemon-reload
+    - name: Create corosync.service.d directory
+      file:
+        path: /etc/systemd/system/corosync.service.d/
+        state: directory
+        owner: root
+        group: root
+        mode: 0755
+    - name: Copy corosync.service drop-in
+      ansible.builtin.copy:
+        src: ../src/debian/corosync_override.conf
+        dest: /etc/systemd/system/corosync.service.d/override.conf
+        owner: root
+        group: root
+        mode: 0644
+      notify: daemon-reload
     - name: Create pacemaker.service.d directory
       file:
         path: /etc/systemd/system/pacemaker.service.d/

--- a/src/debian/corosync_override.conf
+++ b/src/debian/corosync_override.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPre=/bin/sh -c 'while [ $(ip a | grep team0 | grep inet | grep brd | wc -l) -ne 1 ]; do sleep 1; done'


### PR DESCRIPTION
it seems that since the team0 interface is created by OVS, its readiness
is not part of the network-online.target.
This changes makes sure corosync wait for team0 (cluster network) to be
up with an IP before starting

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>