### PR TITLE
[debian] Remove "debian" line from /etc/hosts

### DIFF
--- a/roles/debian/tasks/main.yml
+++ b/roles/debian/tasks/main.yml
@@ -192,6 +192,12 @@
     regexp: '^virtu'
     validate: visudo -cf %s
 
+- name: remove 'debian' from hosts file
+  lineinfile:
+    dest: /etc/hosts
+    state: absent
+    regexp: '^127.*debian'
+
 - name: Copy journald conf file
   ansible.builtin.copy:
     src: ../src/debian/journald.conf


### PR DESCRIPTION
The base debian image includes a "127.0.0.1 debian" line in the
/etc/hosts file.
This commits make the ansible debian prerequisite role remove it.

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>