### PR TITLE
/etc/hosts: bug when adding the logstash_seapath record

### DIFF
--- a/roles/debian/tasks/main.yml
+++ b/roles/debian/tasks/main.yml
@@ -285,6 +285,7 @@
 - name: lineinfile in hosts file for logstash_seapath
   lineinfile:
     dest: /etc/hosts
+    regexp: '.* logstash_seapath$'
     line: "{{ logstash_server_ip }} logstash_seapath"
     state: present
 


### PR DESCRIPTION
In the case the playbook needs to change the ip address, the current task has a bug that make the playbook add a new line instead of changing the existing line. This patch solves this.

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>