### PR TITLE
[debian] syslog-ng: make the timestamp UTC

### DIFF
--- a/templates/syslog-ng.conf.j2
+++ b/templates/syslog-ng.conf.j2
@@ -40,6 +40,7 @@ destination d_net {
                 "{{ syslog_server_ip }}"
                 port(5054)
                 transport("tcp")
+		time_zone("UTC")
                 disk-buffer(
                         mem-buf-size(16384000)
                         disk-buf-size(107374182)


### PR DESCRIPTION
The syslog-ng configuration uses the local time for the messages it
emits. This makes ELK choke (since the default behavior for a logstash
syslog plugin is to consider the timestamp as UTC).
This changes makes syslog-ng uses UTC.

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>