### PR TITLE
[debian] workaround for rcu/kvm bug: reboot host

### DIFF
--- a/roles/debian/hypervisor/tasks/main.yml
+++ b/roles/debian/hypervisor/tasks/main.yml
@@ -75,11 +75,23 @@
     enabled: yes
     state: started
 
-- name: "systemd conf"
+- name: "systemd conf CPUAffinity"
   lineinfile:
     dest: /etc/systemd/system.conf
     regexp: '^CPUAffinity=.*$'
     line: "CPUAffinity={{ cpusystem }}"
+    state: present
+- name: "systemd conf RuntimeWatchdogSec"
+  lineinfile:
+    dest: /etc/systemd/system.conf
+    regexp: '^RuntimeWatchdogSec=.*$'
+    line: "RuntimeWatchdogSec=20"
+    state: present
+- name: "systemd conf RebootWatchdogSec"
+  lineinfile:
+    dest: /etc/systemd/system.conf
+    regexp: '^RebootWatchdogSec=.*$'
+    line: "RebootWatchdogSec=5min"
     state: present
 
 - name: Create systemd slices override
@@ -150,3 +162,47 @@
     daemon_reload: yes
     name: ovs-vswitchd
   when: ovsvswitchd.changed
+
+
+- name: Copy monitor_journalctl.service
+  ansible.builtin.copy:
+    src: ../src/debian/monitor_journalctl.service
+    dest: /etc/systemd/system/monitor_journalctl.service
+    mode: '0644'
+  register: monitor_journalctl_service
+- name: Copy monitor_journalctl service script
+  ansible.builtin.copy:
+    src: ../src/debian/monitor_journalctl.sh
+    dest: /usr/local/sbin/monitor_journalctl.sh
+    mode: '0750'
+  register: monitor_journalctl_script
+- name: daemon-reload monitor_journalctl
+  ansible.builtin.service:
+    daemon_reload: yes
+  when: monitor_journalctl_service.changed or monitor_journalctl_script.changed
+- name: enable monitor_journalctl.service
+  ansible.builtin.systemd:
+    name: monitor_journalctl.service
+    enabled: yes
+
+- name: Copy monitor_journalctl_hard.service
+  ansible.builtin.copy:
+    src: ../src/debian/monitor_journalctl_hard.service
+    dest: /etc/systemd/system/monitor_journalctl_hard.service
+    mode: '0644'
+  register: monitor_journalctl_hard_service
+- name: Copy monitor_journalctl_hard service script
+  ansible.builtin.copy:
+    src: ../src/debian/monitor_journalctl_hard.sh
+    dest: /usr/local/sbin/monitor_journalctl_hard.sh
+    mode: '0750'
+  register: monitor_journalctl_hard_script
+- name: daemon-reload monitor_journalctl_hard
+  ansible.builtin.service:
+    daemon_reload: yes
+  when: monitor_journalctl_hard_service.changed or monitor_journalctl_hard_script.changed
+- name: enable monitor_journalctl_hard.service
+  ansible.builtin.systemd:
+    name: monitor_journalctl_hard.service
+    enabled: yes
+

--- a/src/debian/monitor_journalctl.service
+++ b/src/debian/monitor_journalctl.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Monitor Journalctl
+
+[Service]
+User=root
+Restart=always
+
+ExecStart=/usr/local/sbin/monitor_journalctl.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/src/debian/monitor_journalctl.sh
+++ b/src/debian/monitor_journalctl.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+/usr/bin/journalctl --follow | while read -r line; do
+    if [[ $line == *"rcu_preempt self-detected stall on CPU"* ]]; then
+        echo "date >> /log_reboot_rcu.txt"
+        date >> /log_reboot_rcu.txt
+        echo "systemctl stop pacemaker"
+        /usr/bin/systemctl stop pacemaker
+        echo "/usr/sbin/reboot"
+        /usr/sbin/reboot
+    fi
+done
+

--- a/src/debian/monitor_journalctl_hard.service
+++ b/src/debian/monitor_journalctl_hard.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Monitor Journalctl hard
+
+[Service]
+User=root
+Restart=always
+
+ExecStart=/usr/local/sbin/monitor_journalctl_hard.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/src/debian/monitor_journalctl_hard.sh
+++ b/src/debian/monitor_journalctl_hard.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+/usr/bin/journalctl --follow | while read -r line; do
+    if [[ $line == *"rcu_preempt self-detected stall on CPU"* ]]; then
+        echo "hard: sleep 3min"
+        sleep 180
+        echo "hard reboot"
+        echo s > /proc/sysrq-trigger
+        echo b > /proc/sysrq-trigger
+    fi
+done

--- a/src/debian/system.conf
+++ b/src/debian/system.conf
@@ -26,8 +26,8 @@
 CPUAffinity=0,12
 #NUMAPolicy=default
 #NUMAMask=
-#RuntimeWatchdogSec=0
-#RebootWatchdogSec=10min
+RuntimeWatchdogSec=20
+RebootWatchdogSec=5min
 #ShutdownWatchdogSec=10min
 #KExecWatchdogSec=0
 #WatchdogDevice=


### PR DESCRIPTION
When the VMs are stopping/starting/restarting too fast, we encounter a
bug that bricks the host. The console shows logs like:
- "rcu_preempt self-detected stall on CPU"
- "rcuc/5 kthread starved for 5311 jiffies"
- "asm_sysvec_spurious_apic_interrupt"
- "vmx_handle_exit_irqoff"
- etc.

This commit adds some systemd watchdog configuration, plus 2 services
that will monitor the logs for the rcu_preempt message and try to reboot
the host if it does find one.
The first service will try to stop pacemaker cleanly (to migrate the VMs
to other hosts) and then try to reboot the host cleanly.
The second service will just wait 3min and restart the host abruptly, as
a safeguard when the first service is not successful.

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>