### PR TITLE
[debian] change logstash hostname to "logstash-seapath"

### DIFF
--- a/playbooks/cluster_setup_elastic.yaml
+++ b/playbooks/cluster_setup_elastic.yaml
@@ -1,8 +1,8 @@
 - name: Add elastic cluster ip
   hosts: cluster_machines
   tasks:
-    - name: lineinfile in hosts file for logstash_seapath
+    - name: lineinfile in hosts file for logstash-seapath
       lineinfile:
         dest: /etc/hosts
-        line: "{{ logstash_server_ip }} logstash_seapath"
+        line: "{{ logstash_server_ip }} logstash-seapath"
         state: present

--- a/playbooks/cluster_setup_florentseapath.yaml
+++ b/playbooks/cluster_setup_florentseapath.yaml
@@ -19,10 +19,10 @@
 - name: config elastic metricbeat
   hosts: cluster_machines
   tasks:
-    - name: lineinfile in hosts file for logstash_seapath
+    - name: lineinfile in hosts file for logstash-seapath
       lineinfile:
         dest: /etc/hosts
-        line: "{{ logstash_server_ip }} logstash_seapath"
+        line: "{{ logstash_server_ip }} logstash-seapath"
         state: present
 - name: config MSMTP
   hosts: cluster_machines

--- a/roles/debian/tasks/main.yml
+++ b/roles/debian/tasks/main.yml
@@ -282,10 +282,10 @@
     group: virtu
     mode: '0644'
 
-- name: lineinfile in hosts file for logstash_seapath
+- name: lineinfile in hosts file for logstash-seapath
   lineinfile:
     dest: /etc/hosts
-    regexp: '.* logstash_seapath$'
-    line: "{{ logstash_server_ip }} logstash_seapath"
+    regexp: '.* logstash-seapath$'
+    line: "{{ logstash_server_ip }} logstash-seapath"
     state: present
 

--- a/src/debian/metricbeat.yml
+++ b/src/debian/metricbeat.yml
@@ -104,7 +104,7 @@ setup.kibana:
 # ------------------------------ Logstash Output -------------------------------
 output.logstash:
   # The Logstash hosts
-  hosts: ["logstash_seapath:5066"]
+  hosts: ["logstash-seapath:5066"]
 
   # Optional SSL. By default is off.
   # List of root certificates for HTTPS server verifications


### PR DESCRIPTION
It seems logstash_seapath is not a valid name according to RFC1035,
since underscore characters are not permitted.
This commit changes the expected name to logstash-seapath.

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>