### PR TITLE
debian: RCU priority change

### DIFF
--- a/roles/debian/hypervisor/tasks/main.yml
+++ b/roles/debian/hypervisor/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Copy votp-taskset.service script
-  ansible.builtin.copy:
-    src: ../src/debian/taskset_boot.sh
+  template:
+    src: ../src/debian/taskset_boot.sh.j2
     dest: /usr/local/bin/taskset_boot.sh
     mode: '0755'
   register: votptaskset1
@@ -35,7 +35,7 @@
   lineinfile:
     dest: /etc/default/grub
     regexp: '^GRUB_CMDLINE_LINUX_DEFAULT=".*"$'
-    line: 'GRUB_CMDLINE_LINUX_DEFAULT="ipv6.disable=1 efi=runtime processor.max_cstate=1 intel_idle.max_cstate=1 cpufreq.default_governor=performance default_hugepagesz=1G hugepagesz=1G no_debug_objects intel_pstate=disable nosoftlockup tsc=nowatchdog"'
+    line: 'GRUB_CMDLINE_LINUX_DEFAULT="ipv6.disable=1 efi=runtime processor.max_cstate=1 intel_idle.max_cstate=1 cpufreq.default_governor=performance default_hugepagesz=1G hugepagesz=1G no_debug_objects intel_pstate=disable nosoftlockup rcu_nocbs={{ cpumachinesrt }} rcu_nocb_poll rcutree.kthread_prio=10"'
     state: present
   register: updategrub
 - name: update-grub

--- a/src/debian/taskset_boot.sh
+++ b/src/debian/taskset_boot.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-/usr/bin/taskset -acp 0,12 2
-/usr/bin/taskset -acp 0,12 $(pgrep rcu_preempt)

--- a/src/debian/taskset_boot.sh.j2
+++ b/src/debian/taskset_boot.sh.j2
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+/usr/bin/taskset -acp {{ cpusystem }} 2
+/usr/bin/taskset -acp {{ cpusystem }} $(pgrep rcu_preempt)
+/usr/bin/tuna -t rcu* -c {{ cpusystem }} -m
+


### PR DESCRIPTION
https://lwn.net/Articles/777214/
"rcutree.kthread_prio= specifies the real-time priority to boost to, and
defaults to priority one, the least-important real-time priority level.
You should set this priority level to be greater than the
highest-priority real-time CPU-bound thread. The default priority is
appropriate for the common case where there are no CPU-bound threads
running at real-time priority."

Since we will allow vcpu threads to run at a FIFO prority (1-9), we
follow the documentation by boosting rcu fifo priority to 10.

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>