### PR TITLE
Use GRUB_CMDLINE_LINUX instead of GRUB_CMDLINE_LINUX_DEFAULT

### DIFF
--- a/roles/debian/hypervisor/tasks/main.yml
+++ b/roles/debian/hypervisor/tasks/main.yml
@@ -34,8 +34,8 @@
 - name: "grub conf"
   lineinfile:
     dest: /etc/default/grub
-    regexp: '^GRUB_CMDLINE_LINUX_DEFAULT=".*"$'
-    line: 'GRUB_CMDLINE_LINUX_DEFAULT="ipv6.disable=1 efi=runtime processor.max_cstate=1 intel_idle.max_cstate=1 cpufreq.default_governor=performance default_hugepagesz=1G hugepagesz=1G no_debug_objects intel_pstate=disable nosoftlockup rcu_nocbs={{ cpumachinesrt }} rcu_nocb_poll rcutree.kthread_prio=10"'
+    regexp: '^GRUB_CMDLINE_LINUX=".*"$'
+    line: 'GRUB_CMDLINE_LINUX="ipv6.disable=1 efi=runtime processor.max_cstate=1 intel_idle.max_cstate=1 cpufreq.default_governor=performance default_hugepagesz=1G hugepagesz=1G no_debug_objects intel_pstate=disable nosoftlockup rcu_nocbs={{ cpumachinesrt }} rcu_nocb_poll rcutree.kthread_prio=10"'
     state: present
   register: updategrub
 - name: update-grub


### PR DESCRIPTION
Indeed, GRUB_CMDLINE_LINUX_DEFAULT is set by the seapath iso.

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>