### PR TITLE
Use vm_manager main branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,4 +10,4 @@
 [submodule "src/debian/vm_manager"]
 	path = src/debian/vm_manager
 	url = https://github.com/seapath/vm_manager.git
-        branch = debian
+        branch = main


### PR DESCRIPTION
Following PR 15 on vm-manager we can now use the main branch for debian

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>