### PR TITLE
.cqfd/docker/check_yaml.sh: update script

### DIFF
--- a/.cqfd/docker/check_yaml.sh
+++ b/.cqfd/docker/check_yaml.sh
@@ -48,8 +48,26 @@ while true; do
     shift
 done
 
+errors=0
 for yaml in $(find_yaml "${directory}") ; do
-    echo -n "test $yaml: "
-    yamllint -f parsable "${warns}" "$yaml"
-    echo "ok"
+    output=$(yamllint -f parsable "${warns}" "$yaml")
+    if [ -z "$output" ]
+    then
+        echo "$yaml: $(C green OK)"
+    else
+        echo "$yaml: $(C red KO)"
+        echo $(C red $output)
+        if [ -n "$verbose" ] ; then
+            echo $(C gray "$output")
+        fi
+        ((errors=errors+1))
+    fi
 done
+
+if [ $errors -eq 0 ]
+then
+    exit 0
+else
+    echo "There are $errors errors"
+    exit 1
+fi


### PR DESCRIPTION
The script's output was always 0, even if yamllint found errors in the syntax.
Now, if no error is detected on a file, OK is printed in green next to the file's name.
If an error is detected, KO is printed in red next the file name, the error is printed.
Finally, the total number of errors is printed, and the script exits with 1 if errors were detected.

Signed-off-by: Thibault Sourdin <thibault.sourdin@savoirfairelinux.com>