### PR TITLE
[debian] solving os-prober huge latency

### DIFF
--- a/roles/debian/hypervisor/tasks/main.yml
+++ b/roles/debian/hypervisor/tasks/main.yml
@@ -37,10 +37,20 @@
     regexp: '^GRUB_CMDLINE_LINUX=".*"$'
     line: 'GRUB_CMDLINE_LINUX="ipv6.disable=1 efi=runtime processor.max_cstate=1 intel_idle.max_cstate=1 cpufreq.default_governor=performance default_hugepagesz=1G hugepagesz=1G no_debug_objects intel_pstate=disable nosoftlockup rcu_nocbs={{ cpumachinesrt }} rcu_nocb_poll rcutree.kthread_prio=10"'
     state: present
-  register: updategrub
+  register: updategrub1
 - name: update-grub
   shell: update-grub
   when: updategrub.changed
+- name: "grub conf osprober"
+  lineinfile:
+    dest: /etc/default/grub
+    regexp: '^GRUB_DISABLE_OS_PROBER=.*$'
+    line: 'GRUB_DISABLE_OS_PROBER=true'
+    state: present
+  register: updategrub2
+- name: update-grub
+  shell: update-grub
+  when: updategrub1.changed or updategrub2.changed
 
 - name: "irqbalance conf"
   lineinfile:

--- a/roles/debian/tasks/main.yml
+++ b/roles/debian/tasks/main.yml
@@ -232,6 +232,12 @@
     state: present
     regexp: '^br_netfilter$'
     line: 'br_netfilter'
+- name: add raid6_pq to /etc/modules
+  lineinfile:
+    dest: /etc/modules
+    state: present
+    regexp: '^raid6_pq$'
+    line: 'raid6_pq'
 
 - name: Copy apparmor libvirt-qemu rules
   ansible.builtin.copy:


### PR DESCRIPTION
os-prober is call when updating grub (standard thing when updating the kernel or changing the kernel cmdline)
os-prober need the raid6_pq module loaded (via btrfs), this module like to benchmark things at loading and does this with "preempt_disable()" which create huge latencies.
Once the module is loaded, it does not do this benchmarking again.

This patch implements 2 solutions:
- disabling os-prober completely
- pre-loading raid6_pq (just in case something else needs it in the future)

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>