### PR TITLE
Make ansible create the cluster network without setup_open_vswitch

### DIFF
--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -7,6 +7,22 @@
 # configure VMs.
 
 ---
+- name: configure cluster network
+  hosts: cluster_machines
+  tasks:
+    - name: Remove team0 bridge in OVS
+      command: "/usr/bin/ovs-vsctl --if-exists del-br team0"
+    - name: Create team0 bridge in OVS
+      command: "/usr/bin/ovs-vsctl add-br team0"
+    - name: Enable RSTP on team0 bridge
+      command: "/usr/bin/ovs-vsctl set Bridge team0 rstp_enable=true"
+    - name: Set RSTP priority on team0 bridge
+      command: "/usr/bin/ovs-vsctl set Bridge team0 other_config=rstp-priority=16384"
+    - name: Add interface team0_0 to team0 bridge
+      command: "/usr/bin/ovs-vsctl -- --if-exists del-port {{ team0_0 }} -- add-port team0 {{ team0_0 }}"
+    - name: Add interface team0_1 to team0 bridge
+      command: "/usr/bin/ovs-vsctl -- --if-exists del-port {{ team0_1 }} -- add-port team0 {{ team0_1 }}"
+
 - name: Configure OVS
   hosts: cluster_machines
   vars:

--- a/templates/ovs_configuration.json.j2
+++ b/templates/ovs_configuration.json.j2
@@ -1,2 +1,2 @@
-{% set OVS_configuration = ({ "bridges": ovs_bridges, "unbind_pci_address": unbind_pci_address | default([]) }) %}
+{% set OVS_configuration = ({ "bridges": ovs_bridges, "ignored_bridges": ignored_bridges, "unbind_pci_address": unbind_pci_address | default([]) }) %}
 {{ OVS_configuration | to_nice_json }}


### PR DESCRIPTION
Following https://github.com/seapath/python3-setup-ovs/pull/5, we need ansible to create the cluster network bridges by itself.

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>