### PR TITLE
[debian] Add a host service to provide the PTP status to guests

### DIFF
--- a/roles/debian/hypervisor/tasks/main.yml
+++ b/roles/debian/hypervisor/tasks/main.yml
@@ -213,3 +213,52 @@
     name: monitor_journalctl_hard.service
     enabled: yes
 
+
+- name: create /var/local/ptp_docker folder on hosts
+  file:
+    path: /var/local/ptp_docker
+    state: directory
+    mode: '0755'
+- name: Copy ptp_docker non executable files
+  ansible.builtin.copy:
+    src: ../src/debian/ptp_docker/{{ item }}
+    dest: /var/local/ptp_docker/{{ item }}
+    mode: '0644'
+  with_items:
+    - getptpstatus.php
+    - getptpdetails.php
+    - compose-ptp_docker.yml
+- name: Copy ptp_docker executable files
+  ansible.builtin.copy:
+    src: ../src/debian/ptp_docker/{{ item }}
+    dest: /usr/local/bin/{{ item }}
+    mode: '0755'
+  with_items:
+    - ptpstatus.sh
+
+- name: Copy ptp_status.service
+  ansible.builtin.copy:
+    src: ../src/debian/ptp_docker/ptpstatus.service
+    dest: /etc/systemd/system/ptpstatus.service
+    mode: '0644'
+  register: ptpstatus
+- name: Copy ptp_docker.service
+  ansible.builtin.copy:
+    src: ../src/debian/ptp_docker/ptpdocker.service
+    dest: /etc/systemd/system/ptpdocker.service
+    mode: '0644'
+  register: ptpdocker
+- name: daemon-reload ptpdocker
+  ansible.builtin.service:
+    daemon_reload: yes
+  when: ptpdocker.changed or ptpstatus.changed
+- name: enable ptpstatus.service
+  ansible.builtin.systemd:
+    name: ptpstatus.service
+    enabled: yes
+    state: started
+- name: enable ptpdocker.service
+  ansible.builtin.systemd:
+    name: ptpdocker.service
+    enabled: yes
+    state: started

--- a/src/debian/ptp_docker/compose-ptp_docker.yml
+++ b/src/debian/ptp_docker/compose-ptp_docker.yml
@@ -1,0 +1,13 @@
+version: '3.6'
+
+services:
+  ptp_docker:
+    image: php:apache
+    container_name: ptp_docker
+    ports:
+      - 80:80
+    volumes:
+      - /tmp/ptp.status:/tmp/ptp.status
+      - /tmp/ptp.details:/tmp/ptp.details
+      - /var/local/ptp_docker/getptpstatus.php:/var/www/html/getptpstatus.php
+      - /var/local/ptp_docker/getptpdetails.php:/var/www/html/getptpdetails.php

--- a/src/debian/ptp_docker/getptpdetails.php
+++ b/src/debian/ptp_docker/getptpdetails.php
@@ -1,0 +1,6 @@
+<?php
+
+$output = file_get_contents("/tmp/ptp.details");
+print($output);
+
+?>

--- a/src/debian/ptp_docker/getptpstatus.php
+++ b/src/debian/ptp_docker/getptpstatus.php
@@ -1,0 +1,6 @@
+<?php
+
+$output = file_get_contents("/tmp/ptp.status");
+print($output);
+
+?>

--- a/src/debian/ptp_docker/ptpdocker.service
+++ b/src/debian/ptp_docker/ptpdocker.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=docker apache/php for serving ptp status to vms
+
+[Service]
+Restart=always
+User=root
+
+Environment="COMPOSE_PROJECT_NAME=ptp_docker"
+Environment="COMPOSE_FILE=/var/local/ptp_docker/compose-ptp_docker.yml"
+
+ExecStartPre=-/usr/bin/bash -c '/usr/bin/sleep 1; docker ps -aq -f status=dead | xargs -r docker rm -f'
+ExecStart=/usr/bin/docker-compose -p ${COMPOSE_PROJECT_NAME} -f ${COMPOSE_FILE} up
+ExecStop=/usr/bin/docker-compose -p ${COMPOSE_PROJECT_NAME} -f ${COMPOSE_FILE} stop
+ExecReload=/usr/bin/docker-compose -p ${COMPOSE_PROJECT_NAME} -f ${COMPOSE_FILE} restart
+
+[Install]
+WantedBy=multi-user.target
+

--- a/src/debian/ptp_docker/ptpstatus.service
+++ b/src/debian/ptp_docker/ptpstatus.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=gets ptp status
+
+[Service]
+ExecStartPre=rm -rf /tmp/ptp.status /tmp/ptp.details
+ExecStart=/usr/local/bin/ptpstatus.sh /tmp/ptp.status /tmp/ptp.details
+
+[Install]
+WantedBy=multi-user.target
+WantedBy=ptpdocker.service

--- a/src/debian/ptp_docker/ptpstatus.sh
+++ b/src/debian/ptp_docker/ptpstatus.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+#------------------------------------------------------------------------------
+# Project : Virtual Merging Unit - Driver for legacy SASensor hardware
+# Company : (C) Copyright 2021, Locamation B.V.
+# Function: Linux shell script reading the status of the PTP client with pmc 
+#           and storing the result into a status file.
+#
+#  Any reproduction without written permission is prohibited by law.
+#------------------------------------------------------------------------------
+
+set -e
+set -u
+
+# Global variables
+declare -i PTP_STAT_PREV=0
+declare -i CLOCK_NO_SYNC=0
+declare -i CLOCK_LOCAL_SYNC=1
+declare -i CLOCK_GLOBAL_SYNC=2
+
+PTP_STAT_FILE=""
+PMC_EXE="/usr/sbin/pmc"
+
+PTP_STAT_GMPRESENT="none"
+PTP_STAT_CLOCK_CLASS="none"
+PTP_STAT_CLOCK_ACCURACY="none"
+
+declare -i CLOCK_CLASS_MIN=7 # The minimum requirement for the best clock
+declare -i CLOCK_MIN_ACCURACY=0x23 # 0x23: the time is accurate to within 1 us
+
+# Error checks
+if [[ $# -ne 2 ]]; then
+  echo "ERROR: PTP status and details output files not specified!"
+  exit 1
+fi
+
+PTP_STAT_FILE="$1"
+PTP_DETAILS_FILE="$2"
+
+# Initialize this script and perform some condition checks
+function init() {
+  if [[ ! -f "$PMC_EXE" ]]; then
+    echo "ERROR: linuxptp pmc application ($PMC_EXE) does not exist on this platform."
+    exit 1
+  fi
+
+  ptpStatusFileDir="$(dirname "$PTP_STAT_FILE" 2> /dev/null)"
+  ptpDetailsFileDir="$(dirname "$PTP_DETAILS_FILE" 2> /dev/null)"
+
+  mkdir -p "$ptpStatusFileDir"
+  mkdir -p "$ptpDetailsFileDir"
+
+  # Write initially 0 into the stat file
+  echo "$PTP_STAT_PREV" > "$PTP_STAT_FILE"
+  echo "PTP status write; $PTP_STAT_PREV > '$PTP_STAT_FILE'"
+}
+
+# Gather and analyse the PTP client status using pmc, and return the status according
+# to the iec61850 standard description.
+function getPtpStatus() {
+  local resultVar=$1
+  local clockClassInSpec="true"
+  local pmcOutput=""
+  local -i ptpStatus=$CLOCK_NO_SYNC
+
+  pmcOutput="$($PMC_EXE -s /var/run/timemaster/ptp4l.0.socket -u -b 0 'GET PARENT_DATA_SET' 'GET TIME_STATUS_NP')"
+  echo "$pmcOutput" > "$PTP_DETAILS_FILE"
+  
+  PTP_STAT_GMPRESENT=$(echo "$pmcOutput" | grep 'gmPresent'| tr -d '\t' | tr -s ' ' | cut -f2 -d " ")
+  PTP_STAT_CLOCK_CLASS=$(echo "$pmcOutput" | grep 'gm.ClockClass'| tr -d '\t' | tr -s ' ' | cut -f2 -d " ")
+  PTP_STAT_CLOCK_ACCURACY=$(echo "$pmcOutput" | grep 'gm.ClockAccuracy'| tr -d '\t' | tr -s ' ' | cut -f2 -d " ")
+
+  # Determine whether the Clock Class is not out of spec (even when gmPresent=true)
+  if [[ "$PTP_STAT_CLOCK_CLASS" == "52"  || "$PTP_STAT_CLOCK_CLASS" == "58" ||
+        "$PTP_STAT_CLOCK_CLASS" == "187" || "$PTP_STAT_CLOCK_CLASS" == "193" ]]; then
+    clockClassInSpec=false
+  fi
+
+  if [ "${PTP_STAT_GMPRESENT,,}" == "true" -a "$clockClassInSpec" = true ]; then
+    ptpStatus=$CLOCK_LOCAL_SYNC
+
+    # Swap the following line when clock accuracy is needed:
+    #if [ $PTP_STAT_CLOCK_CLASS -le $CLOCK_CLASS_MIN -a $((PTP_STAT_CLOCK_ACCURACY)) -le $((CLOCK_MIN_ACCURACY)) ]; then
+    if [[ $PTP_STAT_CLOCK_CLASS -le $CLOCK_CLASS_MIN ]]; then
+      ptpStatus=$CLOCK_GLOBAL_SYNC
+    fi
+  fi
+
+  eval $resultVar="'$ptpStatus'"
+}
+
+# Main while loop
+function run() {
+  while true
+  do
+    sleep 1
+    getPtpStatus status
+    setPtpStatus $status
+  done
+}
+
+# Write the given value into the PTP status file
+function setPtpStatus() {
+  local currentPtpStat=$1
+
+  if [[ $PTP_STAT_PREV -ne $currentPtpStat ]]; then
+    echo "PTP status new; gmPresent: $PTP_STAT_GMPRESENT, gm.ClockClass: $PTP_STAT_CLOCK_CLASS, gm.ClockAccuracy: $PTP_STAT_CLOCK_ACCURACY"
+    echo "PTP status write; $PTP_STAT_PREV -> $currentPtpStat > '$PTP_STAT_FILE'"
+    echo "$1" > "$PTP_STAT_FILE"
+
+    PTP_STAT_PREV=$currentPtpStat
+  fi
+}
+
+init
+run
+


### PR DESCRIPTION
This webservice will allow the guests to query the host for the current ptp status, which is needed to populate the SmpSync field in a 61850 SV packet.

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>