### PR TITLE
roles/debian/hypervisor: change the way kernel parameters are set

### DIFF
--- a/.cqfd/docker/check_yaml.sh
+++ b/.cqfd/docker/check_yaml.sh
@@ -17,6 +17,41 @@ find_yaml()
         "^${1}/(ceph-ansible|roles/corosync|roles/systemd_networkd|collections)"
 }
 
+# Name        C
+# Brief       Print colorized string
+# arg1        color name (see below)
+# arg2        string
+C()
+{
+    local color="$1"; shift
+    local text="$*"
+    local nc='\033[0m'
+    local c
+
+    # Only colorize a few terminal types
+    case "$TERM" in
+    linux*|xterm*|screen|vt102) ;;
+    *)
+        echo "$@"
+        return
+        ;;
+    esac
+
+    case "$color" in
+        gray)   c='\033[1;30m' ;;
+        red)    c='\033[1;31m' ;;
+        green)  c='\033[1;32m' ;;
+        yellow) c='\033[1;33m' ;;
+        blue)   c='\033[1;34m' ;;
+        purple) c='\033[1;35m' ;;
+        cyan)   c='\033[1;36m' ;;
+
+        orange_bg) c='\033[48;2;255;165;0m'
+    esac
+
+    printf "${c}${text}${nc}"
+}
+
 directory="."
 warns="--no-warnings"
 

--- a/inventories/seapath_ovstopology_definition_example.yml
+++ b/inventories/seapath_ovstopology_definition_example.yml
@@ -5,8 +5,13 @@ all:
       children:
         hypervisors:
           vars:
-            ovs_bridges:  # this is the object used by ansible to create the json OVS conf that will be uploaded to the nodes, and used by the votp-config_ovs service to create the OVS configuration at each boot    
-              - name: team0 # this is the bridge used to create a "triangle" cluster network between the 3 nodes
+            # this is the object used by ansible to create the json OVS conf
+            # that will be uploaded to the nodes, and used by the
+            # votp-config_ovs service to the OVS configuration at each boot
+            ovs_bridges:
+                # this is the bridge used to create a "triangle" cluster network
+                # between the 3 nodes
+              - name: team0
                 rstp_enable: true
                 other_config: "rstp-priority={{ br_rstp_priority }}"
                 ports:
@@ -39,10 +44,11 @@ all:
                     trunks:
                       - 33
                       - 34
-                 - name: brBRIDGE1_ext # a link to the physical interface for the host
-                   type: system
-                   interface: "{{ brBRIDGE1_ext }}" #this refers to the node inventory
+                    # a link to the physical interface for the host
+                  - name: brBRIDGE1_ext
+                    type: system
+                    # this refers to the node inventory
+                    interface: "{{ brBRIDGE1_ext }}"
                   - name: VM4.0  # a access port (vlan 11) for VM4
                     type: tap
                     tag: 11
-               

--- a/roles/debian/hypervisor/tasks/main.yml
+++ b/roles/debian/hypervisor/tasks/main.yml
@@ -34,10 +34,29 @@
 - name: "grub conf"
   lineinfile:
     dest: /etc/default/grub
-    regexp: '^GRUB_CMDLINE_LINUX=".*"$'
-    line: 'GRUB_CMDLINE_LINUX="ipv6.disable=1 efi=runtime processor.max_cstate=1 intel_idle.max_cstate=1 cpufreq.default_governor=performance default_hugepagesz=1G hugepagesz=1G no_debug_objects intel_pstate=disable nosoftlockup isolcpus=nohz,domain,managed_irq={{ cpumachinesrt }} rcu_nocbs={{ cpumachinesrt }} rcu_nocb_poll rcutree.kthread_prio=10 slab_nomerge pti=on slub_debug=ZF"'
+    regexp: "^(GRUB_CMDLINE_LINUX=(?!.* {{ item }})\"[^\"]*)(\".*)"
+    line: '\1 {{ item }}\2'
     state: present
+    backrefs: yes
   register: updategrub1
+  with_items:
+    - ipv6.disable=1
+    - efi=runtime
+    - processor.max_cstate=1
+    - intel_idle.max_cstate=1
+    - cpufreq.default_governor=performance
+    - default_hugepagesz=1G
+    - hugepagesz=1G
+    - no_debug_objects
+    - intel_pstate=disable
+    - nosoftlockup
+    - "rcu_nocbs={{ cpumachinesrt }}"
+    - rcu_nocb_poll
+    - rcutree.kthread_prio=10
+    - "isolcpus=nohz,domain,managed_irq={{ cpumachinesrt }}"
+    - slab_nomerge
+    - pti=on
+    - slub_debug=ZF
 - name: "grub conf osprober"
   lineinfile:
     dest: /etc/default/grub


### PR DESCRIPTION
To allow modifying kernel parameters elsewhere, do not erase GRUB_CMDLINE_LINUX when setting kernel parameters.