### PR TITLE
Set skew_tick kernel boot param to 1

### DIFF
--- a/roles/debian/hypervisor/tasks/main.yml
+++ b/roles/debian/hypervisor/tasks/main.yml
@@ -57,6 +57,7 @@
     - slab_nomerge
     - pti=on
     - slub_debug=ZF
+    - skew_tick=1
 - name: "grub conf osprober"
   lineinfile:
     dest: /etc/default/grub


### PR DESCRIPTION
According to Redhat, it seems to be a good thing for latency sensitive systems

https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_for_real_time/7/html/tuning_guide/reduce_cpu_performance_spikes

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>