### PR TITLE
[debian] stops using ansible_become

### DIFF
--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -45,12 +45,6 @@ all:
                             cluster_ip_addr: "192.168.55.3"
                             br_rstp_priority: 16384
                             brBRIDGE1_ext: eno1234 #physical nic to use with BRIDGE1 (see the ovs topology inventory)
-                    vars:
-                        ansible_user: admin
-                        ansible_become: true
-                        ansible_become_method: sudo
-                        ansible_become_flags: "-n -E"
-                        bootloader_config_file: /boot/syslinux.cfg
         mons:
             hosts:
                 node1:
@@ -80,7 +74,7 @@ all:
                 ansible_become_flags: "-n -E"
     vars:
         ansible_connection: ssh
-        ansible_user: root
+        ansible_user: virtu
         ansible_python_interpreter: /usr/bin/python3
         dns_server: 10.10.2.1   # Not valid, just for Ansible
         gateway_addr: 10.132.159.1 # Not valid, just for Ansible

--- a/playbooks/cluster_setup_ceph.yaml
+++ b/playbooks/cluster_setup_ceph.yaml
@@ -8,6 +8,7 @@
 - name: Prepare Ceph installation
   hosts:
       mons
+  become: true
   tasks:
       - name: Create Ceph log directory
         file:
@@ -28,6 +29,7 @@
 - name: Ceph OSD disk
   hosts:
       osds
+  become: true
   tasks:
       - name: Cleanup Ceph OSD disks with ceph-volume
         shell:
@@ -40,6 +42,7 @@
 - name: Disable unwanted Ceph mgr module
   hosts:
       mons
+  become: true
   tasks:
       - name: Disable Ceph mgr restful module
         shell:
@@ -48,6 +51,7 @@
 - name: Configure rbd
   hosts:
       osds
+  become: true
   tasks:
       - name: Disable rbd lock
         shell:

--- a/playbooks/cluster_setup_ha.yaml
+++ b/playbooks/cluster_setup_ha.yaml
@@ -8,6 +8,7 @@
 ---
 - name: Configure SEAPATH specific files
   hosts: cluster_machines
+  become: true
   tasks:
   - name: Save cluster machine informations
     template:
@@ -16,6 +17,7 @@
 
 - name: Check if corosync is already setup
   hosts: cluster_machines
+  become: true
   tasks:
     - name: check corosync service status
       systemd:
@@ -42,6 +44,7 @@
 
 - name: Setup Corosync from scratch
   hosts: cluster_machines
+  become: true
   vars_files:
       - ../vars/corosync_vars.yaml
   roles:
@@ -50,6 +53,7 @@
 
 - name: Fetch existing corosync using configuration
   hosts: valid_machine
+  become: true
   vars:
     tmpdir: "/tmp"
   tasks:
@@ -70,6 +74,7 @@
 
 - name: Setup Corosync using existing configuration
   hosts: unconfigured_machine_group
+  become: true
   vars:
     tmpdir: "/tmp"
   tasks:
@@ -97,6 +102,7 @@
 
 - name: Setup Pacemaker
   hosts: unconfigured_machine_group
+  become: true
   tasks:
       - name: Start Pacemaker
         ansible.builtin.systemd:

--- a/playbooks/cluster_setup_keys.yaml
+++ b/playbooks/cluster_setup_keys.yaml
@@ -1,5 +1,6 @@
 - name: Configure ssh keys between hosts
   hosts: cluster_machines
+  become: true
   gather_facts: yes
   tasks:
     - name: generate SSH key

--- a/playbooks/cluster_setup_libvirt.yaml
+++ b/playbooks/cluster_setup_libvirt.yaml
@@ -8,7 +8,7 @@
 ---
 - name: Configure libvirt rbd secret
   hosts: hypervisors
-
+  become: true
   pre_tasks:
       - name: Try to get already defined secret
         shell:
@@ -75,6 +75,7 @@
 
 - name: Create rbd pool
   hosts: hypervisors
+  become: true
   vars:
     rbd_pool_name: "{{ libvirt_rbd_pool | default('rbd') }}"
     pool_name: "{{ libvirt_pool_name | default('ceph') }}"

--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -9,6 +9,7 @@
 ---
 - name: configure cluster network
   hosts: cluster_machines
+  become: true
   tasks:
     - name: Remove team0 bridge in OVS
       command: "/usr/bin/ovs-vsctl --if-exists del-br team0"
@@ -25,6 +26,7 @@
 
 - name: Configure OVS
   hosts: cluster_machines
+  become: true
   vars:
     apply_config: "{{ apply_network_config | default(false) }}"
   tasks:
@@ -49,6 +51,7 @@
         - ovs_conf.changed
 
 - name: Configure Network
+  become: true
   hosts: cluster_machines
   vars_files:
     - ../vars/network_vars.yml
@@ -57,6 +60,7 @@
 
 - name: Network configuration
   hosts: cluster_machines
+  become: true
   vars:
     apply_config: "{{ apply_network_config | default(false) }}"
   tasks:
@@ -69,6 +73,7 @@
 
 - name: Configure hosts and hostname
   hosts: cluster_machines
+  become: true
   tasks:
     - name: Set hostname
       hostname:
@@ -85,6 +90,7 @@
 
 - name: Configure NTP
   hosts: cluster_machines
+  become: true
   tasks:
     - name: Set NTP configuration in /etc/systemd/timesyncd.conf
       lineinfile:
@@ -110,6 +116,7 @@
         state: restarted
 - name: Configure syslog-ng
   hosts: cluster_machines
+  become: true
   tasks:
     - name: Set observer IP address in /etc/syslog-ng/syslog-ng.conf
       lineinfile:
@@ -133,6 +140,7 @@
 
 - name: Configure systemd-networkd-wait-online.service
   hosts: hypervisors
+  become: true
   tasks:
     - block:
         - name: Create systemd-networkd-wait-online.service.d directory
@@ -151,6 +159,7 @@
 
 - name: Restart machine if needed
   hosts: cluster_machines
+  become: true
   tasks:
     - block:
         - name: Restart

--- a/playbooks/cluster_setup_prerequisdebian.yaml
+++ b/playbooks/cluster_setup_prerequisdebian.yaml
@@ -1,8 +1,10 @@
 - name: Prerequis machine debian
   hosts: cluster_machines
+  become: true
   roles:
       - debian
 - name: Prerequis hypervisor debian
   hosts: hypervisors
+  become: true
   roles:
       - debian/hypervisor


### PR DESCRIPTION
ceph-ansible seems to choke when using "ansible_become". This option forces all playbooks to run as root, but some tasks in ceph-ansible are run locally (delegates_to: localhost) and so require not to run as root (become: false is specifically written for these tasks, but is overriden by ansible_become). For example when running ansible-playbook in doker, this would lead to an "sudo missing" error.

Example: https://github.com/ceph/ceph-ansible/blob/d57377ef619c3304c1eaf4d466dae4055b492d7b/roles/ceph-mon/tasks/deploy_monitors.yml#L27

This patch remove ansible_become from the inventory variables, which will make the playbooks themselves decide if they need to run as root. Therefore this patch also adds the "become: true" option to all playbooks.

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>