### PR TITLE
[debian] osd memory: no space in var

### DIFF
--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -86,7 +86,7 @@ all:
         monitor_address: "{{ ansible_host }}"
         osd_pool_default_min_size: 2
         osd_pool_default_size: 3
-        osd_memory_target: 8000000000
+        osd_memory_target: 8076326604
         ci_docker_compose_path: "/opt/docker"
         eg_ip: "10.10.1.100"
         eg_passwd: "1"

--- a/vars/ceph_group_vars/all.yml
+++ b/vars/ceph_group_vars/all.yml
@@ -535,13 +535,12 @@ ceph_conf_overrides:
         osd_pool_default_pgp_num: 128
         osd_crush_chooseleaf_type: 1
         mon_osd_min_down_reporters: 1
-        osd_min_pg_log_entries: 500
-        osd_max_pg_log_entries: 500
     mon:
         auth_allow_insecure_global_id_reclaim: false
     osd:
-        osd_memory_target: "{{ osd_memory_target }}"
-
+        osd_min_pg_log_entries: 500
+        osd_max_pg_log_entries: 500
+        osd memory target: "{{ osd_memory_target }}"
 
 #############
 # OS TUNING #


### PR DESCRIPTION
ceph-ansible sets the osd memory with space in the var name ("osd memory target")
If we override with a var that has no space ("osd_memory_target"), it creates a duplicate settings...

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>