### PR TITLE
cqfd: fix Ansible error

### DIFF
--- a/.cqfd/docker/Dockerfile
+++ b/.cqfd/docker/Dockerfile
@@ -18,8 +18,6 @@ RUN apt-get update && apt-get install -y \
 	python3-libvirt \
 	docker.io \
 	docker-compose \
-	yamllint \
-	ansible \
 	python3-pip
 
 RUN sed -i "s/# en_US\.UTF-8 UTF-8/en_US\.UTF-8 UTF-8/" /etc/locale.gen
@@ -28,6 +26,5 @@ RUN dpkg-reconfigure locales
 # Asciidoctor PDF generator for generating the manual
 RUN gem install asciidoctor-pdf --pre -v 1.5.0.rc2
 ADD check_yaml.sh /usr/bin/check_yaml
-RUN python3 -m pip install docutils==0.16
-ADD documentation_requirements.txt /tmp/requirements.txt
+ADD requirements.txt /tmp/requirements.txt
 RUN python3 -m pip install -r /tmp/requirements.txt

--- a/.cqfd/docker/requirements.txt
+++ b/.cqfd/docker/requirements.txt
@@ -4,3 +4,7 @@ rstcheck
 sphinx
 sphinx-notfound-page
 Pygments >= 2.4.0
+docutils == 0.16
+ansible >=2.9,<2.10
+yamllint
+netaddr


### PR DESCRIPTION
Rework Python module installation to use pip to avoid a conflict error with Jinja2 module.

Signed-off-by: Mathieu Dupré <mathieu.dupre@savoirfairelinux.com>