### PR TITLE
cqfd: fix Ansible error

### DIFF
--- a/.cqfd/docker/Dockerfile
+++ b/.cqfd/docker/Dockerfile
@@ -13,14 +13,12 @@ RUN apt-get update && apt-get install -y \
 	bash \
 	locales \
 	ruby \
-        vim \
+	vim \
 	git \
 	ssh \
 	python3-libvirt \
 	docker.io \
 	docker-compose \
-	yamllint \
-	ansible \
 	rsync \
 	python3-pip
 
@@ -30,6 +28,5 @@ RUN dpkg-reconfigure locales
 # Asciidoctor PDF generator for generating the manual
 RUN gem install asciidoctor-pdf --pre -v 1.5.0.rc2
 ADD check_yaml.sh /usr/bin/check_yaml
-RUN python3 -m pip install docutils==0.16
-ADD documentation_requirements.txt /tmp/requirements.txt
+ADD requirements.txt /tmp/requirements.txt
 RUN python3 -m pip install -r /tmp/requirements.txt

--- a/.cqfd/docker/requirements.txt
+++ b/.cqfd/docker/requirements.txt
@@ -4,3 +4,7 @@ rstcheck
 sphinx
 sphinx-notfound-page
 Pygments >= 2.4.0
+docutils == 0.16
+ansible >=2.9,<2.10
+yamllint
+netaddr


### PR DESCRIPTION
Rework Python module installation to use pip to avoid a conflict error with Jinja2 module.

Signed-off-by: Mathieu Dupré <mathieu.dupre@savoirfairelinux.com>