### PR TITLE
cqfd: add the export flavor

### DIFF
--- a/.cqfdrc
+++ b/.cqfdrc
@@ -1,7 +1,7 @@
 [project]
 org='rte'
 name='ansible'
-flavors='prepare manual module_documentation'
+flavors='prepare manual module_documentation export'
 
 [build]
 command='check_yaml'
@@ -14,3 +14,6 @@ command='asciidoctor-pdf README.adoc OVS_configuration.adoc'
 
 [module_documentation]
 command='./generate_module_documentation.sh'
+
+[export]
+command='rm -f ansible.tar.gz && ./prepare.sh && tar --exclude=ansible.tar.gz --exclude=.git -czf ansible.tar.gz .'

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,9 @@ module_documentation
 # Ignore python cache files
 __pycache__/
 .pyc
+
+# Ignore test template xml
+templates/vm/test.xml.j2
+
+# Ignore exported archive
+/ansible.tar.gz


### PR DESCRIPTION
This flavor exports SEAPATH ansible repository into the ansible.tar.gz archive.

Signed-off-by: Mathieu Dupré <mathieu.dupre@savoirfairelinux.com>