### PR TITLE
playbooks: ensure booting has been finished

### DIFF
--- a/playbooks/ci_set_efi_boot_entries.yaml
+++ b/playbooks/ci_set_efi_boot_entries.yaml
@@ -13,8 +13,5 @@
       changed_when: result.rc == 2
       failed_when: result.rc == 1
     - name: Reboot on default slot
-      reboot:
-      when: result.rc == 2
-    - name: Wait for host to be online
-      wait_for_connection:
+      include_tasks: tasks/soft_restart_machine.yaml
       when: result.rc == 2

--- a/playbooks/cluster_setup_kernel_params.yaml
+++ b/playbooks/cluster_setup_kernel_params.yaml
@@ -39,13 +39,7 @@
             regexp: '(root=.*)'
             replace: '\1 {{ extra_kernel_parameters }}'
           when: extra_param_needed is defined
-        - name: Restart
-          reboot:
-          when:
-            - kernel_parameters_restart is defined
-            - kernel_parameters_restart
-        - name: Wait for host to be online
-          wait_for_connection:
+        - include_tasks: tasks/soft_restart_machine.yaml
           when:
             - kernel_parameters_restart is defined
             - kernel_parameters_restart

--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -142,9 +142,5 @@
 - name: Restart machine if needed
   hosts: cluster_machines
   tasks:
-    - block:
-        - name: Restart
-          reboot:
-        - name: Wait for host to be online
-          wait_for_connection:
+    - include_tasks: tasks/soft_restart_machine.yaml
       when: need_reboot is defined and need_reboot

--- a/playbooks/tasks/soft_restart_machine.yaml
+++ b/playbooks/tasks/soft_restart_machine.yaml
@@ -1,0 +1,12 @@
+# Copyright (C) 2022, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+---
+
+- name: Restart
+  reboot:
+- name: Wait for host to be online
+  wait_for_connection:
+- name: Wait systemd has finished to boot
+  command: systemctl is-system-running --wait
+  register: system_status
+  failed_when: system_status.rc != 0 and system_status.rc != 1


### PR DESCRIPTION
When rebooting ensure systemd has finished to boot the systemd before running Ansible.

Signed-off-by: Mathieu Dupré <mathieu.dupre@savoirfairelinux.com>