### PR TITLE
playbooks: do not set UEFI boot variables by default

### DIFF
--- a/playbooks/ci_set_efi_boot_entries.yaml
+++ b/playbooks/ci_set_efi_boot_entries.yaml
@@ -7,11 +7,13 @@
   hosts: cluster_machines
   gather_facts: false
   tasks:
-    - name: Define SEAPATH boot entries if needed
-      script: "../scripts/add_seapath_boot_entries.sh"
-      register: result
-      changed_when: result.rc == 2
-      failed_when: result.rc == 1
-    - name: Reboot on default slot
-      include_tasks: tasks/soft_restart_machine.yaml
-      when: result.rc == 2
+    - block:
+      - name: Define SEAPATH boot entries if needed
+        script: "../scripts/add_seapath_boot_entries.sh"
+        register: result
+        changed_when: result.rc == 2
+        failed_when: result.rc == 1
+      - name: Reboot on default slot
+        include_tasks: tasks/soft_restart_machine.yaml
+        when: result.rc == 2
+      when: create_efi_entries is defined and create_efi_entries


### PR DESCRIPTION
The Ansible variable create_efi_entries has to be defined if you want Ansible to create SEAPATH UEFI boot variables.

Note: if you use one of the SEAPATH flash image, SEAPATH UEFI boot variables will be set by it.

Signed-off-by: Mathieu Dupré <mathieu.dupre@savoirfairelinux.com>