### PR TITLE
playbooks: create a user for VM live migration

### DIFF
--- a/inventories/seapath.yaml
+++ b/inventories/seapath.yaml
@@ -119,6 +119,11 @@ all:
             ansible_become_flags: "-n -E"
             kernel_parameters_restart: true
             bootloader_config_file: /boot/syslinux.cfg
+            # Uncomment this variable to create the virtu user and enable VM
+            # live migration.
+            # The virtu user have high privileged, for security reasons enable
+            # it only if you need live migration.
+            # create_virtu_user: yes
             ovs_bridges:
               - name: br0
                 ports:

--- a/playbooks/ci_configure_cluster.yaml
+++ b/playbooks/ci_configure_cluster.yaml
@@ -4,4 +4,5 @@
 ---
 - import_playbook: cluster_setup_ceph.yaml
 - import_playbook: cluster_setup_libvirt.yaml
+- import_playbook: cluster_setup_add_virtu_user.yaml
 - import_playbook: cluster_setup_ha.yaml

--- a/playbooks/cluster_setup_add_virtu_user.yaml
+++ b/playbooks/cluster_setup_add_virtu_user.yaml
@@ -1,0 +1,64 @@
+# Copyright (C) 2022, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+# This playbook adds and configures the virtu user. This user is used by libvirt
+# to migrate VM from a host to an other without halting it.
+
+---
+- name: Configure ssh keys between hosts
+  hosts: hypervisors
+  gather_facts: true
+  tasks:
+      - block:
+        - name: Create virtu user
+          user:
+            name: virtu
+            shell: /bin/sh
+            system: true
+            groups: qemu,haclient,admincluster
+            create_home: false
+        - name: Unlock the user
+          replace:
+              path: /etc/shadow
+              regexp: '^virtu:!:'
+              replace: 'virtu:*:'
+        - name: generate SSH key
+          user:
+            name: "root"
+            generate_ssh_key: yes
+            ssh_key_type: rsa
+            ssh_key_bits: 4096
+            ssh_key_file: .ssh/id_rsa
+            ssh_key_passphrase: ""
+            force: false
+        - name: create ssh directory
+          file:
+            path: /etc/ssh/virtu
+            state: directory
+            mode: '0755'
+            owner: virtu
+            group: virtu
+        - name: Fetch the root keyfile
+          fetch:
+            src: "/home/root/.ssh/id_rsa.pub"
+            dest: "buffer/{{ inventory_hostname }}-id_rsa.pub"
+            flat: true
+        - name: Copy the key add to authorized_keys using Ansible module
+          authorized_key:
+            user: virtu
+            state: present
+            path: /etc/ssh/virtu/authorized_keys
+            key: "{{ lookup('file','buffer/{{ item }}-id_rsa.pub')}}"
+          with_items: "{{ groups['hypervisors'] }}"
+        - name: Fetch the ssh keyfile
+          fetch:
+            src: "/etc/ssh/ssh_host_ed25519_key.pub"
+            dest: "buffer/{{ inventory_hostname }}-ssh_host_ed25519_key.pub"
+            flat: true
+        - name: populate the known_hosts files
+          known_hosts:
+            path: /home/root/.ssh/known_hosts
+            name: "{{ item }}"
+            key: "{{ item }} {{ lookup('file','buffer/{{ item }}-ssh_host_ed25519_key.pub') }}"
+          with_items: "{{ groups['hypervisors'] }}"
+        when: create_virtu_user is defined


### PR DESCRIPTION
Add the playbook cluster_setup_add_virtu_user.yaml to create the virtu user. This user can be used to perform VM live migration. This playbooks is called during the cluster setup by the ci_configure_cluster.yaml playbook.

By default the virtu user is not created because virtu user have the access rights to manage Pacemaker and libvirt. So if you do not need live migration it is recommended to not enable this feature. To enable it you have to define the Ansible user create_virtu_user.

Signed-off-by: Mathieu Dupré <mathieu.dupre@savoirfairelinux.com>