### PR TITLE
playbooks: configure Open vSwitch for observer

### DIFF
--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -25,7 +25,7 @@
       command: "/usr/bin/ovs-vsctl -- --if-exists del-port {{ team0_1 }} -- add-port team0 {{ team0_1 }}"
 
 - name: Configure OVS
-  hosts: hypervisors
+  hosts: cluster_machines
   vars:
     apply_config: "{{ apply_network_config | default(false) }}"
   tasks:


### PR DESCRIPTION
Cluster network now use an Open vSwitch bridge, so we also need to configure Open vSwitch for the observer.

Signed-off-by: Mathieu Dupré <mathieu.dupre@savoirfairelinux.com>