### PR TITLE
Team0: Update the example OVS inventory file

### DIFF
--- a/inventories/seapath_ovstopology_definition_example.yml
+++ b/inventories/seapath_ovstopology_definition_example.yml
@@ -8,19 +8,10 @@ all:
             # this is the object used by ansible to create the json OVS conf
             # that will be uploaded to the nodes, and used by the
             # votp-config_ovs service to the OVS configuration at each boot
+            ignored_bridges:
+            # the team0 bridge (cluster network) is created separately by the networking playbook.
+              - "team0"
             ovs_bridges:
-                # this is the bridge used to create a "triangle" cluster network
-                # between the 3 nodes
-              - name: team0
-                rstp_enable: true
-                other_config: "rstp-priority={{ br_rstp_priority }}"
-                ports:
-                  - name: team0_0
-                    type: system
-                    interface: "{{ team0_0 }}"
-                  - name: team0_1
-                    type: system
-                    interface: "{{ team0_1 }}"
               - name: brBRIDGE1
                 rstp_enable: true
                 other_config: "rstp-priority={{ br_rstp_priority }}"


### PR DESCRIPTION
Following 36892794e8c585560c662cadf6fdcdfcc5e020bc (Make ansible create the cluster network without setup_open_vswitch), let's update the example OVS inventory file (removing of the team0 bridge details, replaced by the ignored_bridges object).

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>