### PR TITLE
hddtemp: configuring the hard disk temperature monitoring

### DIFF
--- a/roles/debian/tasks/main.yml
+++ b/roles/debian/tasks/main.yml
@@ -327,3 +327,29 @@
     line: "{{ logstash_server_ip }} logstash-seapath"
     state: present
 
+- name: lineinfile in /etc/default/hddtemp file for DISKS
+  lineinfile:
+    dest: /etc/default/hddtemp
+    regexp: '^DISKS='
+    line: "DISKS=\"{{ main_disk }} {{ ceph_osd_disk if ceph_osd_disk is defined else none }}\""
+    state: present
+  register: updatehddtemp1
+- name: lineinfile in /etc/default/hddtemp file for RUN_DAEMON
+  lineinfile:
+    dest: /etc/default/hddtemp
+    regexp: '^RUN_DAEMON='
+    line: "RUN_DAEMON=\"true\""
+    state: present
+  register: updatehddtemp2
+- name: lineinfile in /etc/default/hddtemp file for INTERFACE
+  lineinfile:
+    dest: /etc/default/hddtemp
+    regexp: '^INTERFACE='
+    line: "INTERFACE=\"{{ ansible_host }}\""
+    state: present
+  register: updatehddtemp3
+- name: Restart hddtemp
+  ansible.builtin.systemd:
+    state: restarted
+    name: hddtemp
+  when: updatehddtemp1.changed or updatehddtemp2.changed or updatehddtemp3.changed


### PR DESCRIPTION
This commit makes the debian prerequisite playbook configure the hddtemp service to expose  hard disks temperature on a standard tcp port, so that it can be easily polled by a supervision system like centreon.

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>