### PR TITLE
Move seapath VirtualDomain resource agent to custom directory

### DIFF
--- a/roles/debian/tasks/main.yml
+++ b/roles/debian/tasks/main.yml
@@ -58,10 +58,16 @@
     dest: /etc/vim/vimrc.local
     mode: '0644'
 
+- name: create /usr/lib/ocf/resource.d/seapath on hosts
+  file:
+    path: /usr/lib/ocf/resource.d/seapath
+    state: directory
+    mode: '0755'
+
 - name: Copy VirtualDomain file
   ansible.builtin.copy:
     src: ../src/debian/VirtualDomain
-    dest: /usr/lib/ocf/resource.d/heartbeat/VirtualDomain
+    dest: /usr/lib/ocf/resource.d/seapath/VirtualDomain
     mode: '0755'
 
 - name: create /var/log/syslog-ng folder on hosts


### PR DESCRIPTION
It is bad practice to override the existing VirtualDomain file since it can/will be overwriten by an upcoming package upgrade. It is recommended to create a custom folder is /usr/lib/ocf/resource.d 

A upcoming PR to bump vm_manager submodule will arrive as soon as the change is merged into vm_manager (https://github.com/seapath/vm_manager/pull/17)

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>