### PR TITLE
add the --remote option when updating submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,6 +14,8 @@
 [submodule "src/cukinia-tests"]
 	path = src/cukinia-tests
 	url = https://github.com/seapath/cukinia-tests.git
+        branch = main
 [submodule "src/cukinia"]
 	path = src/cukinia
 	url = https://github.com/savoirfairelinux/cukinia.git
+        branch = master

--- a/prepare.sh
+++ b/prepare.sh
@@ -52,7 +52,7 @@ ansible-galaxy collection install --collections-path="$(pwd)/collections" -r \
     ansible-requirements.yaml
 
 echo "Update git submodules"
-git submodule update --init --force
+git submodule update --init --force --remote
 
 echo "Copy ceph-ansible site.yml"
 cp -vf src/ceph-ansible-site.yaml ceph-ansible/site.yml


### PR DESCRIPTION
Since our submodules are based on branches (main, master...) we need the remote option to force the fetching of latest references from the origins
And since we add this option, we also must make sure all git submodules have a branch to fetch

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>