### PR TITLE
snmp: exposes ceph status

### DIFF
--- a/roles/debian/tasks/main.yml
+++ b/roles/debian/tasks/main.yml
@@ -206,8 +206,24 @@
   lineinfile:
     dest: /etc/sudoers.d/Debian-snmp
     state: present
-    regexp: '^Debian-snmp'
+    regexp: '^Debian-snmp.*/usr/local/bin/snmp_diskusage.sh'
     line: 'Debian-snmp     ALL = (root) NOPASSWD: /usr/local/bin/snmp_diskusage.sh'
+    validate: visudo -cf %s
+    create: yes
+- name: Allow 'Debian-snmp' user to run snmp_cephstatus.sh
+  lineinfile:
+    dest: /etc/sudoers.d/Debian-snmp
+    state: present
+    regexp: '^Debian-snmp.*/usr/local/bin/snmp_cephstatus.sh'
+    line: 'Debian-snmp     ALL = (root) NOPASSWD: /usr/local/bin/snmp_cephstatus.sh'
+    validate: visudo -cf %s
+    create: yes
+- name: Allow 'Debian-snmp' user to run snmp_cephusage.sh
+  lineinfile:
+    dest: /etc/sudoers.d/Debian-snmp
+    state: present
+    regexp: '^Debian-snmp.*/usr/local/bin/snmp_cephusage.sh'
+    line: 'Debian-snmp     ALL = (root) NOPASSWD: /usr/local/bin/snmp_cephusage.sh'
     validate: visudo -cf %s
     create: yes
 - name: remove 'virtu' from sudoers file

--- a/src/debian/snmp_cephstatus.sh
+++ b/src/debian/snmp_cephstatus.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+/usr/bin/ceph status

--- a/src/debian/snmp_cephusage.sh
+++ b/src/debian/snmp_cephusage.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+/usr/bin/ceph status --format=json | /usr/bin/jq -c .pgmap

--- a/src/debian/snmpd.conf
+++ b/src/debian/snmpd.conf
@@ -19,3 +19,5 @@ extend crmstatus /usr/bin/timeout 1s /bin/bash /usr/local/bin/snmp_crmstatus.sh
 extend domstats /usr/bin/timeout 1s /bin/bash /usr/local/bin/snmp_domstats.sh
 extend dommemstat /usr/bin/timeout 1s /bin/bash /usr/local/bin/snmp_dommemstat.sh
 extend diskusage /usr/bin/timeout 40s /usr/bin/sudo /usr/local/bin/snmp_diskusage.sh
+extend cephstatus /usr/bin/timeout 2s /usr/bin/sudo /usr/local/bin/snmp_cephstatus.sh
+extend cephusage /usr/bin/timeout 2s /usr/bin/sudo /usr/local/bin/snmp_cephusage.sh


### PR DESCRIPTION
This commit allow the ceph status to be exposed with snmpd, so that polling system like nagios are able to retrieve ceph health data

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>