### PR TITLE
hypervisors: set tsc=reliable in cmdline

### DIFF
--- a/roles/debian/hypervisor/tasks/main.yml
+++ b/roles/debian/hypervisor/tasks/main.yml
@@ -73,6 +73,7 @@
     - rcutree.kthread_prio=10
     - "isolcpus=nohz,domain,managed_irq,{{ cpumachinesrt }}"
     - skew_tick=1
+    - tsc=reliable
 - name: "grub conf osprober"
   lineinfile:
     dest: /etc/default/grub


### PR DESCRIPTION
disables Linux kernel clocksource watchdog (best practice for realtime), as well as the stability checks done at bootup

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>