### PR TITLE
setup up systemd-networkd-wait-online.service to replace dirty corosync hack

### DIFF
--- a/roles/debian/tasks/main.yml
+++ b/roles/debian/tasks/main.yml
@@ -27,6 +27,26 @@
     name: votp-config_ovs.service
     enabled: yes
 
+- name: Create systemd-networkd-wait-online.service.d directory
+  file:
+    path: /etc/systemd/system/systemd-networkd-wait-online.service.d/
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+- name: Copy systemd-networkd-wait-online.service drop-in
+  ansible.builtin.copy:
+    src: ../src/debian/systemd-networkd-wait-online_override.conf
+    dest: /etc/systemd/system/systemd-networkd-wait-online.service.d/override.conf
+    owner: root
+    group: root
+    mode: 0644
+  notify: daemon-reload
+- name: enable systemd-networkd-wait-online.service
+  ansible.builtin.systemd:
+    name: systemd-networkd-wait-online.service
+    enabled: yes
+
 - name: Synchronization of src vm_manager on the control machine to dest on the remote hosts
   ansible.posix.synchronize:
     src: ../src/debian/vm_manager
@@ -117,21 +137,6 @@
   ansible.builtin.copy:
     src: ../src/debian/libvirtd_override.conf
     dest: /etc/systemd/system/libvirtd.service.d/override.conf
-    owner: root
-    group: root
-    mode: 0644
-  notify: daemon-reload
-- name: Create corosync.service.d directory
-  file:
-    path: /etc/systemd/system/corosync.service.d/
-    state: directory
-    owner: root
-    group: root
-    mode: 0755
-- name: Copy corosync.service drop-in
-  ansible.builtin.copy:
-    src: ../src/debian/corosync_override.conf
-    dest: /etc/systemd/system/corosync.service.d/override.conf
     owner: root
     group: root
     mode: 0644

--- a/src/debian/corosync_override.conf
+++ b/src/debian/corosync_override.conf
@@ -1,2 +1,0 @@
-[Service]
-ExecStartPre=/bin/sh -c 'while [ $(ip a | grep team0 | grep inet | grep brd | wc -l) -ne 1 ]; do sleep 1; done'

--- a/src/debian/systemd-networkd-wait-online_override.conf
+++ b/src/debian/systemd-networkd-wait-online_override.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/lib/systemd/systemd-networkd-wait-online -i br0 -i team0


### PR DESCRIPTION
Right now the network-online.target is reached before all needed interfaces are up. This poses a problem for corosync (team0 being not up when corosync starts, it fails), problem we solved with a dirty hack (wait loop in a systemd service override).
We have the same problem with newly added service "hddtemp".

This commit cleans everything up by setting up systemd-networkd-wait-online.service and configuring it to wait for at least interfaces br0 and team0. network-online.target will only be reached once
systemd-networkd-wait-online.service is completed, which will solve both corosync and hddtemp timing problems.

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>