### PR TITLE
Timemaster: allow PTP configuration for hosts

### DIFF
--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -11,6 +11,7 @@ all:
                             main_disk: /dev/sda # disk for system
                             ip_addr: "{{ ansible_host }}"
                             subnet: 25 #default is 24, override if necessary
+                            ptp_interface: "eno12419"
                             team0_0: "eno12399" # cluster network first interface
                             team0_1: "eno12409" # cluster network second interface
                             cluster_next_ip_addr : "192.168.55.2" #node 2 cluster network ip
@@ -24,6 +25,7 @@ all:
                             main_disk: /dev/sda
                             ip_addr: "{{ ansible_host }}"
                             subnet: 25
+                            ptp_interface: "eno12419"
                             team0_0: "eno12399"
                             team0_1: "eno12409"
                             cluster_next_ip_addr : "192.168.55.3" #node 3 cluster network ip
@@ -38,6 +40,7 @@ all:
                             main_disk: /dev/sda
                             ip_addr: "{{ ansible_host }}"
                             subnet: 25
+                            ptp_interface: "eno12419"
                             team0_0: "eno12399"
                             team0_1: "eno12409"
                             cluster_next_ip_addr : "192.168.55.1" #ip de hyperviseur 1
@@ -83,8 +86,8 @@ all:
         dns_server: 10.10.2.1   # Not valid, just for Ansible
         gateway_addr: 10.0.0.1 # Not valid, just for Ansible
         apply_network_config: true
-        ntp_servers: "10.10.10.10"
-        fallback_ntp_servers: 
+        ntp_primary_server: "185.254.101.25"
+        ntp_secondary_server: "51.145.123.29"
         ceph_public_network: "192.168.55.0/24"
         ceph_cluster_network: "192.168.55.0/24"
         monitor_address: "{{ ansible_host }}"

--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -97,33 +97,46 @@
         state: absent
         regexp: '^127.*debian'
 
-
-- name: Configure NTP
+- name: Configure TimeMaster
   hosts: cluster_machines
   become: true
   tasks:
-    - name: Set NTP configuration in /etc/systemd/timesyncd.conf
-      lineinfile:
-        dest: /etc/systemd/timesyncd.conf
-        regexp: '{{ item.regexp }}'
-        line: '{{ item.line   }}'
-        insertafter: '\[Time\]'
-        backrefs: true
-        create: true
-        state: present
-      with_items:
-        - regexp: '^\s*#?\s*(NTP=).*$'
-          line: 'NTP={{ ntp_servers }}'
-        - regexp: '^\s*#?\s*(FallbackNTP=).*$'
-          line: 'FallbackNTP={{ fallback_ntp_servers | default("") }}'
-      notify:
-        - Restart systemd timesyncd
-
-  handlers:
-    - name: Restart systemd timesyncd
-      ansible.builtin.service:
-        name: systemd-timesyncd
+    - name: Populate service facts
+      service_facts:
+    - name: stop and disable systemd-timesyncd if it exists
+      service:
+        name: "systemd-timesyncd"
+        state: stopped
+        enabled: false
+      when: "'systemd-timesyncd' in services"
+    - name: stop and disable chrony
+      service:
+        name: "chrony"
+        state: stopped
+        enabled: false
+    - name: Create timemaster configuration
+      template:
+        src: ../templates/timemaster.conf.j2
+        dest: /etc/linuxptp/timemaster.conf
+      register: timemasterconf1
+    - name: comment pool configuration in chrony.conf
+      replace:
+        path: /etc/chrony/chrony.conf
+        regexp: '^(pool .*)'
+        replace: '#\1'
+      register: timemasterconf2
+    - name: start and enable timemaster
+      service:
+        name: "timemaster"
+        state: started
+        enabled: true
+    - name: restart timemaster if necessary
+      service:
+        name: "timemaster"
         state: restarted
+        enabled: true
+      when: timemasterconf1 or timemasterconf2
+
 - name: Configure syslog-ng
   hosts: cluster_machines
   become: true

--- a/templates/timemaster.conf.j2
+++ b/templates/timemaster.conf.j2
@@ -1,0 +1,74 @@
+# Configuration file for timemaster
+
+{% if ptp_interface is defined %}
+[ptp_domain 0]
+ntp_options poll 0
+interfaces {{ ptp_interface }}
+delay 1e-9
+# delay:
+# This option sets the NTP delay of the source (in seconds). Half of this value
+# is included in the maximum assumed error which is used in the source selection
+# algorithm. Increasing the delay is useful to avoid having no majority in the
+# source selection or to make it prefer other sources.
+# The default is 1e-9 (1 nanosecond).
+# Leave as default to leave the error be computed via the std dev of measured samples.
+{% endif %}
+
+[timemaster]
+ntp_program chronyd
+
+[chrony.conf]
+include /etc/chrony/chrony.conf
+{% if ptp_interface is defined %}
+server {{ ntp_primary_server }} iburst maxsamples 10
+{% else %}
+server {{ ntp_primary_server }} iburst maxsamples 10 prefer
+{% endif %}
+server {{ ntp_secondary_server }} iburst maxsamples 10
+
+[ntp.conf]
+includefile /etc/ntp.conf
+
+[ptp4l.conf]
+slaveOnly             1
+network_transport     L2
+
+# IEC 61850-9-3 Profile
+# (from : https://en.wikipedia.org/wiki/IEC/IEEE_61850-9-3)
+network_transport     L2
+delay_mechanism          P2P
+domainNumber             0
+
+# Announce interval: 1s
+logAnnounceInterval      0
+
+# Sync interval: 1 s
+logSyncInterval          0
+
+# Pdelay interval: 1 s
+logMinPdelayReqInterval  0
+operLogPdelayReqInterval 0
+
+# Announce receipt time-out: 3 s (fixed)
+announceReceiptTimeout   3
+
+# Slave-only priority :
+priority1                255
+priority2                255
+# Default clock class : any specialised clock will be better (ie a GPS Grand Master Clock)
+clockClass               248
+
+[chronyd]
+path /usr/sbin/chronyd
+
+[ntpd]
+path /usr/sbin/ntpd
+options -u ntp:ntp -g
+
+[phc2sys]
+path /usr/sbin/phc2sys
+
+[ptp4l]
+path /usr/sbin/ptp4l
+# make ptp4l really verbose (to see synchro values)
+options -l 6


### PR DESCRIPTION
Right now we are using systemd-timesyncd for basic NTP configuration. This commit replaces systemd-timesyncd by timemaster and allow either to use PTP with NTP backup or directly NTP.
The PTP configuration must be done in the inventory with the definition of the "ptp_interface" for each host.
The NTP configuration is done in the inventory with the ntp_primary_server and ntp_seconday_server variables

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>