### PR TITLE
Move networkd wait stuff from debian role to network playbook

### DIFF
--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -152,20 +152,21 @@
   hosts: hypervisors
   become: true
   tasks:
-    - block:
-        - name: Create systemd-networkd-wait-online.service.d directory
-          file:
-            state: directory
-            path: /etc/systemd/system/systemd-networkd-wait-online.service.d
-            owner: root
-            group: root
-            mode: 644
-        - name: Copy systemd-networkd-wait-online.service overide
-          template:
-            src: ../templates/systemd-networkd-wait-online.service.j2
-            dest: >-
-              /etc/systemd/system/systemd-networkd-wait-online.service.d/override.conf
-      when: cluster_interface is defined
+    - name: Create systemd-networkd-wait-online.service.d directory
+      file:
+        path: /etc/systemd/system/systemd-networkd-wait-online.service.d/
+        state: directory
+        owner: root
+        group: root
+        mode: 0755
+    - name: Copy systemd-networkd-wait-online.service overide
+      template:
+        src: ../templates/systemd-networkd-wait-online.service.j2
+        dest: /etc/systemd/system/systemd-networkd-wait-online.service.d/override.conf
+    - name: enable systemd-networkd-wait-online.service
+      ansible.builtin.systemd:
+        name: systemd-networkd-wait-online.service
+        enabled: yes
 
 - name: Restart machine if needed
   hosts: cluster_machines

--- a/roles/debian/tasks/main.yml
+++ b/roles/debian/tasks/main.yml
@@ -27,26 +27,6 @@
     name: votp-config_ovs.service
     enabled: yes
 
-- name: Create systemd-networkd-wait-online.service.d directory
-  file:
-    path: /etc/systemd/system/systemd-networkd-wait-online.service.d/
-    state: directory
-    owner: root
-    group: root
-    mode: 0755
-- name: Copy systemd-networkd-wait-online.service drop-in
-  ansible.builtin.copy:
-    src: ../src/debian/systemd-networkd-wait-online_override.conf
-    dest: /etc/systemd/system/systemd-networkd-wait-online.service.d/override.conf
-    owner: root
-    group: root
-    mode: 0644
-  notify: daemon-reload
-- name: enable systemd-networkd-wait-online.service
-  ansible.builtin.systemd:
-    name: systemd-networkd-wait-online.service
-    enabled: yes
-
 - name: Synchronization of src vm_manager on the control machine to dest on the remote hosts
   ansible.posix.synchronize:
     src: ../src/debian/vm_manager

--- a/src/debian/systemd-networkd-wait-online_override.conf
+++ b/src/debian/systemd-networkd-wait-online_override.conf
@@ -1,3 +1,0 @@
-[Service]
-ExecStart=
-ExecStart=/lib/systemd/systemd-networkd-wait-online -i br0 -i team0

--- a/templates/systemd-networkd-wait-online.service.j2
+++ b/templates/systemd-networkd-wait-online.service.j2
@@ -1,2 +1,3 @@
 [Service]
-ExecStart=/lib/systemd/systemd-networkd-wait-online -i {{ network_interface }}
+ExecStart=
+ExecStart=/lib/systemd/systemd-networkd-wait-online -i br0 -i team0


### PR DESCRIPTION
Commit 48709fc added some networkd wait logic to the debian role (waiting for br0 + team0 interfaces), but there actually already was some networkd logic in the networking playbook.
This commit merges both in the networking playbook.

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>