### PR TITLE
Fixing the uid/gid of the Debian-snmp account

### DIFF
--- a/roles/debian/tasks/main.yml
+++ b/roles/debian/tasks/main.yml
@@ -152,6 +152,41 @@
     enabled: yes
   when: pacemaker_corosync.changed and pacemaker_service_status.status.UnitFileState == "enabled"
 
+- name: get Debian-snmp uid
+  getent:
+    database: passwd
+    key: "Debian-snmp"
+- name: get Debian-snmp gid
+  getent:
+    database: group
+    key: "Debian-snmp"
+- debug:
+    msg:
+      - "user id {{ getent_passwd['Debian-snmp'][1] }}"
+      - "group id {{ getent_group['Debian-snmp'][1] }}"
+
+- name: Set Debian-snmp correct uid/gid
+  block:
+    - name: stop snmpd if needed
+      ansible.builtin.systemd:
+        name: snmpd.service
+        state: stopped
+    - name: Ensure group "Debian-snmp" exists with correct gid
+      ansible.builtin.group:
+        name: Debian-snmp
+        state: present
+        gid: 10002
+    - name: Ensure user Debian-snmp has correct uid and gid
+      user:
+        name: Debian-snmp
+        uid: 10002
+        group: Debian-snmp
+    - name: restart snmpd
+      ansible.builtin.systemd:
+        name: snmpd.service
+        state: started
+  when: getent_passwd['Debian-snmp'][1] != "10002" or getent_group['Debian-snmp'][1] != "10002"
+
 - name: Synchronization of snmp_ scripts
   ansible.posix.synchronize:
     src: ../src/debian/
@@ -361,3 +396,6 @@
     state: restarted
     name: hddtemp
   when: updatehddtemp1.changed or updatehddtemp2.changed or updatehddtemp3.changed
+
+
+


### PR DESCRIPTION
This is necessary in case the user delegates the users/groups/sudo management to an external directory (ldap, activedirectory...) : the directory imposes the uid/gid and so we need to set the same so that there is a local backup with the same uid/gid.
This is true for specific service accounts which right now are:
- virtu (uid/gid=1000), set by build_debian_iso
- ansible (uid/gid=1005), set by build_debian_iso
- ceph (uid/gid=64045), set by ceph installation package
- Debian-snmp (uid/gid=10002), set by the ansible playbook (object of this commit)

Other accounts have no point being managed by an external directory

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>