### PR TITLE
Silly bug in Timemaster playbook

### DIFF
--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -135,7 +135,7 @@
         name: "timemaster"
         state: restarted
         enabled: true
-      when: timemasterconf1 or timemasterconf2
+      when: timemasterconf1.changed or timemasterconf2.changed
 
 - name: Configure syslog-ng
   hosts: cluster_machines


### PR DESCRIPTION
0d5f3e83a906880eb90fb9a98cfbce704e5e0198 make the network playbook restart timemaster even when there is no change.
This commit fixes this.

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>