### PR TITLE
debian roles: split sysctl settings (rt and non rt)

### DIFF
--- a/roles/debian/hypervisor/tasks/main.yml
+++ b/roles/debian/hypervisor/tasks/main.yml
@@ -37,6 +37,14 @@
     name: votp-taskset.service
     enabled: yes
 
+- name: Copy sysctl RT rules
+  ansible.builtin.copy:
+    src: ../src/debian/{{ item }}
+    dest: /etc/sysctl.d/{{ item }}
+    mode: '0644'
+  with_items:
+    - 00-schedrt.conf
+
 - name: Copy sysfs.d cpumask
   template:
     src: ../templates/00-workqueue_cpumask.conf.j2

--- a/roles/debian/tasks/main.yml
+++ b/roles/debian/tasks/main.yml
@@ -278,7 +278,6 @@
     dest: /etc/sysctl.d/{{ item }}
     mode: '0644'
   with_items:
-    - 00-schedrt.conf
     - 00-panicreboot.conf
 - name: add br_netfilter to /etc/modules
   lineinfile:


### PR DESCRIPTION
The RT sysctl settings should go in the debian/hypervisor role, whereas the non RT specific sysctl settings should stay in the debian role.

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>