### PR TITLE
new playbook for rt only requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ playbooks/*
 !playbooks/replace_machine_*.yaml
 !playbooks/test_*.yaml
 !playbooks/tasks/
+!playbooks/standalone*
 inventories/*
 !inventories/README.adoc
 !inventories/*example*

--- a/playbooks/standalone_rt.yaml
+++ b/playbooks/standalone_rt.yaml
@@ -1,0 +1,5 @@
+- name: RT debian
+  hosts: standalone
+  become: true
+  roles:
+      - debian/hypervisor


### PR DESCRIPTION
Playbook to deploy only the RT requirements on a debian machine without any cluster features