### PR TITLE
rules for trafic to reach the VM from outside

### DIFF
--- a/roles/debian/tasks/main.yml
+++ b/roles/debian/tasks/main.yml
@@ -279,6 +279,7 @@
     mode: '0644'
   with_items:
     - 00-panicreboot.conf
+    - 00-bridge_nf_call.conf
 - name: add br_netfilter to /etc/modules
   lineinfile:
     dest: /etc/modules

--- a/src/debian/00-bridge_nf_call.conf
+++ b/src/debian/00-bridge_nf_call.conf
@@ -1,0 +1,3 @@
+net.bridge.bridge-nf-call-arptables = 0
+net.bridge.bridge-nf-call-ip6tables = 0
+net.bridge.bridge-nf-call-iptables = 0


### PR DESCRIPTION
https://unix.stackexchange.com/questions/572022/linux-bridge-for-virtual-machines-not-forwarding-ip-packets-but-is-forwarding-a

This had already been added with commit d8abc1f and add been removed by c4514f4. When I rollback the changed of c4514f4 in commit 0e9b0ab, I forgot to reapply this needed workaround.

Signed-off-by: Florent CARLI <florent.carli@rte-france.com>