### PR TITLE
playbooks: fix vm-manager config installation

### DIFF
--- a/playbooks/test_deploy_cukinia_tests.yaml
+++ b/playbooks/test_deploy_cukinia_tests.yaml
@@ -20,3 +20,21 @@
       copy:
         src: ../src/cukinia-tests/includes/kernel_config_functions
         dest: /usr/share/cukinia/includes/kernel_config_functions
+    - name: Create /usr/share/testdata
+      file:
+        path: /usr/share/testdata
+        state: directory
+        owner: root
+        group: root
+        mode: 0755
+    - name: Copy vm.xml
+      copy:
+        src: ../src/debian/vm_manager/vm_manager/testdata/vm.xml
+        dest: /usr/share/testdata
+    - name: Copy wrong_vm_config.xml
+      copy:
+        src: ../src/debian/vm_manager/vm_manager/testdata/wrong_vm_config.xml
+        dest: /usr/share/testdata
+
+
+


### PR DESCRIPTION
Fix an issue where vm-manager configuration 'vm.xml' and 'wrong_vm_config.xml' files were not installed on target, causing failures in Cukinia tests.

Signed-off-by: Paul Le Guen de Kerneizon <paul.leguendekerneizon@savoirfairelinux.com>