### PR TITLE
Submodule ci

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -52,7 +52,7 @@ ansible-galaxy collection install --collections-path="$(pwd)/collections" -r \
     ansible-requirements.yaml
 
 echo "Update git submodules"
-git submodule update --init --force --remote
+git submodule update --init --force
 
 echo "Copy ceph-ansible site.yml"
 cp -vf src/ceph-ansible-site.yaml ceph-ansible/site.yml


### PR DESCRIPTION
The --remote option checkouts the submodule to the latest remote
tracking branch revision instead of the specified SHA1 commit.
This doesn't allow to test the submodules through the CI since the
commits to be verified are not yet merged.