### PR TITLE
Adapt Ansible playbooks to run functional tests

### DIFF
--- a/playbooks/test_deploy_cukinia_tests.yaml
+++ b/playbooks/test_deploy_cukinia_tests.yaml
@@ -20,3 +20,21 @@
       copy:
         src: ../src/cukinia-tests/includes/kernel_config_functions
         dest: /usr/share/cukinia/includes/kernel_config_functions
+    - name: Create /usr/share/testdata
+      file:
+        path: /usr/share/testdata
+        state: directory
+        owner: root
+        group: root
+        mode: 0755
+    - name: Copy vm.xml
+      copy:
+        src: ../src/debian/vm_manager/vm_manager/testdata/vm.xml
+        dest: /usr/share/testdata
+    - name: Copy wrong_vm_config.xml
+      copy:
+        src: ../src/debian/vm_manager/vm_manager/testdata/wrong_vm_config.xml
+        dest: /usr/share/testdata
+
+
+

--- a/playbooks/test_deploy_cukinia_tests.yaml
+++ b/playbooks/test_deploy_cukinia_tests.yaml
@@ -37,4 +37,18 @@
         dest: /usr/share/testdata
 
 
+- name: Deploy Cukinia's main configuration on observers
+  hosts: observers
+  tasks:
+    - name: Copy cukinia.conf
+      copy:
+        src: ../src/cukinia-tests/cukinia-observer.conf
+        dest: /etc/cukinia/cukinia.conf
 
+- name: Deploy Cukinia's main configuration on hypervisor
+  hosts: hypervisors
+  tasks:
+    - name: Copy cukinia.conf
+      copy:
+        src: ../src/cukinia-tests/cukinia-hypervisor.conf
+        dest: /etc/cukinia/cukinia.conf

--- a/playbooks/test_run_cukinia-sec.yaml
+++ b/playbooks/test_run_cukinia-sec.yaml
@@ -1,0 +1,30 @@
+# Copyright (C) 2022, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+# Ansible playbook that runs Cukinia tests and export the result in CSV.
+
+---
+- hosts: cluster_machines
+  name: Cukinia tests
+  vars:
+    tests_format: junitxml
+    tests_result_name: cukinia.xml
+    cukinia_test_prefix: ".."
+    cukinia_configuration: "/etc/cukinia/cukinia-sec.conf"
+  tasks:
+    - name: Create temporary Cukinia directory
+      tempfile:
+        state: directory
+      register: tmp_cukinia_dir
+    - name: Run tests
+      shell:
+        cmd: >-
+          MACHINENAME={{ cukinia_namespace | default(inventory_hostname) }}
+          cukinia -f {{ tests_format }}
+          -o {{ tmp_cukinia_dir.path }}/{{ tests_result_name }}
+          {{ cukinia_configuration }} || true
+    - name: Fetch result
+      fetch:
+        src: "{{ tmp_cukinia_dir.path }}/{{ tests_result_name }}"
+        dest: "{{ cukinia_test_prefix }}/{{ tests_result_name }}"
+        flat: yes

--- a/playbooks/test_run_cukinia.yaml
+++ b/playbooks/test_run_cukinia.yaml
@@ -27,3 +27,17 @@
         src: "{{ tmp_cukinia_dir.path }}/{{ tests_result_name }}"
         dest: "{{ cukinia_test_prefix }}/{{ tests_result_name }}"
         flat: yes
+    - name: Run cluster tests
+      shell:
+        cmd: >-
+          MACHINENAME=cluster
+          cukinia -f {{ tests_format }}
+          -o {{ tmp_cukinia_dir.path }}/cukinia_cluster.xml /etc/cukinia/cukinia-cluster.conf || true
+      run_once: true
+
+    - name: Fetch cluster result
+      fetch:
+        src: "{{ tmp_cukinia_dir.path }}/cukinia_cluster.xml"
+        dest: "{{ cukinia_test_prefix }}/cukinia_cluster.xml"
+        flat: yes
+      run_once: true

--- a/playbooks/test_run_cukinia.yaml
+++ b/playbooks/test_run_cukinia.yaml
@@ -1,16 +1,16 @@
 # Copyright (C) 2022, RTE (http://www.rte-france.com)
 # SPDX-License-Identifier: Apache-2.0
 
-# Ansible playbook that runs Cukinia tests and export the result in CSV.
+# Ansible playbook that runs Cukinia functional tests and export the result in
+# CSV.
 
 ---
 - hosts: cluster_machines
   name: Cukinia tests
   vars:
     tests_format: junitxml
-    tests_result_name: cukinia.xml
+    tests_result_name: "cukinia_{{ inventory_hostname }}.xml"
     cukinia_test_prefix: ".."
-    cukinia_configuration: "/etc/cukinia/cukinia-sec.conf"
   tasks:
     - name: Create temporary Cukinia directory
       tempfile:
@@ -21,11 +21,9 @@
         cmd: >-
           MACHINENAME={{ cukinia_namespace | default(inventory_hostname) }}
           cukinia -f {{ tests_format }}
-          -o {{ tmp_cukinia_dir.path }}/{{ tests_result_name }}
-          {{ cukinia_configuration }} || true
+          -o {{ tmp_cukinia_dir.path }}/{{ tests_result_name }} || true
     - name: Fetch result
       fetch:
         src: "{{ tmp_cukinia_dir.path }}/{{ tests_result_name }}"
         dest: "{{ cukinia_test_prefix }}/{{ tests_result_name }}"
         flat: yes
-  run_once: true

--- a/prepare.sh
+++ b/prepare.sh
@@ -52,7 +52,7 @@ ansible-galaxy collection install --collections-path="$(pwd)/collections" -r \
     ansible-requirements.yaml
 
 echo "Update git submodules"
-git submodule update --init --force --remote
+git submodule update --init --force
 
 echo "Copy ceph-ansible site.yml"
 cp -vf src/ceph-ansible-site.yaml ceph-ansible/site.yml


### PR DESCRIPTION
This PR modifies Ansible playbooks in order to run functional test for each machine (hypervisor and observer) from the playbook test_run_cukinia.yaml.