### PR TITLE
playbooks: rollback before running the CI

### DIFF
--- a/playbooks/ci_restore_snapshot.yaml
+++ b/playbooks/ci_restore_snapshot.yaml
@@ -1,0 +1,22 @@
+# Copyright (C) 2023, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+# This playbook rollback in the CI to the initiale state using LVM
+---
+- name: Rollback to the initiale state
+  hosts: cluster_machines
+  tasks:
+    - name: Merge lvm snapshot
+      command:
+        cmd: lvconvert --merge vg1/root-snap
+    - name: Restart
+      reboot:
+    - name: Refresh LVM
+      command:
+        cmd:  lvchange --refresh vg1
+    - name: Recreate the snapshot
+      lvol:
+        vg: vg1
+        lv: root
+        snapshot: root-snap
+        size: 7G

--- a/playbooks/ci_the_one_playbook.yaml
+++ b/playbooks/ci_the_one_playbook.yaml
@@ -8,6 +8,7 @@
 # One Playbook to bring them all
 # and in the darkness bind them
 ---
+- import_playbook: ./ci_restore_snapshot.yaml
 - import_playbook: ./cluster_setup_debian.yaml
 - import_playbook: ./cluster_setup_hardened_debian.yaml
 - import_playbook: ./test_deploy_cukinia.yaml


### PR DESCRIPTION
Use LVM to rollback to the initial state before running the CI.

Signed-off-by: Mathieu Dupré <mathieu.dupre@savoirfairelinux.com>