### PR TITLE
Add playbooks to deploy VM's

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ playbooks/*
 !playbooks/test_*.yaml
 !playbooks/tasks/
 !playbooks/standalone*
+!playbooks/vm_*.yaml
 inventories/*
 !inventories/README.adoc
 !inventories/*example*

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ inventories_private/
 # Ignore Cukinia results
 /*.csv
 /*.xml
+
+# VM folder
+vm_images/*

--- a/playbooks/test_deploy_cukinia_tests.yaml
+++ b/playbooks/test_deploy_cukinia_tests.yaml
@@ -20,3 +20,21 @@
       copy:
         src: ../src/cukinia-tests/includes/kernel_config_functions
         dest: /usr/share/cukinia/includes/kernel_config_functions
+    - name: Create /usr/share/testdata
+      file:
+        path: /usr/share/testdata
+        state: directory
+        owner: root
+        group: root
+        mode: 0755
+    - name: Copy vm.xml
+      copy:
+        src: ../src/debian/vm_manager/vm_manager/testdata/vm.xml
+        dest: /usr/share/testdata
+    - name: Copy wrong_vm_config.xml
+      copy:
+        src: ../src/debian/vm_manager/vm_manager/testdata/wrong_vm_config.xml
+        dest: /usr/share/testdata
+
+
+

--- a/playbooks/test_deploy_cukinia_tests.yaml
+++ b/playbooks/test_deploy_cukinia_tests.yaml
@@ -37,4 +37,18 @@
         dest: /usr/share/testdata
 
 
+- name: Deploy Cukinia's main configuration on observers
+  hosts: observers
+  tasks:
+    - name: Copy cukinia.conf
+      copy:
+        src: ../src/cukinia-tests/cukinia-observer.conf
+        dest: /etc/cukinia/cukinia.conf
 
+- name: Deploy Cukinia's main configuration on hypervisor
+  hosts: hypervisors
+  tasks:
+    - name: Copy cukinia.conf
+      copy:
+        src: ../src/cukinia-tests/cukinia-hypervisor.conf
+        dest: /etc/cukinia/cukinia.conf

--- a/playbooks/test_run_cukinia-sec.yaml
+++ b/playbooks/test_run_cukinia-sec.yaml
@@ -1,0 +1,30 @@
+# Copyright (C) 2022, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+# Ansible playbook that runs Cukinia tests and export the result in CSV.
+
+---
+- hosts: cluster_machines
+  name: Cukinia tests
+  vars:
+    tests_format: junitxml
+    tests_result_name: cukinia.xml
+    cukinia_test_prefix: ".."
+    cukinia_configuration: "/etc/cukinia/cukinia-sec.conf"
+  tasks:
+    - name: Create temporary Cukinia directory
+      tempfile:
+        state: directory
+      register: tmp_cukinia_dir
+    - name: Run tests
+      shell:
+        cmd: >-
+          MACHINENAME={{ cukinia_namespace | default(inventory_hostname) }}
+          cukinia -f {{ tests_format }}
+          -o {{ tmp_cukinia_dir.path }}/{{ tests_result_name }}
+          {{ cukinia_configuration }} || true
+    - name: Fetch result
+      fetch:
+        src: "{{ tmp_cukinia_dir.path }}/{{ tests_result_name }}"
+        dest: "{{ cukinia_test_prefix }}/{{ tests_result_name }}"
+        flat: yes

--- a/playbooks/test_run_cukinia.yaml
+++ b/playbooks/test_run_cukinia.yaml
@@ -1,16 +1,16 @@
 # Copyright (C) 2022, RTE (http://www.rte-france.com)
 # SPDX-License-Identifier: Apache-2.0
 
-# Ansible playbook that runs Cukinia tests and export the result in CSV.
+# Ansible playbook that runs Cukinia functional tests and export the result in
+# CSV.
 
 ---
 - hosts: cluster_machines
   name: Cukinia tests
   vars:
     tests_format: junitxml
-    tests_result_name: cukinia.xml
+    tests_result_name: "cukinia_{{ inventory_hostname }}.xml"
     cukinia_test_prefix: ".."
-    cukinia_configuration: "/etc/cukinia/cukinia-sec.conf"
   tasks:
     - name: Create temporary Cukinia directory
       tempfile:
@@ -21,11 +21,9 @@
         cmd: >-
           MACHINENAME={{ cukinia_namespace | default(inventory_hostname) }}
           cukinia -f {{ tests_format }}
-          -o {{ tmp_cukinia_dir.path }}/{{ tests_result_name }}
-          {{ cukinia_configuration }} || true
+          -o {{ tmp_cukinia_dir.path }}/{{ tests_result_name }} || true
     - name: Fetch result
       fetch:
         src: "{{ tmp_cukinia_dir.path }}/{{ tests_result_name }}"
         dest: "{{ cukinia_test_prefix }}/{{ tests_result_name }}"
         flat: yes
-  run_once: true

--- a/playbooks/vm_deploy.yaml
+++ b/playbooks/vm_deploy.yaml
@@ -1,0 +1,39 @@
+# Copyright (C) 2023, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+# Ansible playbook that create and start a VM.
+
+---
+
+# Fetch and create VM config file
+- hosts: hypervisors
+  name: Create and start guest{{ vm_id }}
+  vars:
+    - vm_id: 1
+    - cpu_set: 5
+    - xml_template: >-
+        {{ vm_config |
+        default('../templates/vm/votp_vm_rt_isolated.xml.j2') }}
+    - disk_path: "../vm_images/vm.qcow2"
+# Create and start a VM
+  tasks:
+    - name: Copy the disk on target
+      copy:
+        src: "{{ disk_path }}"
+        dest: /tmp/vm.qcow2
+    - name: Create and start VM
+      cluster_vm:
+        name: guest{{ vm_id }}
+        command: create
+        system_image: /tmp/vm.qcow2
+        xml: >-
+          {{ lookup('template', xml_template,
+          template_vars=dict(
+            title='guest{{ vm_id }}',
+            ovs_port='VM{{ vm_id }}.0',
+            cpuset='{{ cpu_set }}',
+            mac_address='52:54:00:42:ab:0{{ vm_id }}', ),
+          errors='strict') }}
+        metadata:
+            myMetadata: value
+            anotherMetadata: value

--- a/playbooks/vm_remove.yaml
+++ b/playbooks/vm_remove.yaml
@@ -1,0 +1,22 @@
+# Copyright (C) 2023, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+# Ansible playbook that remove a VM.
+---
+
+- hosts: hypervisors
+  name: Stop and remove guest{{ vm_id }}
+  vars:
+    - vm_id: 1
+# Create and start a VM
+  tasks:
+    - name: Stop VM
+      cluster_vm:
+        name: guest{{ vm_id }}
+        command: stop
+        force: true
+    - name: Remove VM
+      cluster_vm:
+        name: guest{{ vm_id }}
+        command: remove
+


### PR DESCRIPTION
This PR adds two playbooks:

- vm_deploy.yaml: a playbook to create and start a VM in cluster
- vm_remove.yaml: a playbook to stop and remove a VM in cluster

VM image files must be stored in `vm_images/` directory.