### PR TITLE
Add playbooks to deploy VM's

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ playbooks/*
 !playbooks/test_*.yaml
 !playbooks/tasks/
 !playbooks/standalone*
+!playbooks/vm_*.yaml
 inventories/*
 !inventories/README.adoc
 !inventories/*example*

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ inventories_private/
 # Ignore Cukinia results
 /*.csv
 /*.xml
+
+# VM folder
+vm_images/*

--- a/playbooks/vm_deploy.yaml
+++ b/playbooks/vm_deploy.yaml
@@ -1,0 +1,39 @@
+# Copyright (C) 2023, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+# Ansible playbook that create and start a VM.
+
+---
+
+# Fetch and create VM config file
+- hosts: hypervisors
+  name: Create and start guest{{ vm_id }}
+  vars:
+    - vm_id: 1
+    - cpu_set: 5
+    - xml_template: >-
+        {{ vm_config |
+        default('../templates/vm/votp_vm_rt_isolated.xml.j2') }}
+    - disk_path: "../vm_images/vm.qcow2"
+# Create and start a VM
+  tasks:
+    - name: Copy the disk on target
+      copy:
+        src: "{{ disk_path }}"
+        dest: /tmp/vm.qcow2
+    - name: Create and start VM
+      cluster_vm:
+        name: guest{{ vm_id }}
+        command: create
+        system_image: /tmp/vm.qcow2
+        xml: >-
+          {{ lookup('template', xml_template,
+          template_vars=dict(
+            title='guest{{ vm_id }}',
+            ovs_port='VM{{ vm_id }}.0',
+            cpuset='{{ cpu_set }}',
+            mac_address='52:54:00:42:ab:0{{ vm_id }}', ),
+          errors='strict') }}
+        metadata:
+            myMetadata: value
+            anotherMetadata: value

--- a/playbooks/vm_remove.yaml
+++ b/playbooks/vm_remove.yaml
@@ -1,0 +1,22 @@
+# Copyright (C) 2023, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+# Ansible playbook that remove a VM.
+---
+
+- hosts: hypervisors
+  name: Stop and remove guest{{ vm_id }}
+  vars:
+    - vm_id: 1
+# Create and start a VM
+  tasks:
+    - name: Stop VM
+      cluster_vm:
+        name: guest{{ vm_id }}
+        command: stop
+        force: true
+    - name: Remove VM
+      cluster_vm:
+        name: guest{{ vm_id }}
+        command: remove
+


### PR DESCRIPTION
This PR adds two playbooks:

- `vm_deploy.yaml`: a playbook to create and start a VM in cluster

- `vm_remove.yaml`: a playbook to stop and remove a VM in cluster

VM image files must be stored in `vm_images/` directory.
