### PR TITLE
roles/debian-hardening: force reboot after applying the role

### DIFF
--- a/playbooks/ci_configure.yaml
+++ b/playbooks/ci_configure.yaml
@@ -6,5 +6,11 @@
 ---
 - import_playbook: ./ci_cleanup_syslog.yaml
 - import_playbook: ./ci_restore_snapshot.yaml
+- name: CI configure skip reboot
+  hosts: cluster_machines
+  tasks:
+  - name: CI configure skip setup_debian reboot
+    set_fact:
+      skip_reboot_setup_debian: true
 - import_playbook: ./cluster_setup_debian.yaml
 - import_playbook: ./cluster_setup_hardened_debian.yaml

--- a/playbooks/ci_restore_snapshot.yaml
+++ b/playbooks/ci_restore_snapshot.yaml
@@ -9,7 +9,7 @@
     - name: Merge lvm snapshot
       command:
         cmd: lvconvert --merge vg1/root-snap
-    - name: Restart
+    - name: Restart for snapshot rollback
       reboot:
     - name: Refresh LVM
       command:

--- a/playbooks/cluster_setup_debian.yaml
+++ b/playbooks/cluster_setup_debian.yaml
@@ -1,4 +1,10 @@
 - import_playbook: cluster_setup_prerequisdebian.yaml
+- name: Setup debian skip setup_network reboot
+  hosts: cluster_machines
+  tasks:
+  - name: Setup debian skip reboot
+    set_fact:
+      skip_reboot_setup_network: true
 - import_playbook: cluster_setup_network.yaml
 - import_playbook: cluster_setup_ceph.yaml
 - import_playbook: cluster_setup_libvirt.yaml
@@ -7,8 +13,9 @@
 - name: Restart all hosts
   hosts: cluster_machines
   tasks:
-    - name: Restart
+    - name: Restart to configure Debian
       reboot:
+      when:
+        - skip_reboot_setup_debian is not defined or not skip_reboot_setup_debian
     - name: Wait for host to be online
       wait_for_connection:
-

--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -184,8 +184,10 @@
   become: true
   tasks:
     - block:
-        - name: Restart
+        - name: Restart to configure network
           reboot:
         - name: Wait for host to be online
           wait_for_connection:
-      when: need_reboot is defined and need_reboot
+      when:
+        - need_reboot is defined and need_reboot
+        - skip_reboot_setup_network is not defined or not skip_reboot_setup_network

--- a/roles/debian-hardening/handlers/main.yml
+++ b/roles/debian-hardening/handlers/main.yml
@@ -2,29 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 
-- name: update-grub
-  shell:
-    cmd: update-grub
-
 - name: update sysfs values using sysctl
   shell:
     cmd: sysctl --system
-
-- name: reload systemd
-  ansible.builtin.systemd:
-    daemon_reload: yes
-
-- name: restart openssh
-  ansible.builtin.systemd:
-    name: sshd
-    state: restarted
-
-- name: restart services
-  ansible.builtin.systemd:
-    name: "{{ item.item }}.service"
-    state: restarted
-  when: item.changed
-  with_items: "{{ services_to_restart.results }}"
-
-- name: reboot
-  reboot:

--- a/roles/debian-hardening/tasks/main.yml
+++ b/roles/debian-hardening/tasks/main.yml
@@ -28,9 +28,6 @@
     backrefs: yes
   register: updategrub
   with_items: "{{ kernel_params }}"
-  notify:
-    - update-grub
-    - reboot
   when: not revert
 
 - name: "Revert kernel parameters added in grub"
@@ -42,9 +39,6 @@
     backrefs: yes
   register: updategrub
   with_items: "{{ kernel_params }}"
-  notify:
-    - update-grub
-    - reboot
   when: revert
 
 - name: "Disable coredumps"
@@ -142,7 +136,6 @@
   copy:
     src: ../src/debian/random-root-passwd.service
     dest: /etc/systemd/system/random-root-passwd.service
-  notify: reload systemd
   when: not revert
   register: randomRoot
 - name: "enable random-root-passwd.service"
@@ -161,7 +154,6 @@
     path: /etc/systemd/system/random-root-passwd.service
     state: absent
   when: revert
-  notify: reload systemd
   register: randomRoot
 
 - name: "Set bash timeout to 300s"
@@ -180,13 +172,11 @@
     src: ../src/debian/ssh-audit_hardening.conf
     dest: /etc/ssh/sshd_config.d/ssh-audit_hardening.conf
   when: not revert
-  notify: restart openssh
 - name: Uninstall openssh hardening rules
   file:
     path: /etc/ssh/sshd_config.d/ssh-audit_hardening.conf
     state: absent
   when: revert
-  notify: restart openssh
 
 - name: Install sudo ansible group rules
   copy:
@@ -365,6 +355,9 @@
     dest: "/etc/systemd/system/{{ item }}.service.d/hardening.conf"
   register: services_to_restart
   with_items: "{{ hardened_services }}"
-  notify:
-    - reload systemd
-    - restart services
+
+- name: Update grub
+  command: update-grub
+
+- name: Final reboot to apply changes
+  reboot:


### PR DESCRIPTION
To ensure all changes are applied reboot at the end of the debian-hardening role.