### PR TITLE
Add playbooks to deploy VM's 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ playbooks/*
 !playbooks/test_*.yaml
 !playbooks/tasks/
 !playbooks/standalone*
+!playbooks/vm_*.yaml
 inventories/*
 !inventories/README.adoc
 !inventories/*example*

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ inventories_private/
 # Ignore Cukinia results
 /*.csv
 /*.xml
+
+# VM folder
+vm_images/*.qcow2

--- a/playbooks/vm_deploy.yaml
+++ b/playbooks/vm_deploy.yaml
@@ -1,0 +1,38 @@
+# Copyright (C) 2023, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+# Ansible playbook that creates and starts a VM.
+
+---
+
+# Fetch and create VM config file
+- hosts: hypervisors
+  name: Create and start guest{{ vm_id }}
+  vars:
+    - image_name: vm
+    - vm_id: 3
+    - cpu_set: 6
+    - xml_template: >-
+        {{ vm_config |
+        default('../templates/vm/votp_vm_standard_config.xml.j2') }}
+    - disk_path: "../vm_images/{{ image_name }}.qcow2"
+# Create and start a VM
+  tasks:
+    - name: Copy the disk on target
+      copy:
+        src: "{{ disk_path }}"
+        dest: /tmp/{{ image_name }}.qcow2
+    - name: Create and start VM
+      cluster_vm:
+        name: guest{{ vm_id }}
+        command: create
+        system_image: /tmp/{{ image_name }}.qcow2
+        xml: >-
+          {{ lookup('template', xml_template,
+          template_vars=dict(
+            title='guest{{ vm_id }}',
+            ovs_port='VM{{ vm_id }}.0',
+            cpuset='{{ cpu_set }}',
+            mac_address='52:54:00:42:ab:0{{ vm_id }}', ),
+          errors='strict') }}
+

--- a/playbooks/vm_remove.yaml
+++ b/playbooks/vm_remove.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2023, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+# Ansible playbook that removes a VM.
+---
+
+- hosts: hypervisors
+  name: Stop and remove guest{{ vm_id }}
+  vars:
+    - vm_id: 1
+  tasks:
+    - name: Remove VM
+      cluster_vm:
+        name: guest{{ vm_id }}
+        command: remove
+

--- a/templates/vm/votp_vm_standard_config.xml.j2
+++ b/templates/vm/votp_vm_standard_config.xml.j2
@@ -1,32 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright (C) 2021, RTE (http://www.rte-france.com) -->
+<!-- Copyright (C) 2023, RTE (http://www.rte-france.com) -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
-
-<!--
-  VM template for test_add_vm.yaml
--->
 
 <domain type="{{ vm_domaine | default('kvm') }}">
     <title>{{ title }}</title>
     <description>
-            VOTP guest without DPDK
+            VOTP guest with RT tweak without DPDK
     </description>
-    <memory unit="MiB">256</memory>
-    <currentMemory unit="MiB">256</currentMemory>
+    <memory unit="KiB">1048576</memory>
+    <currentMemory unit="KiB">1048576</currentMemory>
+    <vcpu placement="static">1</vcpu>
     <os firmware="efi">
-        <type arch="x86_64" machine="pc-q35-3.1">hvm</type>
-        <boot dev="hd" />
-        <bootmenu enable="no" />
-        <bios useserial="yes" rebootTimeout="0" />
-        <smbios mode="emulate" />
+        <type arch="x86_64" machine="pc-q35-5.2">hvm</type>
     </os>
     <features>
-        <acpi />
-        <apic />
-        <vmport state="off" />
+        <acpi/>
+        <apic/>
+        <vmport state="off"/>
     </features>
-    <cpu mode="host-model" check="none">
-        <model fallback="allow" />
+    <cputune>
+        <vcpupin vcpu="0" cpuset="{{ cpuset }}"/>
+        <vcpusched vcpus="0" scheduler="fifo" priority="1" />
+    </cputune>
+    <cpu mode="host-model">
+        <topology sockets="1" dies="1" cores="1" threads="1" />
+        <feature policy="require" name="tsc-deadline" />
     </cpu>
     <clock offset="utc">
         <timer name="rtc" tickpolicy="catchup" />
@@ -60,9 +58,12 @@
         <memballoon model="virtio">
 	    <stats period="5" />
         </memballoon>
-	    <vsock model='virtio'>
+	<vsock model='virtio'>
             <cid auto='yes' />
         </vsock>
         <watchdog model="ib700" action="poweroff" />
     </devices>
+    <resource>
+        <partition>/machine-rt</partition>
+    </resource>
 </domain>

--- a/vm_images/README
+++ b/vm_images/README
@@ -1,0 +1,2 @@
+VM disk images belong in this folder.
+(Expects *.qcow2 files)


### PR DESCRIPTION
This PR adds following files:

Playbooks:

- `vm_deploy.yaml`: a playbook to create and start a VM in cluster. VM image source file must be put in `vm_images/` directory.  The VM is identified by an unique id set by `vm_id` variable. VM image source file must be set using `image_name` variable.

- `vm_remove.yaml`: a playbook to stop and remove a VM in cluster. The VM is identified by an unique id set by `vm_id` variable.

Configuration templates: 

- `votp_vm_standard_config.xml.j2`: a standard configuration based on `votp_vm_rt_isolated.xml.j2` but using 1Gb of RAM.