### PR TITLE
roles/debian/hypervisor: enable SR-IOV for IGB

### DIFF
--- a/roles/debian/hypervisor/tasks/main.yml
+++ b/roles/debian/hypervisor/tasks/main.yml
@@ -81,6 +81,7 @@
     - "isolcpus=nohz,domain,managed_irq,{{ cpumachinesrt }}"
     - skew_tick=1
     - tsc=reliable
+    - igb.max_vfs=5
 - name: "grub conf osprober"
   lineinfile:
     dest: /etc/default/grub


### PR DESCRIPTION
Create 5 virtual NIC using SR-IOV on Intel NIC which use the IGB driver.