### PR TITLE
Anssi bp 028 r73

### DIFF
--- a/playbooks/test_deploy_cukinia_tests.yaml
+++ b/playbooks/test_deploy_cukinia_tests.yaml
@@ -18,8 +18,8 @@
         mode: 0755
     - name: Copy Cukinia's includes
       copy:
-        src: ../src/cukinia-tests/includes/kernel_config_functions
-        dest: /usr/share/cukinia/includes/kernel_config_functions
+        src: ../src/cukinia-tests/includes/
+        dest: /usr/share/cukinia/includes/
     - name: Create /usr/share/testdata
       file:
         path: /usr/share/testdata

--- a/roles/debian-hardening/tasks/main.yml
+++ b/roles/debian-hardening/tasks/main.yml
@@ -403,6 +403,16 @@
     path: /etc/grub.d/01_password
   when: revert
 
+- name: copy syslog.conf
+  copy:
+    src: ../src/debian/syslog.conf
+    dest: /etc/audit/plugins.d/syslog.conf
+
+- name: copy audit.rules
+  copy:
+    src: ../src/debian/audit.rules
+    dest: /etc/audit/rules.d/audit.rules
+
 - name: Update grub
   command: update-grub
 

--- a/roles/debian-hardening/tasks/main.yml
+++ b/roles/debian-hardening/tasks/main.yml
@@ -405,12 +405,12 @@
 
 - name: copy syslog.conf
   copy:
-    src: ../src/debian/syslog.conf
+    src: ../src/debian/auditd/syslog.conf
     dest: /etc/audit/plugins.d/syslog.conf
 
 - name: copy audit.rules
   copy:
-    src: ../src/debian/audit.rules
+    src: ../src/debian/auditd/audit.rules
     dest: /etc/audit/rules.d/audit.rules
 
 - name: Update grub

--- a/src/debian/auditd/audit.rules
+++ b/src/debian/auditd/audit.rules
@@ -1,0 +1,38 @@
+# Based on recommandation of ANSSI BP-28
+
+# Exécution de insmod , rmmod et modprobe
+-w /sbin/insmod -p x
+-w /sbin/modprobe -p x
+-w /sbin/rmmod -p x
+
+# Sur les distributions GNU/Linux récentes , insmod , rmmod et modprobe sont
+# des liens symboliques de kmod
+-w /bin/kmod -p x
+
+# Journaliser les modifications dans /etc/
+-w /etc/ -p wa
+
+# Surveillance de montage/démontage
+-a exit,always -S mount -S umount2 -k audit_mount
+
+# Appels de syscalls x86 suspects
+-a exit,always -F arch=b64 -S ioperm -S modify_ldt -k audit_syscall
+
+# Appels de syscalls qui doivent être rares et surveillés de près
+-a exit,always -F arch=b64 -S get_kernel_syms -S ptrace -k audit_syscall
+-a exit,always -F arch=b64 -S prctl -k audit_syscall
+
+# Rajout du monitoring pour la création ou suppression de fichiers
+# Ces règles peuvent avoir des conséquences importantes sur les
+# performances du système
+-a exit,always -F arch=b64 -S unlink -S rmdir -S rename
+-a exit,always -F arch=b64 -S creat -S open -S openat -F exit=-EACCES
+-a exit,always -F arch=b64 -S truncate -S ftruncate -F exit=-EACCES
+
+# Rajout du monitoring pour le chargement , le changement et
+# le déchargement de module noyau
+-a exit,always -F arch=b64 -S init_module -S delete_module
+-a exit,always -F arch=b64 -S finit_module
+
+# Verrouillage de la configuration de auditd
+-e 2

--- a/src/debian/auditd/syslog.conf
+++ b/src/debian/auditd/syslog.conf
@@ -1,0 +1,6 @@
+active = yes
+direction = out
+path = /sbin/audisp-syslog
+type = always
+format = string
+args = LOG_INFO


### PR DESCRIPTION
This PR adds a playbook  `playbooks/cluster_setup_auditd.yaml` to properly configure auditd on target:

- Redirect all auditd output to syslog
- Configure auditd rules
- Python scripts to generate syscall needed by Cukinia to test auditd rules