### PR TITLE
Standalone mode: allow the playbooks to deploy a single node

### DIFF
--- a/inventories/seapath_standalone_definition_example.yml
+++ b/inventories/seapath_standalone_definition_example.yml
@@ -1,0 +1,32 @@
+---
+all:
+    children:
+        standalone_machine:
+                hosts:
+                    machine1:
+                        ansible_host: 10.0.0.2
+                        main_disk: /dev/sda
+                        network_interface: enp1s0
+                        ip_addr: "{{ ansible_host }}"
+                        subnet: 24
+    vars:
+        ansible_user: ansible
+        ansible_python_interpreter: /usr/bin/python3
+        ansible_connection: ssh
+        ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
+        dns_server: 10.10.2.1   # Not valid, just for Ansible
+        gateway_addr: 10.0.0.1 # Not valid, just for Ansible
+        apply_network_config: true
+        ntp_primary_server: "ntp.midway.ovh"
+        ntp_secondary_server: "ntp.unice.fr"
+        ansible_remote_tmp: /tmp/.ansible/tmp
+        syslog_server_ip: "10.0.0.10"
+        logstash_server_ip: "10.0.0.11"
+        workqueuemask: "1001"
+        irqmask: "ffeffe"
+        cpusystem: "0,16"
+        cpuuser: "1,17"
+        cpumachines: "2-15,18-31"
+        cpumachinesrt: "2-5,18-21"
+        cpumachinesnort: "6-15,22-31"
+        cpuovs: "23"

--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -50,14 +50,18 @@
 
 - name: Configure Network
   become: true
-  hosts: cluster_machines
+  hosts:
+    - cluster_machines
+    - standalone_machine
   vars_files:
     - ../vars/network_vars.yml
   roles:
     - systemd_networkd
 
 - name: Network configuration
-  hosts: cluster_machines
+  hosts:
+    - cluster_machines
+    - standalone_machine
   become: true
   vars:
     apply_config: "{{ apply_network_config | default(false) }}"
@@ -95,8 +99,29 @@
         state: absent
         regexp: '^127.*debian'
 
+- name: Configure hosts and hostname
+  hosts: standalone_machine
+  become: true
+  tasks:
+    - name: Set hostname
+      hostname:
+        name: "{{ inventory_hostname }}"
+        use: systemd
+    - name: Build hosts file
+      lineinfile:
+        dest: /etc/hosts
+        line: "{{ ip_addr }} {{ inventory_hostname }}"
+        state: present
+    - name: remove 'debian' from hosts file
+      lineinfile:
+        dest: /etc/hosts
+        state: absent
+        regexp: '^127.*debian'
+
 - name: Configure TimeMaster
-  hosts: cluster_machines
+  hosts:
+    - cluster_machines
+    - standalone_machine
   become: true
   tasks:
     - name: Populate service facts
@@ -149,7 +174,9 @@
       when: timemasterconf1.changed or timemasterconf2.changed
 
 - name: Configure syslog-ng
-  hosts: cluster_machines
+  hosts:
+    - cluster_machines
+    - standalone_machine
   become: true
   tasks:
     - name: Set observer IP address in /etc/syslog-ng/syslog-ng.conf
@@ -173,7 +200,9 @@
         apply_config
 
 - name: Configure systemd-networkd-wait-online.service
-  hosts: hypervisors
+  hosts:
+    - cluster_machines
+    - standalone_machine
   become: true
   tasks:
     - name: Create systemd-networkd-wait-online.service.d directory
@@ -193,7 +222,9 @@
         enabled: yes
 
 - name: Restart machine if needed
-  hosts: cluster_machines
+  hosts:
+    - cluster_machines
+    - standalone_machine
   become: true
   tasks:
     - block:

--- a/playbooks/cluster_setup_prerequisdebian.yaml
+++ b/playbooks/cluster_setup_prerequisdebian.yaml
@@ -1,10 +1,14 @@
 - name: Prerequis machine debian
-  hosts: cluster_machines
+  hosts:
+    - cluster_machines
+    - standalone_machine
   become: true
   roles:
-      - debian
+    - debian
 - name: Prerequis hypervisor debian
-  hosts: hypervisors
+  hosts:
+    - hypervisors
+    - standalone_machine
   become: true
   roles:
-      - debian/hypervisor
+    - debian/hypervisor

--- a/vars/network_vars.yml
+++ b/vars/network_vars.yml
@@ -1,6 +1,7 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
 # SPDX-License-Identifier: Apache-2.0
 ---
+
 systemd_networkd_network_custom: "{{ custom_network | default([]) }}"
 systemd_networkd_netdev_custom: "{{ custom_netdev | default([]) }}"
 
@@ -21,21 +22,26 @@ wired_systemd_networkd_network:
     - Match:
         - Name: "{{ network_interface }}"
     - Network: "{{ [ {'Bridge': 'br0'} ] + extra_network_config | default([]) }}"
+
+systemd_networkd_netdev_nocluster: "{{ wired_systemd_networkd_netdev | combine(systemd_networkd_netdev_custom) }}"
+systemd_networkd_network_nocluster: "{{ wired_systemd_networkd_network | combine(systemd_networkd_network_custom) }}"
+
+team0_systemd_networkd_network:
   00-team0:
     - Match:
         - Name: "team0"
     - Network:
-        - Address: "{{ cluster_ip_addr }}/{{ subnet | default(24) }}"
+        - Address: "{{ cluster_ip_addr|default('0') }}/{{ subnet | default(24) }}"
   00-team0_0:
     - Match:
-        - Name: "{{ team0_0 }}"
+        - Name: "{{ team0_0|default('0') }}"
     - Link:
         - MTUBytes: 1800
   00-team0_1:
     - Match:
-        - Name: "{{ team0_1 }}"
+        - Name: "{{ team0_1|default('0') }}"
     - Link:
         - MTUBytes: 1800
 
-systemd_networkd_netdev: "{{ wired_systemd_networkd_netdev | combine(systemd_networkd_netdev_custom) }}"
-systemd_networkd_network: "{{ wired_systemd_networkd_network | combine(systemd_networkd_network_custom) }}"
+systemd_networkd_network: "{% if cluster_ip_addr is defined %}{{ systemd_networkd_network_nocluster|combine(team0_systemd_networkd_network) }}{% else %}{{ systemd_networkd_network_nocluster}}{% endif %}"
+systemd_networkd_netdev: "{{ systemd_networkd_netdev_nocluster }}"


### PR DESCRIPTION
This commit allow a standalone node to be deployed with both playbooks cluster_setup_prerequisdebian.yaml and cluster_setup_network.yaml The inventory needs to be different, and define a "standalone_machine" object instead of a "cluster_machines" object.