### PR TITLE
Standalone mode: missing bits

### DIFF
--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -23,7 +23,9 @@
       command: "/usr/bin/ovs-vsctl -- --if-exists del-port {{ team0_1 }} -- add-port team0 {{ team0_1 }}"
 
 - name: Configure OVS
-  hosts: cluster_machines
+  hosts:
+    - cluster_machines
+    - standalone_machine
   become: true
   vars:
     apply_config: "{{ apply_network_config | default(false) }}"

--- a/templates/ovs_configuration.json.j2
+++ b/templates/ovs_configuration.json.j2
@@ -1,2 +1,2 @@
-{% set OVS_configuration = ({ "bridges": ovs_bridges, "ignored_bridges": ignored_bridges, "unbind_pci_address": unbind_pci_address | default([]) }) %}
+{% set OVS_configuration = ({ "bridges": ovs_bridges, "ignored_bridges": ignored_bridges | default([]), "unbind_pci_address": unbind_pci_address | default([]) }) %}
 {{ OVS_configuration | to_nice_json }}


### PR DESCRIPTION
Standalone mode needs OVS configuration
However standalone mode does not have team0 (cluster network) and so does not need the ignored_bridges object.