### PR TITLE
[debian] timemaster: add dependency on networking

### DIFF
--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -161,6 +161,18 @@
         regexp: '^(pool .*)'
         replace: '#\1'
       register: timemasterconf2
+    - name: Create timemaster.service.d directory
+      file:
+        path: /etc/systemd/system/timemaster.service.d/
+        state: directory
+        owner: root
+        group: root
+        mode: 0755
+    - name: Copy timemaster.service overide
+      template:
+        src: ../templates/timemaster.service.j2
+        dest: /etc/systemd/system/timemaster.service.d/override.conf
+      register: timemasterconf3
     - name: start and enable timemaster
       service:
         name: "timemaster"
@@ -171,7 +183,7 @@
         name: "timemaster"
         state: restarted
         enabled: true
-      when: timemasterconf1.changed or timemasterconf2.changed
+      when: timemasterconf1.changed or timemasterconf2.changed or timemasterconf3.changed
 
 - name: Configure syslog-ng
   hosts:

--- a/templates/timemaster.conf.j2
+++ b/templates/timemaster.conf.j2
@@ -22,7 +22,7 @@ include /etc/chrony/chrony.conf
 {% if ptp_interface is defined %}
 server {{ ntp_primary_server }} iburst maxsamples 10
 {% else %}
-server {{ ntp_primary_server }} iburst maxsamples 10 prefer
+server {{ ntp_primary_server }} iburst maxsamples 10 prefer trust
 {% endif %}
 server {{ ntp_secondary_server }} iburst maxsamples 10
 

--- a/templates/timemaster.service.j2
+++ b/templates/timemaster.service.j2
@@ -1,0 +1,3 @@
+[Unit]
+After=network-online.target
+Wants=network-online.target


### PR DESCRIPTION
Timemaster may start too soon, before networking is ready, in which case the synchronization never starts. This commit fixes that.