### PR TITLE
[debian] ptp: allow for optional vlan ID

### DIFF
--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -11,7 +11,8 @@ all:
                             main_disk: /dev/sda # disk for system
                             ip_addr: "{{ ansible_host }}"
                             subnet: 25 #default is 24, override if necessary
-                            ptp_interface: "eno12419"
+                            ptp_interface: "eno12419" #OPTIONAL PTP Interface
+                            ptp_vlanid: 100 #OPTIONAL VlanID for PTP
                             team0_0: "eno12399" # cluster network first interface
                             team0_1: "eno12409" # cluster network second interface
                             cluster_next_ip_addr : "192.168.55.2" #node 2 cluster network ip
@@ -25,7 +26,8 @@ all:
                             main_disk: /dev/sda
                             ip_addr: "{{ ansible_host }}"
                             subnet: 25
-                            ptp_interface: "eno12419"
+                            ptp_interface: "eno12419" #OPTIONAL PTP Interface
+                            ptp_vlanid: 100 #OPTIONAL VlanID for PTP
                             team0_0: "eno12399"
                             team0_1: "eno12409"
                             cluster_next_ip_addr : "192.168.55.3" #node 3 cluster network ip
@@ -39,7 +41,8 @@ all:
                             main_disk: /dev/sda
                             ip_addr: "{{ ansible_host }}"
                             subnet: 25
-                            ptp_interface: "eno12419"
+                            ptp_interface: "eno12419" #OPTIONAL PTP Interface
+                            ptp_vlanid: 100 #OPTIONAL VlanID for PTP
                             team0_0: "eno12399"
                             team0_1: "eno12409"
                             cluster_next_ip_addr : "192.168.55.1" #ip de hyperviseur 1

--- a/inventories/seapath_standalone_definition_example.yml
+++ b/inventories/seapath_standalone_definition_example.yml
@@ -2,13 +2,15 @@
 all:
     children:
         standalone_machine:
-                hosts:
-                    machine1:
-                        ansible_host: 10.0.0.2
-                        main_disk: /dev/sda
-                        network_interface: enp1s0
-                        ip_addr: "{{ ansible_host }}"
-                        subnet: 24
+            hosts:
+                machine1:
+                    ansible_host: 10.0.0.2
+                    main_disk: /dev/sda
+                    network_interface: enp1s0
+                    ip_addr: "{{ ansible_host }}"
+                    subnet: 24
+                    ptp_interface: "enp1s0f1" #OPTIONAL PTP Interface
+                    ptp_vlanid: 100 #OPTIONAL VlanID for PTP
     vars:
         ansible_user: ansible
         ansible_python_interpreter: /usr/bin/python3

--- a/playbooks/test_run_latency_tests.yaml
+++ b/playbooks/test_run_latency_tests.yaml
@@ -9,6 +9,7 @@
 # First, starting hypervisor subscriber
 - hosts: hypervisors
   name: Hypervisor subscriber tests
+  become: true
   vars:
     - svtools_archive_commit_id: 0c7b539
     - poll_timeout: 5
@@ -31,6 +32,7 @@
 # Then starting standalone publisher
 - hosts: standalone
   name: Publisher tests
+  become: true
   vars:
     - trafgen_archive_commit_id: a8936ce
     - poll_timeout: 10
@@ -62,6 +64,7 @@
 # Wait and stop subscriber on hypervisor and getting result
 - hosts: hypervisors
   name: Stop subscriber on hypervisor and getting result
+  become: true
   tasks:
   - name: Stop subscriber hypervisor tests
     command:
@@ -82,6 +85,7 @@
 # Next, we do the same but with with VM as subscriber
 - hosts: guest1
   name: VM subscriber tests
+  become: true
   vars:
     - svtools_archive_commit_id: 0c7b539
     - poll_timeout: 5
@@ -104,6 +108,7 @@
 # Then starting standalone publisher
 - hosts: standalone
   name: Publisher tests
+  become: true
   vars:
     - trafgen_archive_commit_id: a8936ce
     - poll_timeout: 10
@@ -134,6 +139,7 @@
 
 # Stop subscriber on hypervisor and getting result
 - hosts: guest1
+  become: true
   tasks:
   - name: Stop subscriber guest1 tests
     command:

--- a/templates/timemaster.conf.j2
+++ b/templates/timemaster.conf.j2
@@ -3,7 +3,11 @@
 {% if ptp_interface is defined %}
 [ptp_domain 0]
 ntp_options poll 0
+{% if ptp_vlanid is defined %}
+interfaces {{ ptp_interface + '.' + ptp_vlanid|string }}
+{% else %}
 interfaces {{ ptp_interface }}
+{% endif %}
 delay 1e-9
 # delay:
 # This option sets the NTP delay of the source (in seconds). Half of this value


### PR DESCRIPTION
PTP often uses VLAN 100. This commit allows the user to specify a VLAN id as an optional inventory variable.