### PR TITLE
cukinia_tests: use template for apt.conf

### DIFF
--- a/playbooks/test_deploy_cukinia_tests.yaml
+++ b/playbooks/test_deploy_cukinia_tests.yaml
@@ -9,6 +9,12 @@
       copy:
         src: ../src/cukinia-tests/cukinia
         dest: /etc/
+    - name: Copy Cukinia's tests templates
+      template:
+        src: ../src/cukinia-tests/cukinia/{{ item.src }}
+        dest: /etc/cukinia/{{ item.dest }}
+      with_items:
+          - { src: 'common_security_tests.d/apt.conf', dest: 'common_security_tests.d/apt.conf' }
     - name: Create /usr/share/cukinia/includes
       file:
         path: /usr/share/cukinia/includes


### PR DESCRIPTION
sources.list can now be configured to use an apt proxy instead of official repositories.

SFL: #9314
Change-Id: Ibc5ef5f90cce78d27f35d515611ee9c6dc3fcf9f