### PR TITLE
make libvirt use the machine-id way of determining host UUID

### DIFF
--- a/playbooks/cluster_setup_prerequisdebian.yaml
+++ b/playbooks/cluster_setup_prerequisdebian.yaml
@@ -12,3 +12,14 @@
   become: true
   roles:
     - debian/hypervisor
+
+- name: Disable libvirt-guests.service
+  hosts:
+    - cluster_machines
+  become: true
+  tasks:
+    - name: disable libvirt-guests.service
+      ansible.builtin.systemd:
+        name: libvirt-guests.service
+        enabled: no
+        state: stopped

--- a/roles/debian/tasks/main.yml
+++ b/roles/debian/tasks/main.yml
@@ -377,3 +377,14 @@
         src: sources.list.j2
         dest: /etc/apt/sources.list
   when: apt_repo is defined
+
+- name: Make libvirt use the "machine-id" way to determine host UUID
+  lineinfile:
+    dest: /etc/libvirt/libvirtd.conf
+    regexp: "^#?host_uuid_source ="
+    line: "host_uuid_source = \"machine-id\""
+    state: present
+- name: restart libvirtd
+  ansible.builtin.systemd:
+    name: libvirtd.service
+    state: restarted


### PR DESCRIPTION
Host UUID is read from one of the sources specified in host_uuid_source.
- 'smbios': fetch the UUID from 'dmidecode -s system-uuid'
- 'machine-id': fetch the UUID from /etc/machine-id

By default, smbios is used. We found that it did not give unique results for some hardware vendors (Moxa, Advantech)
machine-id works better to have unique UUID for hosts.