### PR TITLE
roles/debian-hardening: disable ipv6 for all machines

### DIFF
--- a/roles/debian-hardening/vars/main.yml
+++ b/roles/debian-hardening/vars/main.yml
@@ -15,6 +15,7 @@ kernel_params:
  - mce=0
  - rng_core.default_quality=500
  - lsm=apparmor,lockdown,capability,landlock,yama,bpf
+ - ipv6.disable=1
 
 hardened_services:
   - ovs-vswitchd

--- a/roles/debian/hypervisor/tasks/main.yml
+++ b/roles/debian/hypervisor/tasks/main.yml
@@ -98,7 +98,6 @@
     backrefs: yes
   register: updategrub1
   with_items:
-    - ipv6.disable=1
     - efi=runtime
     - processor.max_cstate=1
     - intel_idle.max_cstate=1


### PR DESCRIPTION
Previously, ipv6 was disable in a hypervisor file. The observer still had ipv6 enabled.