### PR TITLE
[debian] Disable IPV6 for all machines (not just hypervisors)

### DIFF
--- a/roles/debian/hypervisor/tasks/main.yml
+++ b/roles/debian/hypervisor/tasks/main.yml
@@ -89,7 +89,7 @@
     state: restarted
   when: sysfscpumask.changed or sriov_sysfs.changed
 
-- name: "grub conf"
+- name: "grub conf hypervisor"
   lineinfile:
     dest: /etc/default/grub
     regexp: "^(GRUB_CMDLINE_LINUX=(?!.* {{ item }})\"[^\"]*)(\".*)"
@@ -98,8 +98,6 @@
     backrefs: yes
   register: updategrub1
   with_items:
-    - ipv6.disable=1
-    - efi=runtime
     - processor.max_cstate=1
     - intel_idle.max_cstate=1
     - cpufreq.default_governor=performance
@@ -114,16 +112,9 @@
     - skew_tick=1
     - tsc=reliable
 
-- name: "grub conf osprober"
-  lineinfile:
-    dest: /etc/default/grub
-    regexp: '^GRUB_DISABLE_OS_PROBER=.*$'
-    line: 'GRUB_DISABLE_OS_PROBER=true'
-    state: present
-  register: updategrub2
 - name: update-grub
   command: update-grub
-  when: updategrub1.changed or updategrub2.changed
+  when: updategrub1.changed
 
 - name: "irqbalance conf"
   lineinfile:

--- a/roles/debian/tasks/main.yml
+++ b/roles/debian/tasks/main.yml
@@ -388,3 +388,31 @@
   ansible.builtin.systemd:
     name: libvirtd.service
     state: restarted
+
+- name: "remove /etc/default/grub.d/20_efi_ipv6.cfg (FAI)"
+  file:
+    path: /etc/default/grub.d/20_efi_ipv6.cfg
+    state: absent
+
+- name: "grub conf"
+  lineinfile:
+    dest: /etc/default/grub
+    regexp: "^(GRUB_CMDLINE_LINUX=(?!.* {{ item }})\"[^\"]*)(\".*)"
+    line: '\1 {{ item }}\2'
+    state: present
+    backrefs: yes
+  register: updategrub1
+  with_items:
+    - ipv6.disable=1
+    - efi=runtime
+
+- name: "grub conf osprober"
+  lineinfile:
+    dest: /etc/default/grub
+    regexp: '^GRUB_DISABLE_OS_PROBER=.*$'
+    line: 'GRUB_DISABLE_OS_PROBER=true'
+    state: present
+  register: updategrub2
+- name: update-grub
+  command: update-grub
+  when: updategrub1.changed or updategrub2.changed


### PR DESCRIPTION
Previously, ipv6 was disabled in the hypervisor playbook. The observer still had ipv6 enabled. This commit makes the ipv6 disabling happen in the debian (all nodes) playbook.