### PR TITLE
[debian] Move custom scripts from /usr/bin to /usr/local/bin

### DIFF
--- a/roles/debian/tasks/main.yml
+++ b/roles/debian/tasks/main.yml
@@ -48,7 +48,7 @@
 - name: Synchronization of backup-restore folder on the control machine to dest on the remote hosts
   ansible.posix.synchronize:
     src: ../src/debian/backup-restore/
-    dest: /usr/bin/
+    dest: /usr/local/bin/
     rsync_opts:
       - "--chown=root:root"
 

--- a/src/debian/backup-restore/backup-restore.sh
+++ b/src/debian/backup-restore/backup-restore.sh
@@ -100,7 +100,7 @@ function restoreVMChooseIncDate {
   #incdate=${arrVar[$d]}
   d=$(($c-1))
   incdate=${listIncDateRaw[$d]}
-  /usr/bin/restore_vm.sh $local_tmp_dir $remote_serv:$remote_dir $fulldate $vm $incdate
+  /usr/local/bin/restore_vm.sh $local_tmp_dir $remote_serv:$remote_dir $fulldate $vm $incdate
 }
 function writeVar {
   key=$1
@@ -117,13 +117,13 @@ function backupFull {
   getVars
   [ -z "$remote_dir" ] && { whiptail --msgbox "var remote_dir empty" 10 50; return; }
   [ -z "$remote_serv" ] && { whiptail --msgbox "var remote_serv empty" 10 50; return; }
-  /usr/bin/backup_full.sh $local_dir $remote_serv":"$remote_dir
+  /usr/local/bin/backup_full.sh $local_dir $remote_serv":"$remote_dir
 }
 function backupInc {
   getVars
   [ -z "$remote_dir" ] && { whiptail --msgbox "var remote_dir empty" 10 50; return; }
   [ -z "$remote_serv" ] && { whiptail --msgbox "var remote_serv empty" 10 50; return; }
-  /usr/bin/backup_inc.sh $local_dir $remote_serv":"$remote_dir
+  /usr/local/bin/backup_inc.sh $local_dir $remote_serv":"$remote_dir
 }
 function getValueForVar {
    var=$1

--- a/src/debian/backup-restore/edit_metadata.sh
+++ b/src/debian/backup-restore/edit_metadata.sh
@@ -30,7 +30,7 @@ function editGuest {
   do
     arrVar0=()
     arrVar=()
-    for i in `python3 /usr/bin/get_metadata.py $guest`
+    for i in `python3 /usr/local/bin/get_metadata.py $guest`
     do
       arrVar0+=("$i")
     done

--- a/src/debian/backup-restore/restore_vm.sh
+++ b/src/debian/backup-restore/restore_vm.sh
@@ -40,8 +40,8 @@ echo rsync -ave ssh --progress $remote_dir$fulldatedir/*$guest* $local_tmp_dir/
 rsync -ave ssh --progress $remote_dir$fulldatedir/*$guest* $local_tmp_dir/
 echo
 echo creating vm xml with no disk
-echo python3 /usr/bin/remove_disk_xml.py $local_tmp_dir/system_"$guest"-"$incdate".xml $local_tmp_dir/system_"$guest"-"$incdate"-nodisk.xml
-python3 /usr/bin/remove_disk_xml.py $local_tmp_dir/system_"$guest"-"$incdate".xml $local_tmp_dir/system_"$guest"-"$incdate"-nodisk.xml
+echo python3 /usr/local/bin/remove_disk_xml.py $local_tmp_dir/system_"$guest"-"$incdate".xml $local_tmp_dir/system_"$guest"-"$incdate"-nodisk.xml
+python3 /usr/local/bin/remove_disk_xml.py $local_tmp_dir/system_"$guest"-"$incdate".xml $local_tmp_dir/system_"$guest"-"$incdate"-nodisk.xml
 echo
 echo creating base vm
 echo vm-mgr create -n $guest --force --disable --enable-live-migration --migration-user virtu --xml $local_tmp_dir/system_"$guest"-"$incdate"-nodisk.xml -i $local_tmp_dir/system_"$guest"_"$fulldate".qcow2


### PR DESCRIPTION
Since these scripts are not part of the debian distribution, they should be stored in /usr/local