### PR TITLE
[debian] Introducing ip address for administration

### DIFF
--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -10,6 +10,7 @@ all:
                             network_interface: eno8303 #main interface
                             main_disk: /dev/sda # disk for system
                             ip_addr: "{{ ansible_host }}"
+                            admin_ip_addr: 10.10.11.1 #used for snmp
                             subnet: 25 #default is 24, override if necessary
                             ptp_interface: "eno12419" #OPTIONAL PTP Interface
                             ptp_vlanid: 100 #OPTIONAL VlanID for PTP
@@ -25,6 +26,7 @@ all:
                             network_interface: eno8303
                             main_disk: /dev/sda
                             ip_addr: "{{ ansible_host }}"
+                            admin_ip_addr: 10.10.11.2 #used for snmp
                             subnet: 25
                             ptp_interface: "eno12419" #OPTIONAL PTP Interface
                             ptp_vlanid: 100 #OPTIONAL VlanID for PTP
@@ -40,6 +42,7 @@ all:
                             network_interface: eno8303
                             main_disk: /dev/sda
                             ip_addr: "{{ ansible_host }}"
+                            admin_ip_addr: 10.10.11.3 #used for snmp
                             subnet: 25
                             ptp_interface: "eno12419" #OPTIONAL PTP Interface
                             ptp_vlanid: 100 #OPTIONAL VlanID for PTP

--- a/src/debian/snmpd.conf.j2
+++ b/src/debian/snmpd.conf.j2
@@ -21,4 +21,4 @@ extend dommemstat /usr/bin/timeout 1s /bin/bash /usr/local/bin/snmp_dommemstat.s
 extend diskusage /usr/bin/timeout 40s /usr/bin/sudo /usr/local/bin/snmp_diskusage.sh
 extend cephstatus /usr/bin/timeout 2s /usr/bin/sudo -u ceph /usr/local/bin/snmp_cephstatus.sh
 extend cephusage /usr/bin/timeout 2s /usr/bin/sudo -u ceph /usr/local/bin/snmp_cephusage.sh
-agentAddress udp:{{ ip_addr }}:161
+agentAddress udp:{{ admin_ip_addr }}:161


### PR DESCRIPTION
Currently br0 is created for "remote access" to the hosts, with the "ansible_host" ip address. Users may need to have snmpd (or other services) listen to a different ip address.
This commit introduces "admin_ip_address", a variable for the ip address used for administrative services (right now only snmpd).