### PR TITLE
Increase shutdown timeout to 12s

### DIFF
--- a/src/debian/VirtualDomain
+++ b/src/debian/VirtualDomain
@@ -765,7 +765,7 @@ VirtualDomain_stop() {
 
 			# The "shutdown_timeout" we use here is the operation
 			# timeout specified in the CIB, minus 5 seconds
-			shutdown_timeout=$(( $NOW + ($OCF_RESKEY_CRM_meta_timeout/1000) -5 ))
+			shutdown_timeout=$(( $NOW + ($OCF_RESKEY_CRM_meta_timeout/1000) -12 ))
 			# Loop on status until we reach $shutdown_timeout
 			while [ $NOW -lt $shutdown_timeout ]; do
 				VirtualDomain_status


### PR DESCRIPTION
When force stopping a guest, Pacemaker only gives 5s to libvirt to destroy the VM.
Libvirt gives itself 10s before the original SIGTERM and the final SIGKILL, so a guest can take up to 11-12 seconds to be destroyed. This commit make the VirtualDomain Resource agent give 12s to libvirt.