### PR TITLE
.github/workflows: add label for RTE runner

### DIFF
--- a/.github/workflows/ci-debian.yml
+++ b/.github/workflows/ci-debian.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   CI:
-    runs-on: self-hosted
+    runs-on: [self-hosted, runner-RTE]
     steps:
 
       - name: Initialize sources


### PR DESCRIPTION
A new runner for the yocto version of SEAPATH will soon be added. A tag will be used to differentiate the two runner.

This commit add the tag "runner-RTE" to the workflow for the debian CI.