### PR TITLE
Create a standalone Yocto CI

### DIFF
--- a/playbooks/ci_reboot_on_usb_drive.yaml
+++ b/playbooks/ci_reboot_on_usb_drive.yaml
@@ -1,0 +1,15 @@
+# Copyright (C) 2023 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Configure next reboot to boot on USB drive
+  hosts:
+    - cluster_machines
+    - standalone_machine
+  gather_facts: false
+  tasks:
+    - name: Configure the EFI to boot on USB drive
+      script: "../scripts/configure_boot_next_usb_drive.sh"
+      register: result
+      changed_when: result.rc == 0
+      failed_when: result.rc == 1 or result.rc > 2

--- a/playbooks/ci_standalone_setup.yaml
+++ b/playbooks/ci_standalone_setup.yaml
@@ -1,0 +1,15 @@
+# Copyright (C) 2023 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+
+- import_playbook: ci_reboot_on_usb_drive.yaml
+
+- name: Reflash the machine
+  hosts: standalone_machine
+  gather_facts: false
+  tasks:
+    - name: Reboot the system
+      reboot:
+
+- import_playbook: cluster_setup_configure_hosts.yaml

--- a/playbooks/cluster_setup_configure_hosts.yaml
+++ b/playbooks/cluster_setup_configure_hosts.yaml
@@ -1,11 +1,14 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
+# Copyright (C) 2023 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 # This Ansible playbook configure cluster machines.
 ---
 - import_playbook: cluster_setup_kernel_params.yaml
 - import_playbook: cluster_setup_configure_hugepages.yaml
 - name: remove the static ip previously setup
-  hosts: cluster_machines
+  hosts:
+    - cluster_machines
+    - standalone_machine
   tasks:
       - name: Remove file /etc/systemd/network/000-static_ip.network
         file:

--- a/playbooks/cluster_setup_kernel_params.yaml
+++ b/playbooks/cluster_setup_kernel_params.yaml
@@ -1,4 +1,5 @@
 # Copyright (C) 2020, RTE (http://www.rte-france.com)
+# Copyright (C) 2023 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # This Ansible playbook configures the kernel paremeters.
@@ -6,7 +7,9 @@
 
 ---
 - name: Configure Kernel parameters
-  hosts: cluster_machines
+  hosts:
+    - cluster_machines
+    - standalone_machine
   vars:
     config_file: "{{ bootloader_config_file |
       default('/boot/EFI/BOOT/grub.cfg') }}"

--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -1,4 +1,5 @@
 # Copyright (C) 2020, RTE (http://www.rte-france.com)
+# Copyright (C) 2023 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # This Ansible playbook configures the networks and defines the hostnames. It
@@ -25,7 +26,9 @@
       command: "/usr/bin/ovs-vsctl -- --if-exists del-port {{ team0_1 }} -- add-port team0 {{ team0_1 }}"
 
 - name: Configure OVS
-  hosts: cluster_machines
+  hosts:
+    - cluster_machines
+    - standalone_machine
   vars:
     apply_config: "{{ apply_network_config | default(false) }}"
   tasks:
@@ -50,7 +53,9 @@
         - ovs_conf.changed
 
 - name: Configure Network
-  hosts: cluster_machines
+  hosts:
+    - cluster_machines
+    - standalone_machine
   vars_files:
     - ../vars/network_vars.yml
   roles:
@@ -87,7 +92,9 @@
 
 
 - name: Configure PTP ansible.builtin.service
-  hosts: cluster_machines
+  hosts:
+    - cluster_machines
+    - standalone_machine
   vars:
     apply_config: "{{ apply_network_config | default(false) }}"
   tasks:
@@ -110,13 +117,19 @@
         - ptp_vlan_interface is defined
         - ptp_vlan is defined
 
-- name: Configure hosts and hostname
-  hosts: cluster_machines
+- name: Configure hostname
+  hosts:
+    - cluster_machines
+    - standalone_machine
   tasks:
     - name: Set hostname
       hostname:
         name: "{{ inventory_hostname }}"
         use: systemd
+
+- name: Configure hosts
+  hosts: cluster_machines
+  tasks:
     - name: Build hosts file
       lineinfile:
         dest: /etc/hosts
@@ -133,7 +146,9 @@
       when: cluster_ip_addr is defined
 
 - name: Configure NTP
-  hosts: cluster_machines
+  hosts:
+    - cluster_machines
+    - standalone_machine
   tasks:
     - name: Set NTP configuration in /etc/systemd/timesyncd.conf
       lineinfile:
@@ -161,7 +176,9 @@
         state: restarted
 
 - name: Configure syslog-ng
-  hosts: cluster_machines
+  hosts:
+    - cluster_machines
+    - standalone_machine
   tasks:
     - name: Set observer IP address in /etc/syslog-ng/syslog-ng.conf
       lineinfile:
@@ -201,7 +218,9 @@
       when: cluster_interface is defined
 
 - name: Restart machine if needed
-  hosts: cluster_machines
+  hosts:
+    - cluster_machines
+    - standalone_machine
   tasks:
     - include_tasks: tasks/soft_restart_machine.yaml
       when: need_reboot is defined and need_reboot

--- a/scripts/configure_boot_next_usb_drive.sh
+++ b/scripts/configure_boot_next_usb_drive.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "Please run as root"
+  exit 1
+fi
+
+if [ ! -d /sys/firmware/efi/efivars ]; then
+  echo "Please run on an EFI system"
+  exit 1
+fi
+
+if ! mount |grep -q /sys/firmware/efi/efivars; then
+    mount -t efivarfs efivarfs /sys/firmware/efi/efivars || exit 1
+fi
+
+usb_boot=$(efibootmgr |grep -i USB |cut -d ' ' -f 1  |grep -Eo '[0-9]+')
+if [ -z "${usb_boot}" ]; then
+    echo "No USB boot option found"
+    exit 1
+fi
+
+if efibootmgr |grep -q "BootNext: ${usb_boot}" ; then
+    echo "USB boot option already set"
+    exit 2
+fi
+
+efibootmgr -n "${usb_boot}" || exit 1


### PR DESCRIPTION
This PR adds playbooks and GitHub actions to setup a CI, which tests a standalone hypervisor in the Yocto version.