### PR TITLE
ansible-lint.conf: remove no-tabs exclusion

### DIFF
--- a/ansible-lint.conf
+++ b/ansible-lint.conf
@@ -16,7 +16,6 @@ skip_list:
   - unnamed-task           # All tasks should be named
   - role-name              # All role names should match "^[a-z_][a-z0-9_]*$"
   - risky-file-permissions # All file creation must specify permissions
-  - no-tabs                # Most files should not contain tabs
   - no-handler             # "when: result.changed" should trigger a handler instead
   - no-changed-when        # Commands should not change things if nothing needs doing
   - no-relative-paths      # Doesn't need a relative path in role
@@ -35,9 +34,6 @@ skip_list:
 # - risky-file-permissions concern a global cyber-security question : Specifying
 # permissions on files must be done on the overall SEAPATH project in order to
 # be effective. This is a much bigger task.
-#
-# - no-tabs is raised by a patch task. The concerned tool should soon merge the
-# patch and this will not be required anymore.
 #
 # - no-handler, no-changed-when and no-relative-paths should not be skipped. The
 # raised warnings should be corrected as soon as possible for these three rules to

--- a/playbooks/test_deploy_cukinia.yaml
+++ b/playbooks/test_deploy_cukinia.yaml
@@ -18,5 +18,5 @@
     - name: "Patch cukinia: CAT"
       lineinfile:
        path: /usr/local/bin/cukinia
-       line: "	local CAT=zcat"
+       line: "local CAT=zcat"
        insertafter: 'local line=""'

--- a/roles/debian-hardening/tasks/main.yml
+++ b/roles/debian-hardening/tasks/main.yml
@@ -336,12 +336,12 @@
   lineinfile:
     dest: /etc/pam.d/login
     insertafter: 'auth       optional   pam_faildelay.so  delay=3000000'
-    line: "auth		[success=ok ignore=ignore user_unknown=ignore default=die]  	pam_securetty.so"
+    line: "auth   [success=ok ignore=ignore user_unknown=ignore default=die]    pam_securetty.so"
   when: not revert
 - name: Disable securetty in pam login
   lineinfile:
     dest: /etc/pam.d/login
-    regexp: "^auth		\\[success=ok ignore=ignore user_unknown=ignore default=die\\]  	pam_securetty.so$"
+    regexp: "^auth    \\[success=ok ignore=ignore user_unknown=ignore default=die\\]    pam_securetty.so"
     state: absent
   when: revert
 


### PR DESCRIPTION
The rule "no-tabs" was skipped because a playbook needed to be refactor. This is done now and the rule should not be skipped anymore.