### PR TITLE
Adding the group virtu before the user virtu

### DIFF
--- a/roles/debian/tasks/main.yml
+++ b/roles/debian/tasks/main.yml
@@ -260,6 +260,11 @@
     name: systemd-journald
   when: journaldconf.changed
 
+- name: Create group virtu before the user
+  group :
+    name: virtu
+    state: present
+
 - name: Adding user virtu to groups libvirt and haclient
   user: name=virtu
     group=virtu


### PR DESCRIPTION
When deploying cluster_setup_prerequisdebian.yaml on a fresh Debian install, I had an error at the virtu user creation where the virtu group where missing.