### PR TITLE
workflows: change schedule time to create badges

### DIFF
--- a/.github/workflows/ansible-lint-weekly.yml
+++ b/.github/workflows/ansible-lint-weekly.yml
@@ -11,7 +11,7 @@ env:
 
 on:
   schedule:
-    - cron: 0 11 * * 3
+    - cron: '0 * * * *'
 
 jobs:
   ansible-lint:

--- a/.github/workflows/ci-yocto-weekly.yml
+++ b/.github/workflows/ci-yocto-weekly.yml
@@ -11,7 +11,7 @@ env:
 
 on:
   schedule:
-    - cron: 0 11 * * 3
+    - cron: '0 * * * *'
 
 jobs:
   CI:


### PR DESCRIPTION
The last badges were not created properly. Change the schedule time to re-generate them.