### PR TITLE
workflows: rename weekly badges

### DIFF
--- a/.github/workflows/ansible-lint-weekly.yml
+++ b/.github/workflows/ansible-lint-weekly.yml
@@ -4,7 +4,7 @@
 # This ensure the main branch is always linted properly
 # A badge is derived from this workflow
 
-name: Ansible Lint Weekly
+name: Ansible Lint
 
 env:
   WORK_DIR: /tmp/seapath_ci_${{ github.run_id }}_${{ github.run_attempt }}_${{ github.sha }}

--- a/.github/workflows/ci-yocto-weekly.yml
+++ b/.github/workflows/ci-yocto-weekly.yml
@@ -4,7 +4,7 @@
 # This ensure the main branch is always tested properly.
 # A badge is derived from this workflow.
 
-name: CI Yocto Weekly
+name: CI Yocto
 
 env:
   WORK_DIR: /tmp/seapath_ci_${{ github.run_id }}_${{ github.run_attempt }}_${{ github.sha }}


### PR DESCRIPTION
In order to display all badges the same way on the seapath github main page, the weekly workflows have to be renamed.

A weekly CI for debian should also be created and all workflows correctly named after that.