### PR TITLE
playbooks/cluster_setup_network: update removing FAI network files

### DIFF
--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -70,8 +70,12 @@
   tasks:
     - name: Remove FAI network configuration
       file:
-        path: /etc/systemd/network/00-init.network
+        path: "/etc/systemd/network/{{ item }}.network"
         state: absent
+      with_items:
+        - 01-init.network
+        - 00-init-dhcp
+        - 00-init
     - name: Restart systemd-networkd
       ansible.builtin.systemd:
         name: systemd-networkd


### PR DESCRIPTION
With the changing in build_debian_iso we have to remove 01-init.network and 00-init-dhcp.network.