### PR TITLE
debian prereq: remove all FAI grub defaults

### DIFF
--- a/roles/debian/hypervisor/tasks/main.yml
+++ b/roles/debian/hypervisor/tasks/main.yml
@@ -111,6 +111,7 @@
     - "isolcpus=nohz,domain,managed_irq,{{ cpumachinesrt }}"
     - skew_tick=1
     - tsc=reliable
+    - console=ttyS0,115200
 
 - name: update-grub
   command: update-grub

--- a/roles/debian/tasks/main.yml
+++ b/roles/debian/tasks/main.yml
@@ -388,10 +388,18 @@
     name: libvirtd.service
     state: restarted
 
-- name: "remove /etc/default/grub.d/20_efi_ipv6.cfg (FAI)"
+- name: "find /etc/default/grub.d/*.cfg (FAI)"
+  find:
+    paths: /etc/default/grub.d
+    patterns: '^\d\d.*\.cfg$'
+    use_regex: true
+  register: wildcard_files_to_delete
+
+- name: "remove /etc/default/grub.d/*.cfg (FAI)"
   file:
-    path: /etc/default/grub.d/20_efi_ipv6.cfg
+    path: "{{ item.path }}"
     state: absent
+  with_items: "{{ wildcard_files_to_delete.files }}"
 
 - name: "grub conf"
   lineinfile:
@@ -404,6 +412,7 @@
   with_items:
     - ipv6.disable=1
     - efi=runtime
+    - console=ttyS0,115200
 
 - name: "grub conf osprober"
   lineinfile:


### PR DESCRIPTION
Following https://github.com/seapath/build_debian_iso/pull/57 FAI now has multiple default files for grub
Ansible needs to remove all of them, hence the use of a wildcard pattern (we remove all files in /etc/default/grub.d starting with 2 digits and ending in .cfg)