### PR TITLE
Removing "ansible_become" of inventory

### DIFF
--- a/playbooks/ci_cleanup_syslog.yaml
+++ b/playbooks/ci_cleanup_syslog.yaml
@@ -5,6 +5,7 @@
 ---
 - name: Cleanup syslog-ng files
   hosts: cluster_machines
+  become: true
   tasks:
     - name: Remove /var/log/syslog-ng
       file:

--- a/playbooks/ci_restore_snapshot.yaml
+++ b/playbooks/ci_restore_snapshot.yaml
@@ -5,6 +5,7 @@
 ---
 - name: Rollback to the initiale state
   hosts: cluster_machines
+  become: true
   tasks:
     - name: Merge lvm snapshot
       command:

--- a/playbooks/cluster_setup_hardened_debian.yaml
+++ b/playbooks/cluster_setup_hardened_debian.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 
-- name: Add hardened in SEAPTAH Debian machines
+- name: Add hardened in SEAPATH Debian machines
+  become: true
   hosts: cluster_machines
   vars:
     revert: false

--- a/playbooks/test_deploy_cukinia.yaml
+++ b/playbooks/test_deploy_cukinia.yaml
@@ -4,6 +4,7 @@
 ---
 - name: Install Cukinia
   hosts: cluster_machines
+  become: true
   tasks:
     - name: Copy Cukinia script
       copy:

--- a/playbooks/test_deploy_cukinia_tests.yaml
+++ b/playbooks/test_deploy_cukinia_tests.yaml
@@ -4,6 +4,7 @@
 ---
 - name: Deploy Cukinia's tests
   hosts: cluster_machines
+  become: true
   tasks:
     - name: Copy Cukinia's tests
       synchronize:
@@ -49,6 +50,7 @@
 
 - name: Create /etc/cukinia.conf for observers
   hosts: observers
+  become: true
   tasks:
     - name: Create a symlink cukinia.conf to cukinia-observer.conf
       file:
@@ -58,6 +60,7 @@
 
 - name: Create /etc/cukinia.conf for hypervisors
   hosts: hypervisors
+  become: true
   tasks:
     - name: Create a symlink cukinia.conf to cukinia-hypervisor.conf
       file:

--- a/playbooks/test_run_cukinia.yaml
+++ b/playbooks/test_run_cukinia.yaml
@@ -7,6 +7,7 @@
 ---
 - hosts: cluster_machines
   name: Cukinia tests
+  become: true
   vars:
     tests_format: junitxml
     tests_result_name: "cukinia_{{ inventory_hostname }}.xml"


### PR DESCRIPTION
ansible_become overrides all playbooks, including externally developped (like ceph-ansible).
It's better practice to use "become" on a playbook to playbook basis.