### PR TITLE
Some bugs

### DIFF
--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -73,7 +73,7 @@
         path: "/etc/systemd/network/{{ item }}.network"
         state: absent
       with_items:
-        - 01-init.network
+        - 01-init
         - 00-init-dhcp
         - 00-init
     - name: Restart systemd-networkd
@@ -134,17 +134,24 @@
       - name: configure /etc/systemd/resolved.conf
         lineinfile:
           dest: /etc/systemd/resolved.conf
+          regexp: "^#?LLMNR="
+          line: "LLMNR=no"
+          state: present
+        register: resolved_conf1
+      - name: configure /etc/systemd/resolved.conf
+        lineinfile:
+          dest: /etc/systemd/resolved.conf
           regexp: "^#?DNS="
           line: "DNS={{ dns_servers }}"
           state: present
-        register: resolved_conf
+        register: resolved_conf2
       - name: Create resolv.conf stub link
         ansible.builtin.file:
           src: /run/systemd/resolve/resolv.conf
           dest: /etc/resolv.conf
           state: link
           force: true
-        register: resolv_conf
+        register: resolved_conf3
       - name: Enable systemd-resolved
         ansible.builtin.systemd:
           name: systemd-resolved
@@ -155,7 +162,7 @@
           name: systemd-resolved
           state: restarted
           enabled: true
-        when: resolved_conf.changed or resolv_conf.changed
+        when: resolved_conf1.changed or resolved_conf2.changed or resolved_conf3.changed
       when: dns_servers is defined
 
 - name: Configure TimeMaster

--- a/roles/debian-hardening/tasks/main.yml
+++ b/roles/debian-hardening/tasks/main.yml
@@ -376,7 +376,6 @@
   with_items:
     - apt-daily-upgrade.timer
     - apt-daily.timer
-    - systemd-resolved.service
 
 - name: Set grub password
   template:

--- a/roles/debian/tasks/main.yml
+++ b/roles/debian/tasks/main.yml
@@ -330,6 +330,8 @@
       HISTFILESIZE: 2000000
       LIBVIRT_DEFAULT_URI: "qemu:///system"
       HISTTIMEFORMAT: '"%F %T "'
+      EDITOR: 'vim'
+      SYSTEMD_EDITOR: 'vim'
   with_items: "{{ env_list | dict2items }}"
 
 - name: "PATH for virtu user"


### PR DESCRIPTION
- 01-init.network file was not properly removed
- systemd-resolved was disabled by hardening playbook (it shouldn't)
- systemd-resolved was not bound on a specific address (because af LLMNR)
- vim was not the default editor (vi was, which created some problem with the default vim configuration)
- we also bump the cukinia-tests submodule to take into account the systemd-resolved changes