### PR TITLE
Redoing commit c82f3f1 with variabilized interface

### DIFF
--- a/templates/timemaster.service.j2
+++ b/templates/timemaster.service.j2
@@ -1,3 +1,15 @@
 [Unit]
 After=network-online.target
+{% if ptp_interface is defined %}{% if ptp_vlanid is defined %}
+After=sys-devices-virtual-net-{{ ptp_interface + '.' + ptp_vlanid|string }}.device
+{% else %}
+After=sys-devices-virtual-net-{{ ptp_interface }}.device
+{% endif %}
+{% endif %}
 Wants=network-online.target
+{% if ptp_interface is defined %}{% if ptp_vlanid is defined %}
+Wants=sys-devices-virtual-net-{{ ptp_interface + '.' + ptp_vlanid|string }}.device
+{% else %}
+Wants=sys-devices-virtual-net-{{ ptp_interface }}.device
+{% endif %}
+{% endif %}


### PR DESCRIPTION
Prevent a race condition which could make timemaster fail because the virtual ptp interface was not ready.