### PR TITLE
timemaster: add step_threshold option to ptp4l

### DIFF
--- a/templates/timemaster.conf.j2
+++ b/templates/timemaster.conf.j2
@@ -75,4 +75,4 @@ path /usr/sbin/phc2sys
 [ptp4l]
 path /usr/sbin/ptp4l
 # make ptp4l really verbose (to see synchro values)
-options -l 6
+options -l 6 --step_threshold 0.00001


### PR DESCRIPTION
In case of a link down event on the ptp interface, the PHC is reset and without this option, ptp4l takes forever to compensate for the 37s (TAI-UTC) offset.