### PR TITLE
ntp: allow more than 2 NTP servers

### DIFF
--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -148,8 +148,9 @@ all:
         gateway_addr: 10.0.0.1
         dns_servers: "8.8.8.8 8.8.4.4"
         apply_network_config: true
-        ntp_primary_server: "185.254.101.25"
-        ntp_secondary_server: "51.145.123.29"
+        ntp_servers: 
+            - "185.254.101.25"
+            - "51.145.123.29"
 
         # Ceph settings
         ceph_public_network: "192.168.55.0/24"

--- a/templates/timemaster.conf.j2
+++ b/templates/timemaster.conf.j2
@@ -23,12 +23,14 @@ ntp_program chronyd
 
 [chrony.conf]
 include /etc/chrony/chrony.conf
-{% if ptp_interface is defined %}
-server {{ ntp_primary_server }} iburst maxsamples 10
-{% else %}
-server {{ ntp_primary_server }} iburst maxsamples 10 prefer trust
+{% if ntp_servers is defined %}
+{%- for line in ntp_servers %}{% if ptp_interface is not defined and loop.index==1 %}server {{ line }} prefer iburst maxsamples 10
+{% else %}server {{ line }} iburst maxsamples 10
+{% endif %}{% endfor %}
+{% else %}{% if ptp_interface is defined %}server {{ ntp_primary_server }} iburst maxsamples 10
+{% else %}server {{ ntp_primary_server }} prefer iburst maxsamples 10 prefer trust
+{% endif %}server {{ ntp_secondary_server }} iburst maxsamples 10
 {% endif %}
-server {{ ntp_secondary_server }} iburst maxsamples 10
 
 [ntp.conf]
 includefile /etc/ntp.conf


### PR DESCRIPTION
Replacing ntp_primary_server and ntp_secondary_server variables with ntp_servers which is an array (not limited to 2 items). 
The first item will be the preferred server if no ptp interface is defined. 
For now the change is retro-compatible.