### PR TITLE
split and variabilize accounts used for rescue access and libvirt live-migration

### DIFF
--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -178,3 +178,11 @@ all:
             - http://ftp.fr.debian.org/debian bullseye-backports main contrib non-free
             - https://download.docker.com/linux/debian bullseye stable
             - https://artifacts.elastic.co/packages/8.x/apt stable main
+
+        # Default user with admin privileges, and password hash
+        admin_user: virtu
+        admin_passwd: "XXXXXX"
+        # SSH public keys for the admin_user
+        admin_ssh_keys:
+          - "ssh-rsa key1XXX"
+          - "ssh-rsa key2XXX"

--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -186,3 +186,5 @@ all:
         admin_ssh_keys:
           - "ssh-rsa key1XXX"
           - "ssh-rsa key2XXX"
+        # account used for libvirt live-migration
+        livemigration_user: livemigration

--- a/inventories/seapath_standalone_definition_example.yml
+++ b/inventories/seapath_standalone_definition_example.yml
@@ -69,3 +69,5 @@ all:
                     admin_ssh_keys:
                         - "ssh-rsa key1XXX"
                         - "ssh-rsa key2XXX"
+                    # account used for libvirt live-migration
+                    livemigration_user: livemigration		

--- a/inventories/seapath_standalone_definition_example.yml
+++ b/inventories/seapath_standalone_definition_example.yml
@@ -4,7 +4,6 @@ all:
         standalone_machine:
             hosts:
                 machine1:
-
                     # Ansible variables
                     ansible_host: 10.0.0.2
                     ansible_user: ansible
@@ -63,3 +62,10 @@ all:
                         - http://ftp.fr.debian.org/debian bullseye-backports main contrib non-free
                         - https://download.docker.com/linux/debian bullseye stable
                         - https://artifacts.elastic.co/packages/8.x/apt stable main
+                    # Default user with admin privileges, and password hash
+                    admin_user: virtu
+                    admin_passwd: "XXXXXX"
+                    # SSH public keys for the admin_user
+                    admin_ssh_keys:
+                        - "ssh-rsa key1XXX"
+                        - "ssh-rsa key2XXX"

--- a/playbooks/cluster_setup_keys.yaml
+++ b/playbooks/cluster_setup_keys.yaml
@@ -21,9 +21,9 @@
 
     - name: Copy the key add to authorized_keys using Ansible module
       authorized_key:
-        user: virtu
+        user: "{{ admin_user }}"
         state: present
-        path: /home/virtu/.ssh/authorized_keys
+        path: "/home/{{ admin_user }}/.ssh/authorized_keys"
         #path: /etc/ssh/root/authorized_keys
         key: "{{ lookup('file','buffer/' + item + '-id_rsa.pub') }}"
       with_items: "{{ groups['cluster_machines'] }}"

--- a/playbooks/cluster_setup_keys.yaml
+++ b/playbooks/cluster_setup_keys.yaml
@@ -21,9 +21,9 @@
 
     - name: Copy the key add to authorized_keys using Ansible module
       authorized_key:
-        user: "{{ admin_user }}"
+        user: "{{ livemigration_user }}"
         state: present
-        path: "/home/{{ admin_user }}/.ssh/authorized_keys"
+        path: "/home/{{ livemigration_user }}/.ssh/authorized_keys"
         #path: /etc/ssh/root/authorized_keys
         key: "{{ lookup('file','buffer/' + item + '-id_rsa.pub') }}"
       with_items: "{{ groups['cluster_machines'] }}"

--- a/playbooks/test_deploy_cukinia_tests.yaml
+++ b/playbooks/test_deploy_cukinia_tests.yaml
@@ -20,6 +20,12 @@
       with_items:
           - { src: 'common_security_tests.d/apt.conf.j2',
               dest: 'common_security_tests.d/apt.conf' }
+          - { src: 'hypervisor_security_tests.d/shadow.conf.j2',
+              dest: 'hypervisor_security_tests.d/shadow.conf' }
+          - { src: 'hypervisor_security_tests.d/passwd.conf.j2',
+              dest: 'hypervisor_security_tests.d/passwd.conf' }
+          - { src: 'hypervisor_security_tests.d/groups.conf.j2',
+              dest: 'hypervisor_security_tests.d/groups.conf' }
     - name: Create /usr/share/cukinia/includes
       file:
         path: /usr/share/cukinia/includes

--- a/roles/debian-hardening/tasks/main.yml
+++ b/roles/debian-hardening/tasks/main.yml
@@ -240,7 +240,7 @@
   with_items:
    - ceph
    - Debian-snmp
-   - virtu
+   - "{{ admin_user }}"
    - ansible
   when: not revert
   register: groups_changed

--- a/roles/debian/tasks/main.yml
+++ b/roles/debian/tasks/main.yml
@@ -53,8 +53,8 @@
       - "--chown=root:root"
 
 - name: Copy consolevm.sh
-  ansible.builtin.copy:
-    src: ../src/debian/consolevm.sh
+  template:
+    src: ../src/debian/consolevm.sh.j2
     dest: /usr/local/bin/consolevm
     mode: '0755'
 
@@ -238,19 +238,25 @@
     state: restarted
   when: snmpd_conf.changed
 
-- name: Install sudo virtu user rules
-  copy:
-    src: ../src/debian/sudoers/virtu
-    dest: /etc/sudoers.d/virtu
-    owner: root
-    group: root
-    mode: '0440'
-- name: remove 'virtu' from sudoers file
-  lineinfile:
-    dest: /etc/sudoers
-    state: absent
-    regexp: '^virtu'
-    validate: visudo -cf %s
+- name: removing or not the virtu user created by the iso
+  block:
+    - name: remove 'virtu' from sudoers file
+      lineinfile:
+        dest: /etc/sudoers
+        state: absent
+        regexp: '^virtu'
+        validate: visudo -cf %s
+    - name: Remove the virtu user 
+      ansible.builtin.user:
+        name: virtu
+        state: absent
+        remove: yes
+    - name: Remove the virtu group 
+      ansible.builtin.group:
+        name: virtu
+        state: absent
+  when: admin_user != "virtu"
+
 - name: Install sudo Debian-snmp user rules
   copy:
     src: ../src/debian/sudoers/Debian-snmp
@@ -271,12 +277,34 @@
     name: systemd-journald
   when: journaldconf.changed
 
-- name: Adding user virtu to groups libvirt and haclient
-  user: name=virtu
-    group=virtu
-    shell=/bin/bash
-    groups=libvirt,haclient
-    append=yes
+- name: Ensure admin group exists
+  ansible.builtin.group:
+    name: "{{ admin_user }}"
+    state: present
+    gid: 1000
+- name: Adding admin user
+  user:
+    name: "{{ admin_user }}"
+    shell: /bin/bash
+    group: "{{ admin_user }}"
+    groups: libvirt,haclient
+    uid: 1000
+    password: "{{ admin_passwd | default(omit) }}"
+    append: no
+- name: Add authorized keys to admin user
+  authorized_key:
+    user: "{{ admin_user }}"
+    key: "{{ item }}"
+  with_items: "{{ admin_ssh_keys }}"
+  when: admin_ssh_keys is defined and admin_ssh_keys is iterable
+- name: Install sudo admin user rules
+  copy:
+    content: |
+      {{ admin_user }}   ALL=NOPASSWD:EXEC: ALL
+    dest: "/etc/sudoers.d/{{ admin_user }}"
+    owner: root
+    group: root
+    mode: '0440'
 
 - name: Creating libvirt user with libvirtd permissions
   user: name=libvirt
@@ -334,15 +362,15 @@
       SYSTEMD_EDITOR: 'vim'
   with_items: "{{ env_list | dict2items }}"
 
-- name: "PATH for virtu user"
+- name: "PATH for admin user"
   lineinfile:
-    dest: /home/virtu/.bash_profile
+    dest: "/home/{{ admin_user }}/.bash_profile"
     regexp: '^export PATH'
     line: "export PATH=$PATH:/usr/sbin:/usr/local/sbin:/sbin"
     state: present
     create: yes
-    owner: virtu
-    group: virtu
+    owner: "{{ admin_user }}"
+    group: "{{ admin_user }}"
     mode: '0644'
 
 - name: lineinfile in hosts file for logstash-seapath

--- a/roles/debian/tasks/main.yml
+++ b/roles/debian/tasks/main.yml
@@ -306,6 +306,15 @@
     group: root
     mode: '0440'
 
+- name: Adding live-migration user
+  user:
+    name: "{{ livemigration_user }}"
+    shell: /bin/bash
+    group: libvirt
+    uid: 1001
+    append: no
+  when: livemigration_user != admin_user
+
 - name: Creating libvirt user with libvirtd permissions
   user: name=libvirt
     group=libvirt

--- a/src/debian/consolevm.sh.j2
+++ b/src/debian/consolevm.sh.j2
@@ -12,6 +12,6 @@ else
     echo no hypervisor found for this vm
   else
     echo "$vm is running on $hyp, let's connect !"
-    virsh --connect qemu+ssh://virtu@$hyp/system console $vm
+    virsh --connect qemu+ssh://{{ admin_user }}@$hyp/system console $vm
   fi
 fi

--- a/src/debian/sudoers/virtu
+++ b/src/debian/sudoers/virtu
@@ -1,3 +1,0 @@
-virtu   ALL=NOPASSWD:EXEC: ALL
-
-# This configuration grant all rights to the virtu user. It should be changed later in developpement


### PR DESCRIPTION
Following #225, this PR will variabilize the current "virtu" user (with the "admin_user" variable) and add a user dedicated for libvirt live-migration (in "livemigration_user" variable).
If the "admin_user" is different than "virtu", then the playbook will remove the useless virtu user.
Note that the "admin_user" account will need a password (Seapath CI testing does not allow this user to be password-locked), hence the "admin_password" var to define the password hash.
ssh public keys can also be set for this user with the admin_ssh_keys variable