### PR TITLE
inventory: osd memory target example

### DIFF
--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -198,7 +198,7 @@ all:
           osd:
             osd_min_pg_log_entries: 500
             osd_max_pg_log_entries: 500
-            osd_memory_target: 8076326604
+            osd memory target: 8076326604
         dashboard_enabled: false
 
         # Local path variables


### PR DESCRIPTION
same fix as in a608f84671aabf38a4444360c00ea8097c6c8125

ceph-ansible sets the osd memory with space in the var name ("osd memory target")
If we override with a var that has no space ("osd_memory_target"), it creates a duplicate setting...