### PR TITLE
ceph: force lvm vg refresh before zapping and creating the ceph vg/lv

### DIFF
--- a/playbooks/cluster_setup_ceph.yaml
+++ b/playbooks/cluster_setup_ceph.yaml
@@ -32,6 +32,9 @@
   tasks:
       - name: Prepare OSD disk
         block:
+          - name: Refresh LVM VG
+            command:
+              cmd:  vgchange --refresh
           - name: Get real path for OSD disk
             command: "realpath {{ ceph_osd_disk }}"
             register: ceph_osd_realdisk


### PR DESCRIPTION
Sometimes the zap process fails because the ceph vg and lv are not completely gone:

----
fatal: [virtu-ci3]: FAILED! => changed=true
  cmd:
  - ceph-volume
  - lvm
  - zap
  - /dev/sda
  - --destroy delta: '0:00:41.390807' end: '2023-07-12 11:34:42.307674' msg: non-zero return code rc: 1 start: '2023-07-12 11:34:00.916867' stderr: |- --> Zapping: /dev/sda --> Zapping lvm member /dev/sda. lv_path is /dev/vg_ceph/lv_ceph stderr: Unknown device "/dev/vg_ceph/lv_ceph": No such file or directory stderr: wipefs: error: /dev/vg_ceph/lv_ceph: probing initialization failed: No such file or directory ----