### PR TITLE
inventory: impose ceph_osd_disk to use the /dev/disk/by-path

### DIFF
--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -123,7 +123,8 @@ all:
                 node3:
             vars:
                 # Ceph settings
-                ceph_osd_disk: /dev/sdb # CEPH OSD disk
+                # ceph_osd_disk needs to be set to the "/dev/disk/by-path/" link of the disk used by the osd
+                ceph_osd_disk: "/dev/disk/by-path/pci-0000:c3:00.0-scsi-0:0:1:0"
                 # Required variables by ceph-ansible:
 #                lvm_volumes: # Optional
 #                    - data: lv_ceph # Name of the logical volume to use for the CEPH OSD volume


### PR DESCRIPTION
This is required by the hardening playbook which looks for the "lnk_source" to create the sudo rule
But anyway it's still a best practice since the scsi disk order may vary depending on the hardware