### PR TITLE
Cleaning VM NORT and RT templates

### DIFF
--- a/templates/vm/seapath_guest_nort.xml.j2
+++ b/templates/vm/seapath_guest_nort.xml.j2
@@ -57,6 +57,9 @@
             <cid auto='yes' />
         </vsock>
         <watchdog model="i6300esb" action="poweroff" />
+	<rng model='virtio'>
+            <backend model='random'>/dev/urandom</backend>
+        </rng>
     </devices>
     <resource>
         <partition>/machine/nort</partition>

--- a/templates/vm/seapath_guest_nort.xml.j2
+++ b/templates/vm/seapath_guest_nort.xml.j2
@@ -8,7 +8,6 @@
             SEAPATH guest - not realtime
     </description>
     <memory unit="KiB">1048576</memory>
-    <currentMemory unit="KiB">1048576</currentMemory>
     <vcpu placement="static">1</vcpu>
     <os firmware="efi">
       <type arch="x86_64" machine="pc-q35-3.1">hvm</type>
@@ -38,14 +37,11 @@
         <suspend-to-disk enabled="no" />
     </pm>
     <devices>
-        <emulator>/usr/bin/qemu-system-x86_64</emulator>
         <interface type="ethernet">
             <mac address="{{ mac_address }}"/>
             <target dev="{{ ovs_port }}" managed="no"/>
             <model type="virtio"/>
-            <alias name="net0"/>
         </interface>
-        <controller type="pci" index="0" model="pcie-root" />
         <serial type="pty">
             <target type="isa-serial" port="0">
                 <model name="isa-serial" />

--- a/templates/vm/seapath_guest_rt.xml.j2
+++ b/templates/vm/seapath_guest_rt.xml.j2
@@ -23,6 +23,7 @@
     </features>
     <cputune>
         <vcpupin vcpu="0" cpuset="{{ cpuset }}"/>
+    	<emulatorpin cpuset="{{ cpuset }}"/>
         <vcpusched vcpus="0" scheduler="fifo" priority="1" />
     </cputune>
     <cpu mode="host-model">

--- a/templates/vm/seapath_guest_rt.xml.j2
+++ b/templates/vm/seapath_guest_rt.xml.j2
@@ -62,6 +62,9 @@
             <cid auto='yes' />
         </vsock>
         <watchdog model="i6300esb" action="poweroff" />
+	<rng model='virtio'>
+            <backend model='random'>/dev/urandom</backend>
+        </rng>
     </devices>
     <resource>
         <partition>/machine-rt</partition>

--- a/templates/vm/seapath_guest_rt.xml.j2
+++ b/templates/vm/seapath_guest_rt.xml.j2
@@ -8,7 +8,6 @@
             SEAPATH guest - Realtime
     </description>
     <memory unit="KiB">1048576</memory>
-    <currentMemory unit="KiB">1048576</currentMemory>
     <vcpu placement="static">1</vcpu>
     <os firmware="efi">
       <type arch="x86_64" machine="pc-q35-3.1">hvm</type>
@@ -43,14 +42,11 @@
         <suspend-to-disk enabled="no" />
     </pm>
     <devices>
-        <emulator>/usr/bin/qemu-system-x86_64</emulator>
         <interface type="ethernet">
             <mac address="{{ mac_address }}"/>
             <target dev="{{ ovs_port }}" managed="no"/>
             <model type="virtio"/>
-            <alias name="net0"/>
         </interface>
-        <controller type="pci" index="0" model="pcie-root" />
         <serial type="pty">
             <target type="isa-serial" port="0">
                 <model name="isa-serial" />


### PR DESCRIPTION
Cleaning VM NORT and RT templates.
Libvirt automatically creates the following information, which has now been removed:
- currentMemory unit
- emulator
- controller type

Additionally, unnecessary information within the interface configuration has been removed:
- alias name

Added rng device in all basis templates.

Also added emulatorpin option in cputune.