### PR TITLE
Fix CI: ceph VG/LG already exist + introducing lvm_snapshot_rebooter

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -19,7 +19,7 @@ collections_paths = ./collections:~/.ansible/collections:/usr/share/ansible/coll
 # Uncomment this if you want disable the ssh key check. It is useful in
 # developement but must not be set in production.
 #host_key_checking = False
-gathering = False
+gathering = explicit
 nocows = 1
 callback_whitelist = profile_tasks
 stdout_callback = yaml

--- a/playbooks/cluster_setup_ceph.yaml
+++ b/playbooks/cluster_setup_ceph.yaml
@@ -29,41 +29,52 @@
   hosts:
       osds
   become: true
+  gather_facts: yes
   tasks:
       - name: Prepare OSD disk
         block:
           - name: Refresh LVM VG
             command:
               cmd:  vgchange --refresh
-          - name: Get real path for OSD disk
-            command: "realpath {{ ceph_osd_disk }}"
-            register: ceph_osd_realdisk
-          - name: Cleanup Ceph OSD disks with ceph-volume
-            command: "ceph-volume lvm zap {{ ceph_osd_realdisk.stdout }} --destroy"
-          - name: Create volumes for OSD disk
+          - name: Cleanup LV if we are in existing LV situation
             block:
-              - name: Create partition on OSD disks with parted
-                community.general.parted:
-                  device: "{{ lvm_volumes[0].device }}"
-                  number: "{{ lvm_volumes[0].device_number }}"
-                  state: present
-                  unit: MB
-                  part_end: "{{ lvm_volumes[0].device_size }}"
-                register: ceph_osd_result
-              - name: Get disk/by-path of OSD disk
-                command: "find -L /dev/disk/by-path -samefile {{ ceph_osd_result.disk.dev }} -print -quit"
-                register: ceph_osd_finddisk
-              - name: Create volume group on the partition
-                community.general.lvg:
-                  vg: "{{ lvm_volumes[0].data_vg }}"
-                  pvs: "{{ ceph_osd_finddisk.stdout }}-part{{ lvm_volumes[0].device_number }}"
-              - name: Create logical volume in the VG
-                community.general.lvol:
-                  vg: "{{ lvm_volumes[0].data_vg }}"
-                  lv: "{{ lvm_volumes[0].data }}"
-                  size: "{{ lvm_volumes[0].data_size }}"
+              - name: Cleanup Ceph LV with ceph-volume
+                command: "ceph-volume lvm zap /dev/{{ lvm_volumes[0].data_vg }}/{{ lvm_volumes[0].data }}"
             when:
-              - lvm_volumes is defined
+              - ansible_lvm['lvs'][lvm_volumes[0].data] is defined
+          - name: Create VG/LV if they don't exist
+            block:
+              - name: Get real path for OSD disk
+                command: "realpath {{ ceph_osd_disk }}"
+                register: ceph_osd_realdisk
+              - name: Cleanup Ceph OSD disks with ceph-volume
+                command: "ceph-volume lvm zap {{ ceph_osd_realdisk.stdout }} --destroy"
+              - name: Create volumes for OSD disk
+                block:
+                  - name: Create partition on OSD disks with parted
+                    community.general.parted:
+                      device: "{{ lvm_volumes[0].device }}"
+                      number: "{{ lvm_volumes[0].device_number }}"
+                      state: present
+                      unit: MB
+                      part_end: "{{ lvm_volumes[0].device_size }}"
+                    register: ceph_osd_result
+                  - name: Get disk/by-path of OSD disk
+                    command: "find -L /dev/disk/by-path -samefile {{ ceph_osd_result.disk.dev }} -print -quit"
+                    register: ceph_osd_finddisk
+                  - name: Create volume group on the partition
+                    community.general.lvg:
+                      vg: "{{ lvm_volumes[0].data_vg }}"
+                      pvs: "{{ ceph_osd_finddisk.stdout }}-part{{ lvm_volumes[0].device_number }}"
+                  - name: Create logical volume in the VG
+                    community.general.lvol:
+                      vg: "{{ lvm_volumes[0].data_vg }}"
+                      lv: "{{ lvm_volumes[0].data }}"
+                      size: "{{ lvm_volumes[0].data_size }}"
+                when:
+                  - lvm_volumes is defined
+            when:
+              - ansible_lvm['lvs'][lvm_volumes[0].data] is not defined
         when:
           - new_ceph_installation.changed
 

--- a/roles/debian/tasks/main.yml
+++ b/roles/debian/tasks/main.yml
@@ -506,3 +506,14 @@
 - name: update-grub
   command: update-grub
   when: updategrub1.changed or updategrub2.changed
+
+- name: "add lvm_snapshot_rebooter: script file"
+  ansible.builtin.copy:
+    src: ../src/debian/lvm_snapshot_rebooter.sh
+    dest: /etc/initramfs-tools/scripts/init-premount/lvm_snapshot_rebooter
+    mode: '0755'
+  register: lvm_snapshot_rebooter
+- name: "rebuild initramfs if necessary"
+  command:
+    cmd: /usr/sbin/update-initramfs -u
+  when: lvm_snapshot_rebooter.changed

--- a/src/debian/lvm_snapshot_rebooter.sh
+++ b/src/debian/lvm_snapshot_rebooter.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+# LVM snapshot rebooter : wait for any merging LV and reboot once done
+# Use this it to workaround GRUB limitation : it does not handle LV with merging snapshot
+
+PREREQ="lvm"
+prereqs()
+{
+   echo "$PREREQ"
+}
+
+case $1 in
+prereqs)
+   prereqs
+   exit 0
+   ;;
+esac
+
+. /scripts/functions
+
+# TIMEOUT=600 # How much time to wait for the merge to complete before panic'ing (empty/undef for unlimited)
+# TODO make a proper config entry? (/conf/initramfs.conf)
+
+if [ ! -x "/sbin/lvm" ]; then
+   panic "lvs executable not found"
+fi
+
+is_lvm_snapshot_merging() {
+	lv_merging_nb=$(/sbin/lvm lvs --select 'lv_merging!=0' | /usr/bin/wc -l)
+	test $lv_merging_nb -ne 0
+}
+
+log_begin_msg "Starting LVM Snapshot rebooter"
+
+# Wait for LVM elements to appear and be activated by udev
+wait_for_udev 10
+
+if is_lvm_snapshot_merging; then
+	log_end_msg
+	/sbin/lvm vgchange -a y
+	log_begin_msg "Waiting for snapshot merging to complete..."
+	count=0
+	while is_lvm_snapshot_merging; do
+		count=$(( count + 1 ))
+		sleep 1
+		if [ -n "$TIMEOUT" ] && [ "$count" -gt "$TIMEOUT" ]; then
+			panic "Timeout while waiting for LVM snapshot merging!"
+		fi
+	done
+
+	log_success_msg "Snapshot merging complete, rebooting..."
+	sleep 3 # To allow display on console
+
+	reboot -f # No init to handle reboot => -f
+else
+	log_success_msg "Done. (No LVM snapshot need merging)"
+fi
+
+exit 0
+


### PR DESCRIPTION
This change has to be merged ASAP for the CI to be functionnal.
A CI workflow on a "lvm rebooter" PR crashed the initramfs so I had to reinstall the 3 servers. I used a software raid installation for which the ceph VG and LV are created with the ISO. We need to make a change in the ceph playbook for this case to be dealt with.

Indeed, it might be a good target to assume the ceph VG and LV have already been created (for example for a softraid situation). In that case the ceph playbook must deal with multiple possibilities:
- Is it a new ceph installation or not ?
- if it's a new installation, do we already have the ceph VG and LV, in which case we zap them and move to the installation
- if the ceph VG and LV don't exist, are we really in a "customized lvm situation"
- if we are, then we create what the inventory requires, then move to the installation
- if we are not, then we use the whole "ceph_osd_disk" disk and move to the installation

The first commit adds the "existing ceph VG/LG case".

---------

While we repair the CI, we also need to fix a problem with the rollback process (2nd commit):

GRUB lvm module has a limitation : it does not handle correctly the case when a LV is marked for a merging with its snapshot. GRUB does not see the snapshot. When using a snapshot for /boot, it means that /boot (has seen by grub) and / will be desynchronized. In particular, the kernel and its modules may not match anymore which result in a degraded system.

To work around that, lvm_snapshot_rebooter can be used to wait for the merging to complete in the initramfs and reboot if needed. That way, GRUB will see a updated version of /boot.