### PR TITLE
ceph: plan for the case ceph VG/LG already exist

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -19,7 +19,7 @@ collections_paths = ./collections:~/.ansible/collections:/usr/share/ansible/coll
 # Uncomment this if you want disable the ssh key check. It is useful in
 # developement but must not be set in production.
 #host_key_checking = False
-gathering = False
+gathering = explicit
 nocows = 1
 callback_whitelist = profile_tasks
 stdout_callback = yaml

--- a/playbooks/cluster_setup_ceph.yaml
+++ b/playbooks/cluster_setup_ceph.yaml
@@ -29,41 +29,52 @@
   hosts:
       osds
   become: true
+  gather_facts: yes
   tasks:
       - name: Prepare OSD disk
         block:
           - name: Refresh LVM VG
             command:
               cmd:  vgchange --refresh
-          - name: Get real path for OSD disk
-            command: "realpath {{ ceph_osd_disk }}"
-            register: ceph_osd_realdisk
-          - name: Cleanup Ceph OSD disks with ceph-volume
-            command: "ceph-volume lvm zap {{ ceph_osd_realdisk.stdout }} --destroy"
-          - name: Create volumes for OSD disk
+          - name: Cleanup LV if we are in existing LV situation
             block:
-              - name: Create partition on OSD disks with parted
-                community.general.parted:
-                  device: "{{ lvm_volumes[0].device }}"
-                  number: "{{ lvm_volumes[0].device_number }}"
-                  state: present
-                  unit: MB
-                  part_end: "{{ lvm_volumes[0].device_size }}"
-                register: ceph_osd_result
-              - name: Get disk/by-path of OSD disk
-                command: "find -L /dev/disk/by-path -samefile {{ ceph_osd_result.disk.dev }} -print -quit"
-                register: ceph_osd_finddisk
-              - name: Create volume group on the partition
-                community.general.lvg:
-                  vg: "{{ lvm_volumes[0].data_vg }}"
-                  pvs: "{{ ceph_osd_finddisk.stdout }}-part{{ lvm_volumes[0].device_number }}"
-              - name: Create logical volume in the VG
-                community.general.lvol:
-                  vg: "{{ lvm_volumes[0].data_vg }}"
-                  lv: "{{ lvm_volumes[0].data }}"
-                  size: "{{ lvm_volumes[0].data_size }}"
+              - name: Cleanup Ceph LV with ceph-volume
+                command: "ceph-volume lvm zap /dev/{{ lvm_volumes[0].data_vg }}/{{ lvm_volumes[0].data }}"
             when:
-              - lvm_volumes is defined
+              - ansible_lvm['lvs'][lvm_volumes[0].data] is defined
+          - name: Create VG/LV if they don't exist
+            block:
+              - name: Get real path for OSD disk
+                command: "realpath {{ ceph_osd_disk }}"
+                register: ceph_osd_realdisk
+              - name: Cleanup Ceph OSD disks with ceph-volume
+                command: "ceph-volume lvm zap {{ ceph_osd_realdisk.stdout }} --destroy"
+              - name: Create volumes for OSD disk
+                block:
+                  - name: Create partition on OSD disks with parted
+                    community.general.parted:
+                      device: "{{ lvm_volumes[0].device }}"
+                      number: "{{ lvm_volumes[0].device_number }}"
+                      state: present
+                      unit: MB
+                      part_end: "{{ lvm_volumes[0].device_size }}"
+                    register: ceph_osd_result
+                  - name: Get disk/by-path of OSD disk
+                    command: "find -L /dev/disk/by-path -samefile {{ ceph_osd_result.disk.dev }} -print -quit"
+                    register: ceph_osd_finddisk
+                  - name: Create volume group on the partition
+                    community.general.lvg:
+                      vg: "{{ lvm_volumes[0].data_vg }}"
+                      pvs: "{{ ceph_osd_finddisk.stdout }}-part{{ lvm_volumes[0].device_number }}"
+                  - name: Create logical volume in the VG
+                    community.general.lvol:
+                      vg: "{{ lvm_volumes[0].data_vg }}"
+                      lv: "{{ lvm_volumes[0].data }}"
+                      size: "{{ lvm_volumes[0].data_size }}"
+                when:
+                  - lvm_volumes is defined
+            when:
+              - ansible_lvm['lvs'][lvm_volumes[0].data] is not defined
         when:
           - new_ceph_installation.changed
 


### PR DESCRIPTION
This change has to be merged ASAP for the CI to be functionnal

It might be a good target to assume the ceph VG and LG have already been created (for example for a softraid situation). In that case the ceph playbook must deal with multiple possibilities:
- Is it a new ceph installation or not ?
- if it's a new installation, do we already have the ceph VG and LV, in which case we zap them and move to the installation
- if the ceph VG and LV don't exist, are we really in a "customized lvm situation"
- if we are, then we create what the inventory requires, then move to the installation
- if we are not, then we use the whole "ceph_osd_disk" disk and move to the installation

This commit adds the "existing ceph VG/LG case".