### PR TITLE
run extra crm commands

### DIFF
--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -117,6 +117,11 @@ all:
                   preferred_host: "node3"
                   migrate_to_timeout: 180
                   enable: false
+                  ##Instead of preferred_host or pinned_host, you can add more complex rules here
+                  #crm_config_cmd:
+                  #  - location ntpstatus_location_test test rule ntpstatus: defined ntpstatus
+                  #  - location ptpstatus_location_test test rule ptpstatus: defined ptpstatus
+                  #  - location cli-prefer-test test role=Started 100: virtu-elabo1
 
         # Ceph groups
         # All machines in the cluster must be part of mons groups
@@ -246,3 +251,9 @@ all:
           - "ssh-rsa key2XXX"
         # account used for libvirt live-migration
         livemigration_user: livemigration
+
+        extra_crm_cmd_to_run:
+          - primitive ntpstatus_test ocf:seapath:ntpstatus params host_ip=ntp.unice.fr multiplier=500 op monitor timeout=10 interval=10
+          - primitive ptpstatus_test ocf:seapath:ptpstatus op monitor timeout=10 interval=10 op_params multiplier=1000
+          - clone cl_ntpstatus_test ntpstatus_test meta target-role=Started
+          - clone cl_ptpstatus_test ptpstatus_test meta target-role=Started

--- a/library/cluster_vm.py
+++ b/library/cluster_vm.py
@@ -190,6 +190,11 @@ options:
       - VM list to be be colocated with the VM define in I(name) parameter
       - This parameter is required if I(command) is C(define_colocation)
     type: list
+  crm_config_cmd:
+    description:
+      - list of crm config to run when enabling this guest
+      - This parameter is optional
+    type: list
 
 requirements:
     - python >= 3.7
@@ -324,6 +329,14 @@ EXAMPLES = r"""
     colocated_vms:
      - guest1
      - guest2
+
+# Define a list of crm command to run when enabling the guest
+- name: create a guest and run extra crm commands
+  cluster_vm:
+    name: GUEST1
+    command: create
+    crm_config_cmd:
+     - location ping_test_GUEST1 GUEST1 rule pingd: defined pingd
 """
 
 RETURN = """
@@ -448,6 +461,7 @@ def run_module():
         clear_constraint=dict(type="bool", required=False, default=False),
         strong=dict(type="bool", required=False, default=False),
         colocated_vms=dict(type="list", required=False),
+        crm_config_cmd=dict(type="list", required=False),
     )
     result = {}
     required = [
@@ -500,6 +514,7 @@ def run_module():
     clear_constraint = args.get("clear_constraint", False)
     strong_constraint = args.get("strong", False)
     colocated_vms = args.get("colocated_vms", [])
+    crm_config_cmd = args.get("crm_config_cmd", [])
 
     vm_name_command_list = commands_list.copy()
     vm_name_command_list.remove("list_vms")
@@ -533,6 +548,7 @@ def run_module():
                 live_migration=live_migration,
                 migration_user=migration_user,
                 migrate_to_timeout=migrate_to_timeout,
+                crm_config_cmd=crm_config_cmd,
             )
         elif command == "clone":
             vm_manager.clone(

--- a/playbooks/cluster_setup_ha.yaml
+++ b/playbooks/cluster_setup_ha.yaml
@@ -118,3 +118,15 @@
         command: crm configure property stonith-enabled=false
         run_once: true
         when: groups['valid_machine'] is undefined
+
+- name: run extra CRM commands
+  hosts: all
+  become: true
+  tasks:
+      - name: run extra CRM configuration commands
+        command: "/usr/sbin/crm configure {{ item }}"
+        when: extra_crm_cmd_to_run is defined
+        run_once: true
+        no_log: true
+        failed_when: 0 == 1
+        loop: "{{ extra_crm_cmd_to_run }}"

--- a/playbooks/deploy_vms_cluster.yaml
+++ b/playbooks/deploy_vms_cluster.yaml
@@ -24,6 +24,7 @@
         enable: true
         pinned_host: "{{ hostvars[item].pinned_host | default(None) }}"
         preferred_host: "{{ hostvars[item].preferred_host | default(None) }}"
+        crm_config_cmd: "{{ hostvars[item].crm_config_cmd | default(None) }}"
         xml: >-
           {{ lookup('template',
           hostvars[item].vm_template,

--- a/playbooks/tasks/deploy_vm.yaml
+++ b/playbooks/tasks/deploy_vm.yaml
@@ -19,6 +19,7 @@
     live_migration: "{{ hostvars[item].live_migration | default('') }}"
     migration_user: "{{ hostvars[item].migration_user | default('') }}"
     migrate_to_timeout: "{{ hostvars[item].migrate_to_timeout | default('') }}"
+    crm_config_cmd: "{{ hostvars[item].crm_config_cmd | default('') }}"
     enable: "{{ hostvars[item].enable | default(true) }}"
 - name: Remove temporary file
   file:


### PR DESCRIPTION
This will allow running custom "crm configure" commands at the end of the HA playbook. This can allow setup location resources for guests (ping or else), stickiness parameters or even fencing options.
Then we need to allow the guests to embed customize location rules, and for that we make the necessary adjustement to the vm-manager ansible plugin. 
The needed improvement has been done in vm_manager with commit https://github.com/seapath/vm_manager/commit/9701165b7f464a1beb7e79316234e999081fc9e1