### PR TITLE
Changes needed to upgrade to Debian 12

### DIFF
--- a/.cqfd/docker/Dockerfile
+++ b/.cqfd/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN set -x \
         vim \
     && sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen \
     && python3 -m venv --system-site-packages /env \
-    && /env/bin/pip install ansible==2.9.27 ansible-lint==5.4.0 yamllint six netaddr \
+    && /env/bin/pip install ansible==2.10.7 ansible-lint==5.4.0 yamllint six netaddr \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/*
 
 ENV PATH="/env/bin:/env/usr/bin:/env/sbin:/env/usr/sbin:$PATH"

--- a/.github/workflows/ci-debian.yml
+++ b/.github/workflows/ci-debian.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   CI:
-    runs-on: [self-hosted, runner-RTE]
+    runs-on: [self-hosted, runner-RTE-12]
     steps:
 
       - name: Initialize sources

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,7 @@
 	path = ceph-ansible
 	url = https://github.com/ceph/ceph-ansible.git
 	ignore = dirty
-	branch = stable-4.0
+	branch = stable-6.0
 [submodule "src/debian/python3-setup-ovs"]
 	path = src/debian/python3-setup-ovs
 	url = https://github.com/seapath/python3-setup-ovs.git

--- a/README.adoc
+++ b/README.adoc
@@ -88,13 +88,13 @@ NOTE: Later you must prefix all ansible command with `cqfd run`.
 === Use Ansible without cqfd
 
 Without `cqfd` you need to install the dependencies manually.
-The client machine that is going to run Ansible must have Ansible 2.9 installed
-an Inventory file and playbook files to play. To install Ansible 2.9 on this
+The client machine that is going to run Ansible must have Ansible 2.10 installed
+an Inventory file and playbook files to play. To install Ansible 2.10 on this
 machine please refer to the Ansible documentation at
 https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html.
 
-*Warning:* Curently only the Ansible version 2.9 is supported. Other versions
-will not work. Ansible 2.9 is the packaged version in Ubuntu 20.04 and Fedora 33.
+*Warning:* Curently only the Ansible version 2.10 is supported. Other versions
+will not work.
 
 Also you must also install the netaddr python3 module.
 

--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -263,10 +263,9 @@ all:
         # Optional list variable to change apt repositories. All repositories will be overrides.
         # If defined as empty list [], all apt repositories will be removed
         apt_repo:
-          - http://ftp.fr.debian.org/debian bullseye main contrib non-free
-          - http://security.debian.org/debian-security bullseye-security main contrib non-free
-          - http://ftp.fr.debian.org/debian bullseye-backports main contrib non-free
-          - https://download.docker.com/linux/debian bullseye stable
+          - http://ftp.fr.debian.org/debian bookworm main contrib non-free non-free-firmware
+          - http://security.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware
+          - http://ftp.fr.debian.org/debian bookworm-backports main contrib non-free non-free-firmware
           - https://artifacts.elastic.co/packages/8.x/apt stable main
 
         # Default user with admin privileges, and password hash

--- a/inventories/seapath_standalone_definition_example.yml
+++ b/inventories/seapath_standalone_definition_example.yml
@@ -65,10 +65,9 @@ all:
                     # Optional list variable to change apt repositories. All repositories will be overrides.
                     # If defined as empty list [], all apt repositories will be removed
                     apt_repo:
-                        - http://ftp.fr.debian.org/debian bullseye main contrib non-free
-                        - http://security.debian.org/debian-security bullseye-security main contrib non-free
-                        - http://ftp.fr.debian.org/debian bullseye-backports main contrib non-free
-                        - https://download.docker.com/linux/debian bullseye stable
+                        - http://ftp.fr.debian.org/debian bookworm main contrib non-free non-free-firmware
+                        - http://security.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware
+                        - http://ftp.fr.debian.org/debian bookworm-backports main contrib non-free non-free-firmware
                         - https://artifacts.elastic.co/packages/8.x/apt stable main
                     # Default user with admin privileges, and password hash
                     admin_user: virtu

--- a/prepare.sh
+++ b/prepare.sh
@@ -21,9 +21,9 @@ if ! command -v ansible &>/dev/null ; then
     exit 1
 fi
 
-echo "Test Ansible version is 2.9"
-if ! ansible --version | grep -q 'ansible 2.9' ; then
-    echo "Error: Installed version of ansible must match 2.9" 1>&2
+echo "Test Ansible version is 2.10"
+if ! ansible --version | grep -q 'ansible 2.10' ; then
+    echo "Error: Installed version of ansible must match 2.10" 1>&2
     echo "See README.adoc for instructions" 1>&2
 fi
 

--- a/roles/debian-hardening/physical_machine/tasks/main.yml
+++ b/roles/debian-hardening/physical_machine/tasks/main.yml
@@ -24,7 +24,7 @@
 - name: Restrict ceph sudoers file
   template:
     src: ../src/debian/sudoers/ceph.j2
-    dest: /etc/sudoers.d/ceph-osd-smartctl
+    dest: /etc/sudoers.d/ceph-smartctl
     owner: root
     group: root
     mode: '0440'

--- a/src/debian/ceph-crash_hardening.conf
+++ b/src/debian/ceph-crash_hardening.conf
@@ -12,4 +12,4 @@ RestrictNamespaces=pid user cgroup
 PrivateDevices=yes
 ProtectKernelLogs=true
 
-SystemCallFilter=~@obsolete @swap @aio @clock @cpu-emulation @keyring @memlock @module @mount @reboot @setuid @timer
+SystemCallFilter=~@obsolete @swap @aio @clock @cpu-emulation @keyring @memlock @module @mount @reboot @timer

--- a/src/debian/sudoers/ceph.j2
+++ b/src/debian/sudoers/ceph.j2
@@ -10,4 +10,6 @@
 # The replace directive add an escape backslash before the colon character
 # for the file to be properly parsed.
 
-ceph ALL=NOPASSWD: /usr/sbin/smartctl -a --json=o {{ ceph_osd_disk_stat.stat.lnk_source if ceph_osd_disk is defined else none }}
+{% if ceph_osd_disk is defined %}
+ceph ALL=NOPASSWD: /usr/sbin/smartctl -a --json=o {{ ceph_osd_disk_stat.stat.lnk_source }}
+{% endif %}


### PR DESCRIPTION
In accordance with SEAPATH TSC on Oct 12, 2023, this PR will make ansible compatible with deploying seapath on blank nodes running debian 12.
The branch "debian11" has been created based on current debian-main.