### PR TITLE
library/cluster_vm: set crm_config_cmd default value to None

### DIFF
--- a/library/cluster_vm.py
+++ b/library/cluster_vm.py
@@ -514,7 +514,7 @@ def run_module():
     clear_constraint = args.get("clear_constraint", False)
     strong_constraint = args.get("strong", False)
     colocated_vms = args.get("colocated_vms", [])
-    crm_config_cmd = args.get("crm_config_cmd", [])
+    crm_config_cmd = args.get("crm_config_cmd", None)
 
     vm_name_command_list = commands_list.copy()
     vm_name_command_list.remove("list_vms")


### PR DESCRIPTION
The default crm_config_cmd value has to be None and not [].