### PR TITLE
deploy_vm: absence of crm_config_cmd bug

### DIFF
--- a/library/cluster_vm.py
+++ b/library/cluster_vm.py
@@ -514,7 +514,7 @@ def run_module():
     clear_constraint = args.get("clear_constraint", False)
     strong_constraint = args.get("strong", False)
     colocated_vms = args.get("colocated_vms", [])
-    crm_config_cmd = args.get("crm_config_cmd", [])
+    crm_config_cmd = args.get("crm_config_cmd", None)
 
     vm_name_command_list = commands_list.copy()
     vm_name_command_list.remove("list_vms")

--- a/playbooks/deploy_vms_cluster.yaml
+++ b/playbooks/deploy_vms_cluster.yaml
@@ -24,7 +24,7 @@
         enable: true
         pinned_host: "{{ hostvars[item].pinned_host | default(None) }}"
         preferred_host: "{{ hostvars[item].preferred_host | default(None) }}"
-        crm_config_cmd: "{{ hostvars[item].crm_config_cmd | default(None) }}"
+        crm_config_cmd: "{{ hostvars[item].crm_config_cmd | default(omit) }}"
         xml: >-
           {{ lookup('template',
           hostvars[item].vm_template,

--- a/playbooks/tasks/deploy_vm.yaml
+++ b/playbooks/tasks/deploy_vm.yaml
@@ -19,7 +19,7 @@
     live_migration: "{{ hostvars[item].live_migration | default('') }}"
     migration_user: "{{ hostvars[item].migration_user | default('') }}"
     migrate_to_timeout: "{{ hostvars[item].migrate_to_timeout | default('') }}"
-    crm_config_cmd: "{{ hostvars[item].crm_config_cmd | default('') }}"
+    crm_config_cmd: "{{ hostvars[item].crm_config_cmd | default(omit) }}"
     enable: "{{ hostvars[item].enable | default(true) }}"
 - name: Remove temporary file
   file:


### PR DESCRIPTION
If crm_config_cmd is not defined for a VM, it is created empty by vm-mgr and that causes problems.
This patch makes sure crm_config_cmd is not created when not present in the VM definition