### PR TITLE
backup-restore: parametrize rsync remote shell command

### DIFF
--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -265,3 +265,6 @@ all:
           - primitive ptpstatus_test ocf:seapath:ptpstatus op monitor timeout=10 interval=10 op_params multiplier=1000
           - clone cl_ntpstatus_test ntpstatus_test meta target-role=Started
           - clone cl_ptpstatus_test ptpstatus_test meta target-role=Started
+
+        #backup-restore uses rsync to connect to the offsite storage server, with the -e (remote shell) option. Default remote shell is "ssh" but you can override it here. This it particularly useful to change the port used by ssh.
+        backuprestore_rsync_remote_shell: "ssh -p 22"

--- a/roles/debian/physical_machine/tasks/main.yml
+++ b/roles/debian/physical_machine/tasks/main.yml
@@ -60,14 +60,11 @@
       - "--exclude=*.j2"
 - name: Copy backup-restore templates
   template:
-    src: ../src/debian/backup-restore/{{ item.src }}
-    dest: /usr/local/bin/{{ item.dest }}
+    src: "{{ item }}"
+    dest: /usr/local/bin/{{ item | basename | regex_replace('\.j2$', '') }}
     mode: '0755'
-  with_items:
-    - src:
-        restore_vm.sh.j2
-      dest:
-        restore_vm.sh
+  with_fileglob:
+    - ../src/debian/backup-restore/*.j2
 
 - name: create /usr/lib/ocf/resource.d/seapath on hosts
   file:

--- a/src/debian/backup-restore/backup-restore.sh.j2
+++ b/src/debian/backup-restore/backup-restore.sh.j2
@@ -15,7 +15,7 @@ function addExitToArray {
 }
 function addIndexToArray {
   local -n myarray=$1
-  for idx in `seq 1 ${#myarray[@]}`; do
+  for idx in `seq 1 ${{ '{#' }}myarray[@]}`; do
     arrVar+=($idx")")
     arrVar+=("${myarray[$(($idx-1))]}")
   done
@@ -41,7 +41,7 @@ function restoreVMChooseFullDate {
     [ -z "$remote_dir" ] && { whiptail --msgbox "var remote_dir empty" 10 50; break; }
     [ -z "$remote_serv" ] && { whiptail --msgbox "var remote_serv empty" 10 50; break; }
 
-    local listFullDate=($(ssh $remote_serv "cd $remote_dir ; ls"))
+    local listFullDate=($({{ backuprestore_rsync_remote_shell | default('ssh') }} $remote_serv "cd $remote_dir ; ls"))
     local arrVar=()
     addIndexToArray listFullDate
     addExitToArray arrVar
@@ -61,7 +61,7 @@ function restoreVMChooseFullDate {
 function restoreVMChooseVM {
   while [ 1 ]
   do
-    local listVM=($(ssh $remote_serv "cd $remote_dir ; cd $fulldate; ls *.qcow2 | grep -E "^system_" | cut -d"_" -f 2 | sort -u"))
+    local listVM=($({{ backuprestore_rsync_remote_shell | default('ssh') }} $remote_serv "cd $remote_dir ; cd $fulldate; ls *.qcow2 | grep -E "^system_" | cut -d"_" -f 2 | sort -u"))
     local arrVar=()
     addIndexToArray listVM
     addExitToArray arrVar
@@ -79,7 +79,7 @@ function restoreVMChooseVM {
   done
 }
 function restoreVMChooseIncDate {
-  local listIncDateRaw=($(ssh $remote_serv "cd $remote_dir ; cd $fulldate; ls *_""$vm""-*.xml | cut -d- -f2 | cut -d. -f1"))
+  local listIncDateRaw=($({{ backuprestore_rsync_remote_shell | default('ssh') }} $remote_serv "cd $remote_dir ; cd $fulldate; ls *_""$vm""-*.xml | cut -d- -f2 | cut -d. -f1"))
   local listIncDate=()
   for idx in ${listIncDateRaw[@]}; do
     e=`echo "$idx" | sed 's/./&-/4;s/./&-/7;s/./& /10;s/./&:/13'`

--- a/src/debian/backup-restore/backup_full.sh.j2
+++ b/src/debian/backup-restore/backup_full.sh.j2
@@ -31,4 +31,4 @@ do
   qemu-img convert -f raw -O qcow2 rbd:rbd/$i@$d $f/$i"_"$d.qcow2
   echo ----
 done
-rsync -ave ssh --progress $f $remote_dir
+rsync -ave '{{ backuprestore_rsync_remote_shell | default('ssh') }}' --progress $f $remote_dir

--- a/src/debian/backup-restore/backup_inc.sh.j2
+++ b/src/debian/backup-restore/backup_inc.sh.j2
@@ -26,4 +26,4 @@ do
   echo backuping metadata
   rbd image-meta list rbd/$i > $latest_full/$i-meta-$d.txt
 done
-rsync -ave ssh --progress $latest_full $remote_dir
+rsync -ave '{{ backuprestore_rsync_remote_shell | default('ssh') }}' --progress $latest_full $remote_dir


### PR DESCRIPTION
backup-restore uses rsync to connect to the offsite storage server, with the -e (remote shell) option.
This commit sets the default rsync remote shell to "ssh", but it can now be overriden with the backuprestore_rsync_remote_shell variable
This it particularly useful to change the port used by ssh.