### PR TITLE
waiting changes

### DIFF
--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -31,6 +31,18 @@ all:
                             cluster_ip_addr: "192.168.55.1"
                             br_rstp_priority: 12288
                             brBRIDGE1_ext: eno1234 #physical nic to use with BRIDGE1 (see the ovs topology inventory)
+                            custom_network:
+                              - 01-enp24s0_sriov:
+                                - Match:
+                                  - Name: "enp24s0*"
+                                - SR-IOV:
+                                  - VirtualFunction: 0
+                                  - Trust: 1
+                                  - LinkState: on
+                                - SR-IOV:
+                                  - VirtualFunction: 1
+                                  - Trust: 1
+                                  - LinkState: on
 
                         node2:
                             # ansbile variables
@@ -246,11 +258,11 @@ all:
         # Optional list variable to change apt repositories. All repositories will be overrides.
         # If defined as empty list [], all apt repositories will be removed
         apt_repo:
-            - http://ftp.fr.debian.org/debian bullseye main contrib non-free
-            - http://security.debian.org/debian-security bullseye-security main contrib non-free
-            - http://ftp.fr.debian.org/debian bullseye-backports main contrib non-free
-            - https://download.docker.com/linux/debian bullseye stable
-            - https://artifacts.elastic.co/packages/8.x/apt stable main
+          - http://ftp.fr.debian.org/debian bullseye main contrib non-free
+          - http://security.debian.org/debian-security bullseye-security main contrib non-free
+          - http://ftp.fr.debian.org/debian bullseye-backports main contrib non-free
+          - https://download.docker.com/linux/debian bullseye stable
+          - https://artifacts.elastic.co/packages/8.x/apt stable main
 
         # Default user with admin privileges, and password hash
         admin_user: virtu

--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -294,3 +294,4 @@ all:
           GUEST4: []        # no filtering, including untagged trafic
 
         #cluster_protocol: "HSR" # RSTP or HSR, default is RSTP
+        chrony_wait_timeout_sec: 180 #time in seconds the boot sequence will wait for chrony to sync

--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -210,7 +210,8 @@ all:
         # Main network configuration
         gateway_addr: 10.0.0.1
         dns_servers: "8.8.8.8 8.8.4.4"
-        apply_network_config: true
+        apply_network_config: false # do we restart the ovs_config script to apply the changes to the ovs topology (default: false)
+        skip_reboot_setup_network: true # if we do no apply the changes (apply_network_config=false), then the network playbook will reboot the servers at the end. You can choose to skip this reboot here (default: false)
         ntp_servers:
             - "185.254.101.25"
             - "51.145.123.29"

--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -13,6 +13,7 @@ all:
                             network_interface: eno8303 #main interface
                             ip_addr: "{{ ansible_host }}"
                             subnet: 25 #default is 24, override if necessary
+                            #br0vlan: 159 #if the main interface on br0 is on a vlan that the host must manage
 
                             # Admin network settings
                             admin_ip_addr: 10.10.11.1 #used for snmp
@@ -281,3 +282,10 @@ all:
           - primitive ptpstatus_test ocf:seapath:ptpstatus op monitor timeout=10 interval=10 op_params multiplier=1000
           - clone cl_ntpstatus_test ntpstatus_test meta target-role=Started
           - clone cl_ptpstatus_test ptpstatus_test meta target-role=Started
+
+        # if br0vlan is set, then the host's remote access network ip is on a vlan, but a trunk port has been given to the host so that guests can connect to other vlans. You create the interfaces for those guests here:
+        guests_on_br0:
+          GUEST1: 159       #access port on vlan 159
+          GUEST2: [159,160] #trunk port on vlan 159 and 160
+          GUEST3: [1-4094]  # no filtering, excluding untagged trafic
+          GUEST4: []        # no filtering, including untagged trafic

--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -27,6 +27,7 @@ all:
                             # Cluster network settings
                             team0_0: "eno12399" # cluster network first interface
                             team0_1: "eno12409" # cluster network second interface
+                            #hsr_mac_address: "70:FF:76:1C:0E:8C" # if using HSR for cluster network, you need to specify the mac address for each host
                             cluster_next_ip_addr : "192.168.55.2" #node 2 cluster network ip
                             cluster_previous_ip_addr : "192.168.55.3" #node 3 cluster network ip
                             cluster_ip_addr: "192.168.55.1"
@@ -66,6 +67,7 @@ all:
                             # Cluster network settings
                             team0_0: "eno12399"
                             team0_1: "eno12409"
+                            #hsr_mac_address: "70:FF:76:1C:0E:8D" # if using HSR for cluster network, you need to specify the mac address for each host
                             cluster_next_ip_addr : "192.168.55.3" #node 3 cluster network ip
                             cluster_previous_ip_addr :  "192.168.55.1" #node 1 cluster network ip
                             cluster_ip_addr: "192.168.55.2"
@@ -93,6 +95,7 @@ all:
                             # Cluster network settings
                             team0_0: "eno12399"
                             team0_1: "eno12409"
+                            #hsr_mac_address: "70:FF:76:1C:0E:8E" # if using HSR for cluster network, you need to specify the mac address for each host
                             cluster_next_ip_addr : "192.168.55.1" #ip de hyperviseur 1
                             cluster_previous_ip_addr :  "192.168.55.2" #ip de l'hyperviseur 2
                             cluster_ip_addr: "192.168.55.3"
@@ -289,3 +292,5 @@ all:
           GUEST2: [159,160] #trunk port on vlan 159 and 160
           GUEST3: [1-4094]  # no filtering, excluding untagged trafic
           GUEST4: []        # no filtering, including untagged trafic
+
+        #cluster_protocol: "HSR" # RSTP or HSR, default is RSTP

--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -294,6 +294,41 @@
         sriov_network_pool_name: "{{ 'sr-iov-net-' + item.key }}"
       when: sriov is defined
 
+- name: configure guests br0 interfaces
+  hosts: cluster_machines
+  become: true
+  tasks:
+    - debug:
+        var: item.value
+      with_items: "{{ guests_on_br0 | dict2items }}"
+      when: guests_on_br0 is defined
+#      failed_when: 1 == 1
+    - name: create 00-GUESTtap.netdev
+      template:
+        src: ../templates/00-GUESTtap.netdev.j2
+        dest: /etc/systemd/network/00-{{ item.key }}tap.netdev
+        owner: "root"
+        group: "systemd-network"
+        mode: '0644'
+      with_items: "{{ guests_on_br0 | dict2items }}"
+      when: guests_on_br0 is defined
+      register: guest_br0_netdev
+    - name: create 00-GUESTtap.network
+      template:
+        src: ../templates/00-GUESTtap.network.j2
+        dest: /etc/systemd/network/00-{{ item.key }}tap.network
+        owner: "root"
+        group: "systemd-network"
+        mode: '0644'
+      with_items: "{{ guests_on_br0 | dict2items }}"
+      when: guests_on_br0 is defined
+      register: guest_br0_network
+    - name: Restart systemd-networkd
+      ansible.builtin.systemd:
+        name: systemd-networkd
+        state: restarted
+      when: guest_br0_netdev.changed or guest_br0_network.changed
+
 - name: Restart machine if needed
   hosts:
     - cluster_machines

--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -11,16 +11,64 @@
   tasks:
     - name: Remove team0 bridge in OVS
       command: "/usr/bin/ovs-vsctl --if-exists del-br team0"
-    - name: Create team0 bridge in OVS
-      command: "/usr/bin/ovs-vsctl add-br team0"
-    - name: Enable RSTP on team0 bridge
-      command: "/usr/bin/ovs-vsctl set Bridge team0 rstp_enable=true"
-    - name: Set RSTP priority on team0 bridge
-      command: "/usr/bin/ovs-vsctl set Bridge team0 other_config=rstp-priority={{ br_rstp_priority }}"
-    - name: Add interface team0_0 to team0 bridge
-      command: "/usr/bin/ovs-vsctl -- --if-exists del-port {{ team0_0 }} -- add-port team0 {{ team0_0 }}"
-    - name: Add interface team0_1 to team0 bridge
-      command: "/usr/bin/ovs-vsctl -- --if-exists del-port {{ team0_1 }} -- add-port team0 {{ team0_1 }}"
+    - block:
+      - name: Populate service facts
+        service_facts:
+      - name: stop and disable hsr service if it exists
+        service:
+          name: "hsr"
+          state: stopped
+          enabled: false
+        when: "'hsr.service' in services"
+      - name: Create team0 bridge in OVS
+        command: "/usr/bin/ovs-vsctl add-br team0"
+      - name: Enable RSTP on team0 bridge
+        command: "/usr/bin/ovs-vsctl set Bridge team0 rstp_enable=true"
+      - name: Set RSTP priority on team0 bridge
+        command: "/usr/bin/ovs-vsctl set Bridge team0 other_config=rstp-priority={{ br_rstp_priority }}"
+      - name: Add interface team0_0 to team0 bridge
+        command: "/usr/bin/ovs-vsctl -- --if-exists del-port {{ team0_0 }} -- add-port team0 {{ team0_0 }}"
+      - name: Add interface team0_1 to team0 bridge
+        command: "/usr/bin/ovs-vsctl -- --if-exists del-port {{ team0_1 }} -- add-port team0 {{ team0_1 }}"
+      when: cluster_protocol is not defined or cluster_protocol != "HSR" or hsr_mac_address is not defined
+    - block:
+      - name: copy hsr.sh script
+        template:
+          src: ../src/debian/hsr.sh.j2
+          dest: /usr/local/sbin/hsr.sh
+          mode: 0755
+          owner: root
+          group: root
+        register: hsr1
+      - name: copy hsrstop.sh script
+        template:
+          src: ../src/debian/hsrstop.sh.j2
+          dest: /usr/local/sbin/hsrstop.sh
+          mode: 0755
+          owner: root
+          group: root
+        register: hsr2
+      - name: copy hsr systemd service file
+        ansible.builtin.copy:
+          src: ../src/debian/hsr.service
+          dest: /etc/systemd/system/hsr.service
+          mode: '0644'
+        register: hsr3
+      - name: daemon-reload hsr
+        ansible.builtin.service:
+          daemon_reload: yes
+        when: hsr1.changed or hsr2.changed or hsr3.changed
+      - name: enable hsr.service
+        ansible.builtin.systemd:
+          name: hsr.service
+          enabled: yes
+        register: hsrservice
+      - name: Restart hsr
+        ansible.builtin.systemd:
+          name: hsr
+          state: restarted
+        when: hsr1.changed or hsr2.changed or hsr3.changed or hsrservice.changed
+      when: cluster_protocol is defined and cluster_protocol == "HSR" and hsr_mac_address is defined
 
 - name: Configure OVS
   hosts:

--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -231,7 +231,7 @@
         name: "systemd-timesyncd"
         state: stopped
         enabled: false
-      when: "'systemd-timesyncd' in services"
+      when: "'systemd-timesyncd.service' in services"
     - name: Create timemaster configuration
       template:
         src: ../templates/timemaster.conf.j2

--- a/roles/debian/physical_machine/tasks/main.yml
+++ b/roles/debian/physical_machine/tasks/main.yml
@@ -97,6 +97,23 @@
     - "--chmod=F755"
     - "--chown=root:root"
 
+- name: Copy chrony-wait.service
+  template:
+    src: ../src/debian/chrony-wait.service.j2
+    dest: /etc/systemd/system/chrony-wait.service
+    owner: root
+    group: root
+    mode: '0644'
+  register: chronywait
+- name: daemon-reload chrony-wait.service
+  ansible.builtin.service:
+    daemon_reload: yes
+  when: chronywait.changed
+- name: enable chrony-wait.service
+  ansible.builtin.systemd:
+    name: chrony-wait.service
+    enabled: yes
+
 - name: Create libvirtd.service.d directory
   file:
     path: /etc/systemd/system/libvirtd.service.d/

--- a/src/debian/chrony-wait.service.j2
+++ b/src/debian/chrony-wait.service.j2
@@ -1,0 +1,46 @@
+[Unit]
+Description=Wait for chrony to synchronize system clock
+Documentation=man:chronyc(1)
+After=timemaster.service
+Requires=timemaster.service
+Before=time-sync.target
+Wants=time-sync.target
+
+[Service]
+Type=oneshot
+# Wait for chronyd to update the clock and the remaining
+# correction to be less than 0.1 seconds
+ExecStart=/usr/bin/chronyc -h 127.0.0.1,::1 waitsync 0 0.1 0.0 1
+# Wait for at most chrony_wait_timeout_sec seconds
+TimeoutStartSec={{ chrony_wait_timeout_sec }}
+RemainAfterExit=yes
+StandardOutput=null
+
+CapabilityBoundingSet=
+DevicePolicy=closed
+DynamicUser=yes
+IPAddressAllow=localhost
+IPAddressDeny=any
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+PrivateDevices=yes
+PrivateUsers=yes
+ProtectClock=yes
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectProc=invisible
+ProtectSystem=strict
+RestrictAddressFamilies=AF_INET AF_INET6
+RestrictNamespaces=yes
+RestrictRealtime=yes
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources
+UMask=0777
+
+[Install]
+WantedBy=multi-user.target

--- a/src/debian/hsr.service
+++ b/src/debian/hsr.service
@@ -1,0 +1,17 @@
+# Copyright (C) 2021, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+[Unit]
+Description="configure HSR interface for cluster network"
+Before=basic.target
+After=local-fs.target sysinit.target
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/usr/local/sbin/hsr.sh
+ExecStop=/usr/local/sbin/hsrstop.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/src/debian/hsr.sh.j2
+++ b/src/debian/hsr.sh.j2
@@ -1,0 +1,21 @@
+#!/bin/bash
+ETH0={{ team0_0 }}
+ETH1={{ team0_1 }}
+PRP=hsr0
+MTU=9000
+MAC={{ hsr_mac_address }}
+IP={{ cluster_ip_addr }}/24
+SUPERVISION=45
+ip link set dev $PRP  down
+ip link del dev $PRP
+ip link set dev $ETH0 down
+ip link set dev $ETH1 down
+ip link set dev $ETH0 mtu $MTU
+ip link set dev $ETH1 mtu $MTU
+ip link set dev $ETH0 address $MAC
+ip link set dev $ETH1 address $MAC
+ip link set dev $ETH0 up
+ip link set dev $ETH1 up
+ip link add name $PRP type hsr slave1 $ETH0 slave2 $ETH1 supervision $SUPERVISION proto 0 version 1
+ip a add dev $PRP $IP
+ip link set dev $PRP up

--- a/src/debian/hsrstop.sh.j2
+++ b/src/debian/hsrstop.sh.j2
@@ -1,0 +1,8 @@
+#!/bin/bash
+ETH0={{ team0_0 }}
+ETH1={{ team0_1 }}
+PRP=hsr0
+ip link set dev $PRP  down
+ip link del dev $PRP
+ip link set dev $ETH0 down
+ip link set dev $ETH1 down

--- a/src/debian/pacemaker_override.conf.j2
+++ b/src/debian/pacemaker_override.conf.j2
@@ -1,7 +1,6 @@
 [Unit]
-After=rbdmap.service
-After=libvirt-guests.service
-After=ceph.target
+Wants=libvirtd.service
+After=libvirtd.service
 
 [Install]
 WantedBy=corosync.service

--- a/templates/00-GUESTtap.netdev.j2
+++ b/templates/00-GUESTtap.netdev.j2
@@ -1,0 +1,3 @@
+[NetDev]
+Name={{ item.key }}tap
+Kind=tap

--- a/templates/00-GUESTtap.network.j2
+++ b/templates/00-GUESTtap.network.j2
@@ -1,0 +1,22 @@
+[Match]
+Name={{ item.key }}tap
+
+[Network]
+Bridge=br0
+
+[BridgeVLAN]
+{% if item.value.__class__.__name__ == 'list' %}
+{% if item.value|length==0 %}
+VLAN=1-4094
+PVID=4094
+EgressUntagged=4094
+{% else %}
+{% for vid in item.value %}
+VLAN={{ vid }}
+{% endfor %}
+{% endif %}
+{% else %}
+VLAN={{ item.value }}
+PVID={{ item.value }}
+EgressUntagged={{ item.value }}
+{% endif %}

--- a/templates/ovs_configuration.json.j2
+++ b/templates/ovs_configuration.json.j2
@@ -1,2 +1,8 @@
-{% set OVS_configuration = ({ "bridges": ovs_bridges, "ignored_bridges": ignored_bridges | default([]), "unbind_pci_address": unbind_pci_address | default([]) }) %}
+{% set taps=[] %}
+{%- if guests_on_br0 is defined %}
+{%- for guest, vlan in guests_on_br0.items() %}
+{{- taps.append(guest+'tap') or "" }}
+{%- endfor %}
+{%- endif %}
+{% set OVS_configuration = ({ "bridges": ovs_bridges, "ignored_bridges": ignored_bridges | default([]), "ignored_taps": taps | default([]), "unbind_pci_address": unbind_pci_address | default([]) }) %}
 {{ OVS_configuration | to_nice_json }}

--- a/templates/systemd-networkd-wait-online.service.j2
+++ b/templates/systemd-networkd-wait-online.service.j2
@@ -1,3 +1,3 @@
 [Service]
 ExecStart=
-ExecStart=/lib/systemd/systemd-networkd-wait-online -i br0 -i team0
+ExecStart=/lib/systemd/systemd-networkd-wait-online -i {{ 'vlan'+br0vlan|string if br0vlan is defined else 'br0' }} -i {{ 'hsr0' if cluster_protocol is defined and cluster_protocol == 'HSR' else 'team0' }}

--- a/vars/network_vars.yml
+++ b/vars/network_vars.yml
@@ -5,23 +5,63 @@
 systemd_networkd_network_custom: "{{ custom_network | default([]) }}"
 systemd_networkd_netdev_custom: "{{ custom_netdev | default([]) }}"
 
-wired_systemd_networkd_netdev:
+br0vlan_systemd_networkd_netdev:
+  00-br0:
+    - NetDev:
+        - Name: "br0"
+        - Kind: "bridge"
+    - Bridge:
+        - DefaultPVID: "none"
+        - VLANFiltering: "yes"
+  00-br0vlan:
+    - NetDev:
+        - Name: "vlan{{ br0vlan | default('') }}"
+        - Kind: "vlan"
+    - VLAN:
+        - Id: "{{ br0vlan | default('') }}"
+br0vlan_systemd_networkd_network:
+  00-br0vlan:
+    - Match:
+        - Name: "vlan{{ br0vlan | default('') }}"
+    - Network:
+        - Gateway: "{{ gateway_addr }}"
+        - Address: "{{ ip_addr }}/{{ subnet | default(24) }}"
+  00-br0:
+    - Match:
+        - Name: "br0"
+    - Network:
+        - VLAN: "vlan{{ br0vlan | default('') }}"
+    - BridgeVLAN:
+        - VLAN: "{{ br0vlan | default('') }}"
+  00-wired:
+    - Match:
+        - Name: "{{ network_interface }}"
+    - Network: "{{ [ {'Bridge': 'br0'} ] + extra_network_config | default([]) }}"
+    - BridgeVLAN:
+        - VLAN: 159
+        - PVID: 4094
+        - EgressUntagged: 4094
+
+br0_systemd_networkd_netdev:
   00-br0:
     - NetDev:
         - Name: "br0"
         - Kind: "bridge"
 
-wired_systemd_networkd_network:
-  01-br0:
+br0_systemd_networkd_network:
+  00-br0:
     - Match:
         - Name: "br0"
     - Network:
         - Gateway: "{{ gateway_addr }}"
         - Address: "{{ ip_addr }}/{{ subnet | default(24) }}"
-  01-wired:
+  00-wired:
     - Match:
         - Name: "{{ network_interface }}"
     - Network: "{{ [ {'Bridge': 'br0'} ] + extra_network_config | default([]) }}"
+
+wired_systemd_networkd_netdev: "{{ br0vlan_systemd_networkd_netdev if br0vlan is defined else br0_systemd_networkd_netdev }}"
+wired_systemd_networkd_network: "{{ br0vlan_systemd_networkd_network if br0vlan is defined else br0_systemd_networkd_network }}"
 
 systemd_networkd_netdev_nocluster: "{{ wired_systemd_networkd_netdev | combine(systemd_networkd_netdev_custom) }}"
 systemd_networkd_network_nocluster: "{{ wired_systemd_networkd_network | combine(systemd_networkd_network_custom) }}"
@@ -43,5 +83,5 @@ team0_systemd_networkd_network:
     - Link:
         - MTUBytes: 1800
 
-systemd_networkd_network: "{% if cluster_ip_addr is defined %}{{ systemd_networkd_network_nocluster|combine(team0_systemd_networkd_network) }}{% else %}{{ systemd_networkd_network_nocluster}}{% endif %}"
+systemd_networkd_network: "{{ systemd_networkd_network_nocluster|combine(team0_systemd_networkd_network) if cluster_ip_addr is defined else systemd_networkd_network_nocluster}}"
 systemd_networkd_netdev: "{{ systemd_networkd_netdev_nocluster }}"


### PR DESCRIPTION
**example inventory: cleanup + add SR-IOV example**

----
**add support for vlan on br0**

Seapath configures the main network interface of the host in a bridge called br0. This is to allow a Guest to easily bridge on this interface, to give that guest easy remote access. 
In some network topologies, this main host network interface is a trunk, and the host need to support vlan tagging to get access to the network. 
This commit makes this topology supported, throught the use of the "br0vlan" configuration variable (in which the user simply has to set the vlanid number).

Then we have to provide a way to configure the guests access to br0. 
This is now possible with the "guest_on_br0" variable in which we define the tap interfaces for the guests (port access or trunk are possible). The user will then only have to configure its guests (livbirt xml) to use those taps, exactly like what we do with OVS, like this:
 ```
    <interface type="ethernet">
      <target dev="GUESTtap" managed="no"/>
      <model type="virtio" />
      <address type="pci" domain="0x0000" bus="0x00" slot="0x01" function="0x0" />
    </interface>
```

----
**add support for HSR for cluster network**

Debian 12 comes with a backported kernel including the HSR module, allowing to use HSR for cluster networking instead of RSTP.
This commit make it possible to choose between the two.

----
**systemd ordering: add chrony-wait to time-sync.target**

Many services depends on the time-sync.target (ceph, pacemaker...). However the time-sync.target is not linked to anything right now. This commit add the chrony-wait service, inspired from what's coming in chrony with debian12, to the time-sync.target.
This means ceph and pacemaker will wait for chrony to be synced.
Also we make pacemaker depend on libvirtd, just to be sure the system is able to run guests before we launch pacemaker.

----
**solves bug in disabling systemd-timesyncd**

----
**example inventory: network reboot params documentation**