### PR TITLE
VirtualDomain RA: deal with 2 nodes down

### DIFF
--- a/library/cluster_vm.py
+++ b/library/cluster_vm.py
@@ -123,6 +123,11 @@ options:
       - Unix account to be used to connect using SSH to the destination host
       - Optional parameter relevant only if I(command) is C(create) or C(clone)
     type: str
+  stop_timeout:
+    description:
+      - Time given to a guest to stop (in seconds)
+      - Optional parameter relevant only if I(command) is C(create) or C(clone)
+    type: str
   migrate_to_timeout:
     description:
       - Time given to a guest to live migrate (in seconds)
@@ -457,6 +462,7 @@ def run_module():
         pinned_host=dict(type="str", require=False),
         live_migration=dict(type="bool", require=False),
         migration_user=dict(type="str", require=False),
+        stop_timeout=dict(type="str", require=False),
         migrate_to_timeout=dict(type="str", require=False),
         clear_constraint=dict(type="bool", required=False, default=False),
         strong=dict(type="bool", required=False, default=False),
@@ -510,6 +516,7 @@ def run_module():
     pinned_host = args.get("pinned_host", None)
     live_migration = args.get("live_migration", None)
     migration_user = args.get("migration_user", None)
+    stop_timeout = args.get("stop_timeout", None)
     migrate_to_timeout = args.get("migrate_to_timeout", None)
     clear_constraint = args.get("clear_constraint", False)
     strong_constraint = args.get("strong", False)
@@ -547,6 +554,7 @@ def run_module():
                 pinned_host=pinned_host,
                 live_migration=live_migration,
                 migration_user=migration_user,
+                stop_timeout=stop_timeout,
                 migrate_to_timeout=migrate_to_timeout,
                 crm_config_cmd=crm_config_cmd,
             )
@@ -562,6 +570,7 @@ def run_module():
                 pinned_host=pinned_host,
                 live_migration=live_migration,
                 migration_user=migration_user,
+                stop_timeout=stop_timeout,
                 migrate_to_timeout=migrate_to_timeout,
                 clear_constraint=clear_constraint,
             )

--- a/src/debian/pacemaker_ra/VirtualDomain
+++ b/src/debian/pacemaker_ra/VirtualDomain
@@ -875,25 +875,39 @@ VirtualDomain_stop() {
 				if [ -n "${OCF_RESKEY_CRM_shutdown_mode}" ]; then
 					shutdown_opts="--mode ${OCF_RESKEY_CRM_shutdown_mode}"
 				fi
-				virsh $VIRSH_OPTIONS shutdown ${DOMAIN_NAME} $shutdown_opts
+				ocf_log info "virsh $VIRSH_OPTIONS shutdown ${DOMAIN_NAME} $shutdown_opts"
+				timeout 1s virsh $VIRSH_OPTIONS shutdown ${DOMAIN_NAME} $shutdown_opts
+				virsh_timeout_status=$?
+				if [ $virsh_timeout_status -eq 124 ] #timeout, there's something wrong with the guest
+				then
+					# Something went wrong, break from switch case, and resort to forced stop (destroy).
+					ocf_log info "${DOMAIN_NAME} shutdown problem, force_stop"
+					force=1
+				else
+					force=0
+				fi
 			fi
 
 			# The "shutdown_timeout" we use here is the operation
-			# timeout specified in the CIB, minus 12 seconds
-			shutdown_timeout=$(( $NOW + ($OCF_RESKEY_CRM_meta_timeout/1000) -12 ))
+			# timeout specified in the CIB, minus 17 seconds (because it has been seen cases where the destroy operation takes more than 15s)
+			shutdown_timeout=$(( $NOW + ($OCF_RESKEY_CRM_meta_timeout/1000) -17 ))
 			# Loop on status until we reach $shutdown_timeout
-			while [ $NOW -lt $shutdown_timeout ]; do
+                        ocf_log info "${DOMAIN_NAME} shutdown_timeout=$shutdown_timeout, NOW=$NOW"
+			while [ $NOW -lt $shutdown_timeout -a $force -ne 1 ]; do
 				VirtualDomain_status
 				status=$?
+                                ocf_log info "${DOMAIN_NAME} VirtualDomain_status $status"
 				case $status in
 					$OCF_NOT_RUNNING)
 						# This was a graceful shutdown.
+                                                ocf_log info "${DOMAIN_NAME} This was a graceful shutdown."
 						return $OCF_SUCCESS
 						;;
 					$OCF_SUCCESS)
 						# Domain is still running, keep
 						# waiting (until shutdown_timeout
 						# expires)
+                                                ocf_log info "${DOMAIN_NAME} sleep 1."
 						sleep 1
 						;;
 					*)
@@ -912,6 +926,7 @@ VirtualDomain_stop() {
 	# OK. Now if the above graceful shutdown hasn't worked, kill
 	# off the domain with destroy. If that too does not work,
 	# have the LRM time us out.
+        ocf_log info "${DOMAIN_NAME} force_stop"
 	force_stop
 }
 


### PR DESCRIPTION
When we stop 2 nodes, the remaining node is not supposed to run any guest. In our current setup, that means the remaining node will try to gracefully stop the running nodes it has. But the problem is that ceph is not available anymore if 2 nodes are missing, so the disks of the guests are not available. Gracefully shutting the vm will not be possible + we noticed some non-reliable behavior when the storage layer is missing. In some cases, "virsh shutdown" will take 30s to a minute to return, which is not compatible with the pacemaker resource agent (pacemaker will timeout after 25sec, so the virsh destroy will not have been sent...). For this problem, this commit makes the pacemaker VirtualDomain RA timeout the "virsh shutdown" command after 1 sec. If the timeout has been reached, then we move directly to a "virsh destroy". This commits also adds more logging/debug to the VirtualDomain RA.

It also has been seen cases for which "virsh destroy" takes a little more than 15s (10seconds for libvirt to try a SIGTERM then a SIGKILL, and 5 more seconds for virtual devices cleaning (networking, PCI, SR-IOV), etc. Hence we should increase the "destroy" timeout of the virtualdomain resource agent from 12 to 17. In a future commit, we might want to make this timeout also configurable. The total stop timeout must then also be increased of 5 sec (25 --> 30s): this is done with an evolution of vm_manager.

This commit also makes this stop_timeout configurable for guests that would need more than 30-17 = 13s to gracefully shutdown.