### PR TITLE
virt-df.sh: adds lvm compatibility (backport debian11)

### DIFF
--- a/roles/debian/physical_machine/tasks/main.yml
+++ b/roles/debian/physical_machine/tasks/main.yml
@@ -323,3 +323,10 @@
   command:
     cmd: /usr/sbin/update-initramfs -u
   when: udevlvm.changed or lvm_snapshot_rebooter.changed
+
+- name: "add rbd type to lvm.conf"
+  ansible.builtin.lineinfile:
+    path: /etc/lvm/lvm.conf
+    insertafter: 'devices {'
+    line: "        types = [ \"rbd\", 1024 ]"
+    state: present

--- a/src/debian/virt-df.sh
+++ b/src/debian/virt-df.sh
@@ -1,21 +1,45 @@
 #!/bin/bash
 for devname in /dev/rbd*
 do
-  rbd unmap $devname 2>/dev/null
+  /usr/bin/rbd unmap $devname 2>/dev/null
 done
-for guest in `virsh --connect qemu:///system list --all | awk 'NR>2 { print $2 }' | sed /^$/d`
+for guest in `virsh --connect qemu:///system list --all | /usr/bin/awk 'NR>2 { print $2 }' | sed /^$/d`
 do
   mkdir -p /t
   /usr/bin/umount /t 2>/dev/null
-  devname=`rbd map --read-only system_"$guest"`
+  /usr/sbin/lvs > /tmp/lvs1
+  devname=`/usr/bin/rbd map --read-only system_"$guest"`
+  /usr/sbin/lvs 2>/dev/null > /tmp/lvs2
+  sort < /tmp/lvs1 | /usr/bin/awk '{ print $1 " " $2 " " $4 }' > /tmp/lvs1.sorted
+  sort < /tmp/lvs2 | /usr/bin/awk '{ print $1 " " $2 " " $4 }' > /tmp/lvs2.sorted
+  declare -A lvsdiff
+  while IFS="," read -r a b; do
+    b=$(echo $b | sed 's/ *$//g')
+    lvsdiff["$a"]="$b"
+  done < <(comm -13 /tmp/lvs1.sorted /tmp/lvs2.sorted | /usr/bin/awk '{ print $1 "," $2 }')
+  rm -f /tmp/lvs1 /tmp/lvs2 /tmp/lvs1.sorted /tmp/lvs2.sorted
+  for lvname in "${!lvsdiff[@]}"
+  do
+    vgname=${lvsdiff[$lvname]}
+    #echo "lvname is '$lvname'  => vgname is '$vgname'"
+    /usr/sbin/lvchange -ay /dev/$vgname/$lvname
+    /usr/bin/mount -o ro,noload /dev/$vgname/$lvname /t 2>/dev/null
+    returncode=$?
+    if [ $returncode -eq 0 ]; then
+      /usr/bin/df -k | grep -E "\/t$" | /usr/bin/awk -v guest="$guest" '{ print guest ":" $1 " total:" $2 " used:" $3 " available:" $4 " disk-usage:" $5 }'
+    fi
+    /usr/bin/umount /t 2>/dev/null
+    /usr/sbin/lvchange -an /dev/$vgname/$lvname
+  done
+  unset lvsdiff
   for part in $devname"p"*
   do
     /usr/bin/mount -o ro,noload $part /t 2>/dev/null
     returncode=$?
     if [ $returncode -eq 0 ]; then
-  	  df -k | grep $part | awk -v guest="$guest" '{ print guest ":" $1 " total:" $2 " used:" $3 " available:" $4 " disk-usage:" $5 }'
+      /usr/bin/df -k | grep -E "\/t$" | /usr/bin/awk -v guest="$guest" '{ print guest ":" $1 " total:" $2 " used:" $3 " available:" $4 " disk-usage:" $5 }'
     fi
     /usr/bin/umount /t 2>/dev/null
   done
-  rbd unmap $devname
+  /usr/bin/rbd unmap $devname
 done


### PR DESCRIPTION
virt-df.sh makes it possible for the hypervisors to retrieve the disk occupation of the guests (by mounting the rbd readonly). This commits adds compatibility for lvm on guests.