### PR TITLE
syslog: remove old syslog config in network playbook

### DIFF
--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -280,33 +280,6 @@
         state: stopped
         enabled: false
 
-- name: Configure syslog-ng
-  hosts:
-    - cluster_machines
-    - standalone_machine
-    - VMs
-  become: true
-  tasks:
-    - name: Set observer IP address in /etc/syslog-ng/syslog-ng.conf
-      lineinfile:
-        dest: /etc/syslog-ng/syslog-ng.conf
-        regexp: '(^\s*#?\s*(ip\()?)("[1-9][0-9]{2}(\.[0-9]{1,3}){3}")(\))?'
-        line: '\1"{{ syslog_server_ip }}"\5'
-        backrefs: true
-        state: present
-      notify:
-        - Restart systemd syslog-ng
-
-  handlers:
-    - name: Restart systemd syslog-ng
-      vars:
-        apply_config: "{{ apply_network_config | default(false) }}"
-      ansible.builtin.service:
-        name: syslog-ng@default
-        state: restarted
-      when:
-        apply_config
-
 - name: Configure systemd-networkd-wait-online.service
   hosts:
     - cluster_machines


### PR DESCRIPTION
Syslog configuration is done in ansible/roles/debian/tasks/main.yml.
This commit removes a syslog configuration task in the network playbook.