### PR TITLE
Adds HTTP API to vm_manager (backport debian11)

### DIFF
--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -280,12 +280,14 @@ all:
         livemigration_user: livemigration
 
         #pacemaker_shutdown_timeout: "2min"
+        #enable_vmmgr_http_api: false
+        #cluster_ip: 10.10.11.4 # IP the vm-mgr http api will bind on
         extra_crm_cmd_to_run:
           # for ntp status monitoting, be sure host_ip is the ip address of the server and not its hostname
-          - primitive ntpstatus_test ocf:seapath:ntpstatus params host_ip=10.10.10.10 multiplier=500 op monitor timeout=10 interval=10
-          - primitive ptpstatus_test ocf:seapath:ptpstatus op monitor timeout=10 interval=10 op_params multiplier=1000
-          - clone cl_ntpstatus_test ntpstatus_test meta target-role=Started
-          - clone cl_ptpstatus_test ptpstatus_test meta target-role=Started
+          - "primitive ntpstatus_test ocf:seapath:ntpstatus params host_ip=10.10.10.10 multiplier=500 op monitor timeout=10 interval=10"
+          - "primitive ptpstatus_test ocf:seapath:ptpstatus op monitor timeout=10 interval=10 op_params multiplier=1000"
+          - "clone cl_ntpstatus_test ntpstatus_test meta target-role=Started"
+          - "clone cl_ptpstatus_test ptpstatus_test meta target-role=Started"
 
         # if br0vlan is set, then the host's remote access network ip is on a vlan, but a trunk port has been given to the host so that guests can connect to other vlans. You create the interfaces for those guests here:
         guests_on_br0:

--- a/playbooks/cluster_setup_ha.yaml
+++ b/playbooks/cluster_setup_ha.yaml
@@ -130,3 +130,16 @@
         no_log: true
         failed_when: 0 == 1
         loop: "{{ extra_crm_cmd_to_run }}"
+      - name: run extra CRM configuration commands for vm-mgr http api
+        command: "/usr/sbin/crm configure {{ item }}"
+        when:
+          - enable_vmmgr_http_api is defined
+          - enable_vmmgr_http_api is true
+          - cluster_ip is defined
+        run_once: true
+        no_log: true
+        failed_when: 0 == 1
+        loop:
+          - "primitive ClusterIP IPaddr2 params ip={{ cluster_ip }} cidr_netmask=32 op monitor interval=30s meta target-role=Started"
+          - "primitive vmmgrapi systemd:vmmgrapidocker.service"
+          - "colocation vmmgrapi_colocation inf: ClusterIP vmmgrapi"

--- a/roles/debian/physical_machine/tasks/main.yml
+++ b/roles/debian/physical_machine/tasks/main.yml
@@ -330,3 +330,73 @@
     insertafter: 'devices {'
     line: "        types = [ \"rbd\", 1024 ]"
     state: present
+
+- name: install vm-mgr http interface
+  block:
+    - name: create /var/local/vmmgrapi folder on hosts
+      file:
+        path: /var/local/vmmgrapi
+        state: directory
+        mode: '0755'
+    - name: Copy vmmgrapi docker files
+      ansible.builtin.copy:
+        src: ../src/debian/vmmgrapi_docker/{{ item }}
+        dest: /var/local/vmmgrapi/{{ item }}
+        mode: '0644'
+      with_items:
+        - api.php
+      register: vmmgrapidocker_files
+    - name: Copy vmmgrapi docker templates
+      ansible.builtin.template:
+        src: ../src/debian/vmmgrapi_docker/{{ item }}.j2
+        dest: /var/local/vmmgrapi/{{ item }}
+        mode: '0644'
+      with_items:
+        - compose-vmmgrapi.yml
+      register: vmmgrapidocker_templates
+    - name: Copy vmmgrapi pipe run files
+      ansible.builtin.copy:
+        src: ../src/debian/vmmgrapi_docker/{{ item }}
+        dest: /usr/local/bin/{{ item }}
+        mode: '0755'
+      with_items:
+        - vmmgrapipiperun.sh
+      register: vmmgrapipiperun_files
+
+    - name: Copy vmmgrapi pipe run service
+      ansible.builtin.copy:
+        src: ../src/debian/vmmgrapi_docker/vmmgrapipiperun.service
+        dest: /etc/systemd/system/vmmgrapipiperun.service
+        mode: '0644'
+      register: vmmgrapipiperun_service
+    - name: Copy vmmgrapi apache php docker service
+      ansible.builtin.copy:
+        src: ../src/debian/vmmgrapi_docker/vmmgrapidocker.service
+        dest: /etc/systemd/system/vmmgrapidocker.service
+        mode: '0644'
+      register: vmmgrapidocker_service
+
+    - name: daemon-reload vmmgrapi
+      ansible.builtin.service:
+        daemon_reload: yes
+      when: vmmgrapipiperun_service.changed or vmmgrapidocker_service.changed
+
+  when: enable_vmmgr_http_api is defined and enable_vmmgr_http_api is true
+
+- name: disable vm-mgr http interface if needed
+  block:
+    - name: Populate service facts
+      service_facts:
+    - name: stop and disable vmmgrapipiperun.service
+      ansible.builtin.systemd:
+        name: vmmgrapipiperun.service
+        enabled: no
+        state: stopped
+      when: "'vmmgrapipiperun.service' in services"
+    - name: stop and disable vmmgrapidocker.service
+      ansible.builtin.systemd:
+        name: vmmgrapidocker.service
+        enabled: no
+        state: stopped
+      when: "'vmmgrapidocker.service' in services"
+  when: enable_vmmgr_http_api is not defined or enable_vmmgr_http_api is false

--- a/src/debian/vmmgrapi_docker/api.php
+++ b/src/debian/vmmgrapi_docker/api.php
@@ -1,0 +1,16 @@
+<?php
+if ((isset($_GET["cmd"])) and (isset($_GET["code"]))) {
+  $code = htmlspecialchars($_GET["code"]);
+  $cmd = htmlspecialchars($_GET["cmd"]);
+  if (is_string($cmd) and is_string($code)) {
+    if (preg_match("#^vm-mgr [a-zA-Z0-9 \-_/]+$#", $cmd)) {
+      $pipe = "/run/vmmgr.pipe";
+      system("echo \"$code$cmd\" >$pipe",$retval);
+      $fpipe=fopen($pipe,'r');
+      $output=fread($fpipe,10000);
+      fclose($fpipe);
+      echo "$output\n";
+    }
+  }
+}
+?>

--- a/src/debian/vmmgrapi_docker/compose-vmmgrapi.yml.j2
+++ b/src/debian/vmmgrapi_docker/compose-vmmgrapi.yml.j2
@@ -1,0 +1,11 @@
+version: '3.6'
+
+services:
+  vmmgrapi:
+    image: php:apache
+    container_name: vmmgrapi
+    ports:
+      - {{ cluster_ip }}:8080:80
+    volumes:
+      - /run/vmmgr.pipe:/run/vmmgr.pipe
+      - /var/local/vmmgrapi/api.php:/var/www/html/api.php:ro

--- a/src/debian/vmmgrapi_docker/vmmgrapidocker.service
+++ b/src/debian/vmmgrapi_docker/vmmgrapidocker.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=docker apache/php for serving vm-mgr api
+Requires=vmmgrapipiperun.service
+After=vmmgrapipiperun.service
+
+[Service]
+Restart=always
+
+Environment="COMPOSE_PROJECT_NAME=vmmgrapi"
+Environment="COMPOSE_FILE=/var/local/vmmgrapi/compose-vmmgrapi.yml"
+
+ExecStartPre=-/usr/bin/bash -c '/usr/bin/sleep 1; docker ps -aq -f status=dead -f status=exited | xargs -r docker rm -f'
+ExecStart=/usr/bin/docker-compose -p ${COMPOSE_PROJECT_NAME} -f ${COMPOSE_FILE} up
+ExecStop=/usr/bin/docker-compose -p ${COMPOSE_PROJECT_NAME} -f ${COMPOSE_FILE} stop
+ExecReload=/usr/bin/docker-compose -p ${COMPOSE_PROJECT_NAME} -f ${COMPOSE_FILE} restart
+
+[Install]
+WantedBy=multi-user.target

--- a/src/debian/vmmgrapi_docker/vmmgrapipiperun.service
+++ b/src/debian/vmmgrapi_docker/vmmgrapipiperun.service
@@ -1,0 +1,11 @@
+[Unit]
+Description="run vm-mgr api pipe cmds"
+PartOf=vmmgrapidocker.service
+
+[Service]
+Restart=always
+Type=simple
+ExecStart=/usr/local/bin/vmmgrapipiperun.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/src/debian/vmmgrapi_docker/vmmgrapipiperun.sh
+++ b/src/debian/vmmgrapi_docker/vmmgrapipiperun.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+pipe=/run/vmmgr.pipe
+uid=33 #UID of the apache user
+secret=$(/usr/bin/cat /vmmgrapi.secret)
+
+while true
+do
+  if [ ! -p ${pipe} ]
+  then
+    /usr/bin/rm -rf ${pipe}
+    /usr/bin/mkfifo ${pipe}
+  fi
+  uid1="$(/usr/bin/stat -c '%u' "${pipe}")"
+  if [ ${uid1} -ne "${uid}" ]
+  then
+    /usr/bin/chown ${uid} ${pipe}
+  fi
+  p="$(/usr/bin/cat ${pipe})"
+  code=$(/usr/bin/echo ${p} | /usr/bin/cut -c-30)
+  cmd=$(/usr/bin/echo ${p} | /usr/bin/cut -c31-)
+
+  if [ "${code}" == "${secret}" ]
+  then
+    eval "/usr/bin/timeout 10s ${cmd}" >$pipe 2>&1
+  else
+    echo "dont try to hack me" >$pipe
+  fi
+done


### PR DESCRIPTION
This commit will add way to control vm-manager with an HTTP request on any node.

1) A docker container running apache-php will listen on port 8080
   It will wait for the command to run and for a security code.
   It will not check the security code itself
   It will check the provided command to run starts with "vm-mgr" and only contains needed characters (to prevent command injection attacks)
   If all is correct, it will send the code and the requested command to a FIFO pipe (see step 2 now)
   Once sent, it will read the same FIFO pipe to wait for the return of the command
   It will then output the return of the command

2) A systemd service will read the fifo pipe in a loop
   at every loop, it will check the fifo pipe exists and has the correct permissions
   it will read the pipe and wait for a command
   Once the code+command arrive, it will check the provided security code is the same as the content of file /vmmgrapi.secret (this file has to be manually created by root on all nodes + chmod 600)
   it will then run the command, with a 10s timeout, and write the output of the command to the pipe

Both those services must be managed with pacemaker (they are linked systemd units).
In order to respect the bindind socket rule (that any service must bind on a specific IP address), Pacemaker must manage an IpAddr2 resource, colocated with the docker systemd service. The docker container will only listen to the "moving" ip address.
Examples are provided in the default inventory.