### PR TITLE
playbooks: add a playbook to run all Cukinia's tests

### DIFF
--- a/playbooks/ci_all_machines_tests.yaml
+++ b/playbooks/ci_all_machines_tests.yaml
@@ -1,0 +1,26 @@
+# Copyright (C) 2023 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Ansible playbook that runs all Cukinia's tests.
+
+---
+- hosts: "{{ machines_tested | default('cluster_machines') }}"
+  name: Cukinia tests
+  tasks:
+    - name: Create temporary Cukinia directory
+      tempfile:
+        state: directory
+      register: tmp_cukinia_dir
+    - name: Common tests
+      shell:
+        cmd: >-
+          MACHINENAME={{ cukinia_namespace | default(inventory_hostname) }}
+          cukinia -f junitxml -o {{ tmp_cukinia_dir.path }}/cukinia.xml
+          /etc/cukinia/cukinia.conf || true
+    - name: Fetch result
+      fetch:
+        src: '{{ tmp_cukinia_dir.path }}/cukinia.xml'
+        dest: >-
+          {{ cukinia_test_prefix | default('.') }}/all/{{ inventory_hostname
+          }}/cukinia.xml
+        flat: yes


### PR DESCRIPTION
The playbook will run all tests defined in /etc/cukinia/cukinia.conf.