### PR TITLE
hypervisor role: solved grub task bug

### DIFF
--- a/roles/debian/hypervisor/tasks/main.yml
+++ b/roles/debian/hypervisor/tasks/main.yml
@@ -92,8 +92,8 @@
 - name: "grub conf hypervisor"
   lineinfile:
     dest: /etc/default/grub
-    regexp: "^(GRUB_CMDLINE_LINUX=(?!.* {{ item }})\"[^\"]*)(\".*)"
-    line: '\1 {{ item }}\2'
+    regexp: '^(GRUB_CMDLINE_LINUX=(?:(?![" ]{{ item.split("=")[0] }}=?).)*"?)\s*(?:{{ item.split("=")[0] }}(?:=\S+)?\s*)?(.*")$'
+    line: '\1 {{ item.split("=")[0] + (("="+item.split("=")[1]) if item.split("=")|length>1 and item.split("=")[1] != None and item.split("=")[1] != "" else "") }} \2'
     state: present
     backrefs: yes
   register: updategrub1
@@ -101,8 +101,6 @@
     - processor.max_cstate=1
     - intel_idle.max_cstate=1
     - cpufreq.default_governor=performance
-    - hugepagesz=1G
-    - no_debug_objects
     - intel_pstate=disable
     - nosoftlockup
     - "rcu_nocbs={{ cpumachinesrt }}"
@@ -111,6 +109,15 @@
     - "isolcpus=nohz,domain,managed_irq,{{ cpumachinesrt }}"
     - skew_tick=1
     - tsc=reliable
+
+# Another way would be to use a dictionnary so that the regexp is a bit simpler
+#  lineinfile:
+#    regexp: '^(GRUB_CMDLINE_LINUX=(?:(?![" ]{{ item.key }}=?).)*"?)\s*(?:{{ item.key }}(?:=\S+)?\s*)?(.*")$'
+#    line: '\1 {{ item.key + ("="+item.value|string if item.value != None else "") }} \2'
+#  with_items:
+#    - processor.max_cstate: "1"
+#    - intel_idle.max_cstate: "1"
+#    - rcu_nocb_poll
 
 - name: update-grub
   command: update-grub


### PR DESCRIPTION
This commit makes it possible to change a value of a grub cmdline parameter. 
Before this commit "key=value1" and "key=value2" were considered as two different token, and so changing from value1 to value2 would just add "key=value2" over "key=value1".
This commit changed the regexp so that changing an existing key is possible..

This commit also removes hugepagesz=1G and no_debug_objects which are not useful for now.