### PR TITLE
ptp_vsock: fix the names of the files

### DIFF
--- a/src/debian/ptp_vsock.py
+++ b/src/debian/ptp_vsock.py
@@ -11,9 +11,9 @@ def client_handler(connection):
     data = connection.recv(2048)
     message = data.decode('utf-8')
     if message == 'STATUS':
-      file = open("/var/run/ptpstatus/ptp.status", "r")
+      file = open("/var/run/ptpstatus/ptp_state", "r")
     if message == 'DETAILS':
-      file = open("/var/run/ptpstatus/ptp.details", "r")
+      file = open("/var/run/ptpstatus/ptp_status", "r")
     data = file.read()
     connection.sendall(data.encode("utf-8"))
     connection.close()


### PR DESCRIPTION
ptp_status write in /var/run/ptpstatus/ptp_state and /var/run/ptpstatus/ptp_status https://github.com/seapath/ansible/blob/ad61ec896d9ebf3735110745d37dd2faa906f7eb/src/debian/ptpstatus/ptpstatus.service#L7

This commits fixes the names of the files the ptp_vsock service read of from (they should be the same).