### PR TITLE
debian role: add automatic mode to forced boot fsck

### DIFF
--- a/roles/debian/tasks/main.yml
+++ b/roles/debian/tasks/main.yml
@@ -206,6 +206,8 @@
   with_items:
     - ipv6.disable=1
     - efi=runtime
+    - fsck.mode=force
+    - fsck.repair=yes
     - "{{ grub_append | default([]) }}"
 
 - name: "grub conf osprober"


### PR DESCRIPTION
On industrial servers, we can assume the fsck repair needs to be done automatically if it ever needs to be done. 
See https://askubuntu.com/questions/1006417/automatically-force-fsck-fy-when-encountering-unexpected-inconsistency-run-fs