### PR TITLE
Multiple networking changes

### DIFF
--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -100,6 +100,12 @@
         - not apply_config
         - ovs_conf.changed
 
+    - name: run extra ovs-vsctl configuration commands
+      command: "/usr/bin/ovs-vsctl {{ item }}"
+      when:
+        - ovs_vsctl_cmds is defined
+      loop: "{{ ovs_vsctl_cmds }}"
+
 - name: Configure Network
   become: true
   hosts:

--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -9,11 +9,11 @@
   hosts: cluster_machines
   become: true
   tasks:
+    - name: Populate service facts
+      service_facts:
     - name: Remove team0 bridge in OVS
       command: "/usr/bin/ovs-vsctl --if-exists del-br team0"
     - block:
-      - name: Populate service facts
-        service_facts:
       - name: stop and disable hsr service if it exists
         service:
           name: "hsr"
@@ -22,14 +22,16 @@
         when: "'hsr.service' in services"
       - name: Create team0 bridge in OVS
         command: "/usr/bin/ovs-vsctl add-br team0"
-      - name: Enable RSTP on team0 bridge
-        command: "/usr/bin/ovs-vsctl set Bridge team0 rstp_enable=true"
-      - name: Set RSTP priority on team0 bridge
-        command: "/usr/bin/ovs-vsctl set Bridge team0 other_config=rstp-priority={{ br_rstp_priority }}"
       - name: Add interface team0_0 to team0 bridge
         command: "/usr/bin/ovs-vsctl -- --if-exists del-port {{ team0_0 }} -- add-port team0 {{ team0_0 }}"
       - name: Add interface team0_1 to team0 bridge
         command: "/usr/bin/ovs-vsctl -- --if-exists del-port {{ team0_1 }} -- add-port team0 {{ team0_1 }}"
+      - name: Change MacAddress of team0 bridge internal interface
+        command: "/usr/bin/ovs-vsctl set bridge team0 other-config:hwaddr=\\\"{{ '02:00:00' | community.general.random_mac(seed=inventory_hostname+'team0') }}\\\""
+      - name: Enable RSTP on team0 bridge
+        command: "/usr/bin/ovs-vsctl set Bridge team0 rstp_enable=true"
+      - name: Set RSTP priority on team0 bridge
+        command: "/usr/bin/ovs-vsctl set Bridge team0 other_config=rstp-priority={{ br_rstp_priority }}"
       when: cluster_protocol is not defined or cluster_protocol != "HSR" or hsr_mac_address is not defined
     - block:
       - name: copy hsr.sh script


### PR DESCRIPTION
Networking: change mac address of internal team0 interface

By default the team0 internal interface will have the same mac address as one of the physical interfaces.
This becomes a problem when using udev/networkd to customize the physical interface based on its mac address.
The internal interface needs its own mac address, that we can generate randomly.

----
Networking playbook: allow ovs-vsctl extra commands

Since votp-config_ovs destroys and recreate the whole OVS topology at every start, we need a way to persist specifities in the bridges configuration (for example: NetFlows exporters...). We introduce the inventory variable "ovs_vsctl_cmds" for this purpose.
