### PR TITLE
irqbalance: use IRQBALANCE_BANNED_CPULIST

### DIFF
--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -121,7 +121,7 @@ all:
                         logstash_server_ip: 10.10.10.10
 
                         # Realtime/CPUs cgroups isolation configuration
-                        irqmask: "ffeffe" #IRQBALANCE FORBIDDEN CPU, here it mean 0 and 12 are the only allowed cpus
+                        isolcpus: "2-5,14-17" # CPUs to isolate (isolcpus, irqbalance)
                         workqueuemask: "1001" #workqueue mask, here it mean 0 and 12 are the only allowed cpus
                         cpusystem: "0,12" # CPUs reserves for system
                         cpuuser: "1,13" # CPUs reserves for user applications

--- a/roles/debian/hypervisor/tasks/main.yml
+++ b/roles/debian/hypervisor/tasks/main.yml
@@ -103,10 +103,10 @@
     - cpufreq.default_governor=performance
     - intel_pstate=disable
     - nosoftlockup
-    - "rcu_nocbs={{ cpumachinesrt }}"
+    - "rcu_nocbs={{ isolcpus }}"
     - rcu_nocb_poll
     - rcutree.kthread_prio=10
-    - "isolcpus=nohz,domain,managed_irq,{{ cpumachinesrt }}"
+    - "isolcpus=nohz,domain,managed_irq,{{ isolcpus }}"
     - skew_tick=1
     - tsc=reliable
 
@@ -126,8 +126,8 @@
 - name: "irqbalance conf"
   lineinfile:
     dest: /etc/default/irqbalance
-    regexp: '^IRQBALANCE_BANNED_CPUS=".*"$'
-    line: 'IRQBALANCE_BANNED_CPUS="{{ irqmask }}"'
+    regexp: '^IRQBALANCE_BANNED_CPULIST=".*"$'
+    line: 'IRQBALANCE_BANNED_CPULIST="{{ isolcpus }}"'
     state: present
   register: irqbalanceconf
 - name: restart irqbalance


### PR DESCRIPTION
IRQBALANCE_BANNED_CPUS is discarded in debian 12