### PR TITLE
network_vars: remove vlan filtering on physical port

### DIFF
--- a/vars/network_vars.yml
+++ b/vars/network_vars.yml
@@ -38,9 +38,7 @@ br0vlan_systemd_networkd_network:
         - Name: "{{ network_interface }}"
     - Network: "{{ [ {'Bridge': 'br0'} ] + extra_network_config | default([]) }}"
     - BridgeVLAN:
-        - VLAN: 159
-        - PVID: 4094
-        - EgressUntagged: 4094
+        - VLAN: "1-4094"
 
 br0_systemd_networkd_netdev:
   00-br0:


### PR DESCRIPTION
In case of VLAN filtering, we let the physical port accept ALL vlan ids by defau
lts (1-4094)