### PR TITLE
inventories fixes for irqbalance on debian12

### DIFF
--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -123,7 +123,7 @@ all:
                         logstash_server_ip: 10.10.10.10
 
                         # Realtime/CPUs cgroups isolation configuration
-                        isolcpus: "2-5,14-17" # CPUs to isolate (isolcpus, irqbalance)
+                        isolcpus: "2-5,14-17" # CPUs to isolate (isolcpus, irqbalance on debian 12)
                         workqueuemask: "1001" #workqueue mask, here it mean 0 and 12 are the only allowed cpus
                         cpusystem: "0,12" # CPUs reserves for system
                         cpuuser: "1,13" # CPUs reserves for user applications

--- a/inventories/seapath_standalone_definition_example.yml
+++ b/inventories/seapath_standalone_definition_example.yml
@@ -48,7 +48,7 @@ all:
                       'eno12429': 7
 
                     # Realtime/CPUs cgroups isolation configuration
-                    irqmask: "ffeffe"
+                    isolcpus: "2-5,14-17" # CPUs to isolate (isolcpus, irqbalance on debian 12)
                     workqueuemask: "1001" #workqueue mask, here it mean 0 and 12 are the only allowed cpus
                     cpusystem: "0,12" # CPUs reserves for system
                     cpuuser: "1,13" # CPUs reserves for user applications


### PR DESCRIPTION
On debian 12, irqmask is replaced with isolcpus in /etc/default/irqbalance