### PR TITLE
workflows/ci-debian: clone with submodules

### DIFF
--- a/.github/workflows/ci-debian.yml
+++ b/.github/workflows/ci-debian.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Initialize sources
         run: mkdir ${{ env.WORK_DIR }}; cd ${{ env.WORK_DIR }};
-             git clone -q --depth 1 -b main https://github.com/seapath/ci ci;
+             git clone -q --depth 1 --recurse-submodules -b main https://github.com/seapath/ci ci;
              echo "CI sources downloaded successfully";
              ci/launch.sh init;
 


### PR DESCRIPTION
A submodule was added in the CI repository to get test-report-pdf. This commit adds the fetch of this submodule when cloning the CI in the GitHub Action file.