### PR TITLE
ha playbook: improves the extra cmd to run

### DIFF
--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -284,12 +284,12 @@ all:
         livemigration_user: livemigration
 
         #pacemaker_shutdown_timeout: "2min"
-        extra_crm_cmd_to_run:
+        extra_crm_cmd_to_run: |
           # for ntp status monitoting, be sure host_ip is the ip address of the server and not its hostname
-          - primitive ntpstatus_test ocf:seapath:ntpstatus params host_ip=10.10.10.10 multiplier=500 op monitor timeout=10 interval=10
-          - primitive ptpstatus_test ocf:seapath:ptpstatus op monitor timeout=10 interval=10 op_params multiplier=1000
-          - clone cl_ntpstatus_test ntpstatus_test meta target-role=Started
-          - clone cl_ptpstatus_test ptpstatus_test meta target-role=Started
+          primitive ntpstatus_test ocf:seapath:ntpstatus params host_ip=10.10.10.10 multiplier=500 op monitor timeout=10 interval=10
+          primitive ptpstatus_test ocf:seapath:ptpstatus op monitor timeout=10 interval=10 op_params multiplier=1000
+          clone cl_ntpstatus_test ntpstatus_test meta target-role=Started
+          clone cl_ptpstatus_test ptpstatus_test meta target-role=Started
 
         # if br0vlan is set, then the host's remote access network ip is on a vlan, but a trunk port has been given to the host so that guests can connect to other vlans. You create the interfaces for those guests here:
         guests_on_br0:

--- a/playbooks/cluster_setup_ha.yaml
+++ b/playbooks/cluster_setup_ha.yaml
@@ -124,23 +124,27 @@
   become: true
   tasks:
       - name: run extra CRM configuration commands
-        command: "/usr/sbin/crm configure {{ item }}"
+        command:
+          cmd: crm -d config load update -
+          stdin: "{{ extra_crm_cmd_to_run }}"
         when: extra_crm_cmd_to_run is defined
         run_once: true
-        no_log: true
-        failed_when: 0 == 1
-        loop: "{{ extra_crm_cmd_to_run }}"
+        register: extra_crm_cmd_to_run_task
+        changed_when: "'CIB commit successful' in extra_crm_cmd_to_run_task.stdout"
       - name: run extra CRM configuration commands for vm-mgr http api
-        command: "/usr/sbin/crm configure {{ item }}"
+        command:
+          cmd: crm -d config load update -
+          stdin: "{{ vmmgrapi_cmd_list }}"
         when:
           - enable_vmmgr_http_api is defined
           - enable_vmmgr_http_api is true
           - admin_cluster_ip is defined
         run_once: true
-        no_log: true
-        failed_when: 0 == 1
-        loop:
-          - "primitive ClusterIP IPaddr2 params ip={{ admin_cluster_ip }} cidr_netmask=32 op monitor interval=30s meta target-role=Started"
-          - "primitive vmmgrapi systemd:nginx.service  op monitor interval=30s"
-          - "colocation vmmgrapi_colocation inf: ClusterIP vmmgrapi"
+        register: vmmgrapi_cmd_list_task
+        changed_when: "'CIB commit successful' in vmmgrapi_cmd_list_task.stdout"
+        vars:
+          vmmgrapi_cmd_list: |
+            primitive ClusterIP IPaddr2 params ip={{ admin_cluster_ip }} cidr_netmask=32 op monitor interval=30s meta target-role=Started
+            primitive vmmgrapi systemd:nginx.service  op monitor interval=30s
+            colocation vmmgrapi_colocation inf: ClusterIP vmmgrapi
 


### PR DESCRIPTION
the extra cmd to run with crm are run every time the playbook is run, with errors being ignored
This is kind of declarative and idempotent but:
1) it does not support modification of existing resources (if the resource exists, it will just fail, not modify it)
2) it runs a cmd task for every line/resource
3) it does not return whether something was actually changed or not
4) it requires failures to be ignored

All in all, it's not very clean.

With this commit all this problems are solved.
1) the "crm load update" process will update an existing resource and create it if it does not exist
2) it runs only once for all resources
3) we use "changed_when" to find out if something was actually changed
4) we still have full logging and failure detection if needs be