### PR TITLE
network playbook: do not change the macaddress of br0

### DIFF
--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -86,8 +86,6 @@
         command: "/usr/bin/ovs-vsctl -- --if-exists del-port {{ team0_0 }} -- add-port team0 {{ team0_0 }}"
       - name: Add interface team0_1 to team0 bridge
         command: "/usr/bin/ovs-vsctl -- --if-exists del-port {{ team0_1 }} -- add-port team0 {{ team0_1 }}"
-      - name: Change MacAddress of team0 bridge internal interface
-        command: "/usr/bin/ovs-vsctl set bridge team0 other-config:hwaddr=\\\"{{ '02:00:00' | community.general.random_mac(seed=inventory_hostname+'team0') }}\\\""
       - name: Enable RSTP on team0 bridge
         command: "/usr/bin/ovs-vsctl set Bridge team0 rstp_enable=true"
       - name: Set RSTP priority on team0 bridge


### PR DESCRIPTION
Changing the mac address of the br0 default internal interface does not do anything, since the task just after (RSTP setting), makes the macaddress change back to default. This change was introduced in the first place to that we could use udev (.link files in networkd) to rename physical interfaces based on their macaddress.
Since the br0 internal interface gets the same address as one physical interface in the bridge, udev tried to rename the ovs internal interface as well... and hanged. The workaround is to specify "Kind=!openvswitch" in the Match section of the link file.