### PR TITLE
backup-restore: include/exclude VM options and estimated storage

### DIFF
--- a/src/debian/backup-restore/backup-restore.sh
+++ b/src/debian/backup-restore/backup-restore.sh
@@ -22,6 +22,8 @@ function addIndexToArray {
 }
 function getVars {
   source ${conffile}
+  include_vm=${include_vm:-".*"}
+  exclude_vm=${exclude_vm:-NonExistingGuestNameForDefault}
 }
 function getVarsOld {
   readVar local_dir
@@ -121,14 +123,14 @@ function backupFull {
   [ -z "$remote_dir" ] && { whiptail --msgbox "var remote_dir empty" 10 50; return; }
   [ -z "$remote_shell" ] && { whiptail --msgbox "var remote_shell empty" 10 50; return; }
   [ -z "$remote_serv" ] && { whiptail --msgbox "var remote_serv empty" 10 50; return; }
-  /usr/local/bin/backup_full.sh $local_dir "$remote_shell" $remote_serv":"$remote_dir
+  /usr/local/bin/backup_full.sh $local_dir "$remote_shell" $remote_serv":"$remote_dir "$include_vm" "$exclude_vm"
 }
 function backupInc {
   getVars
   [ -z "$remote_dir" ] && { whiptail --msgbox "var remote_dir empty" 10 50; return; }
   [ -z "$remote_shell" ] && { whiptail --msgbox "var remote_shell empty" 10 50; return; }
   [ -z "$remote_serv" ] && { whiptail --msgbox "var remote_serv empty" 10 50; return; }
-  /usr/local/bin/backup_inc.sh $local_dir "$remote_shell" $remote_serv":"$remote_dir
+  /usr/local/bin/backup_inc.sh $local_dir "$remote_shell" $remote_serv":"$remote_dir "$include_vm" "$exclude_vm"
 }
 function getValueForVar {
    var=$1
@@ -148,6 +150,8 @@ function settings {
           "3)" "change value remote_dir, currently \"$remote_dir\""   \
           "4)" "change value local_tmp_dir, currently \"$local_tmp_dir\""   \
           "5)" "change value remote_shell, currently \"$remote_shell\""   \
+          "6)" "change value include_vm, currently \"$include_vm\""   \
+          "7)" "change value exclude_vm, currently \"$exclude_vm\""   \
           3>&2 2>&1 1>&3
     )
     [[ "$?" = 1 ]] && break
@@ -162,8 +166,20 @@ function settings {
       ;;
       "5)") getValueForVar remote_shell
       ;;
+      "6)") getValueForVar include_vm
+      ;;
+      "7)") getValueForVar exclude_vm
+      ;;
     esac
   done
+}
+
+function estimate {
+    getVars
+    CMD="/usr/local/bin/backup_du.py \"${include_vm}\" \"${exclude_vm}\""
+    echo "Estimating backup volume, please wait"
+    echo
+    whiptail --title "Estimated Volume for a FULL Backup" --msgbox "$(${CMD})" --scrolltext 15 78
 }
 
 while [ 1 ]
@@ -174,6 +190,7 @@ do
     "2)" "backup inc"   \
     "3)" "restore vm"   \
     "4)" "change settings"   \
+    "5)" "estimate backup volume"   \
     3>&2 2>&1 1>&3
   )
   [[ "$?" = 1 ]] && break
@@ -186,6 +203,8 @@ do
     "3)") restoreVMChooseFullDate
     ;;
     "4)") settings
+    ;;
+    "5)") estimate
     ;;
   esac
 done

--- a/src/debian/backup-restore/backup_du.py
+++ b/src/debian/backup-restore/backup_du.py
@@ -1,0 +1,73 @@
+#!/usr/bin/python3
+## ------------------------------
+## Backup DU
+## Estimating volume Backup
+## ------------------------------
+from subprocess import check_output
+import sys
+
+FMT_LIG = "%-20s %10d"
+
+def convert_size(nb, unit):
+    match unit.upper():
+        case "GIB":
+            size = float(nb)*1024*1024*1024
+        case "MIB":
+            size = float(nb)*1024*1024
+        case "KIB":
+            size = float(nb)*1024
+        case _:
+            size = 0
+
+    return int(size+0.5)
+
+def convert_mo(nb):
+    return int( (nb/1000/1000)+0.5 )
+
+def pr_lig(n, z, u):
+    f = FMT_LIG+u
+    print( f % (n,z) )
+
+def pr_table(d):
+    total = 0
+    for k,v in d.items():
+        pr_lig(k, v, " MB")
+        total += v
+
+    print("-" * 35 )
+    pr_lig("TOTAL :", total, " MB")
+    print()
+    pr_lig(" Estimating En GB",  int((total/1000)+0.5), " GB" )
+
+def read_du_rbd(data):
+    volume={}
+    cmd = '/usr/bin/rbd du 2>/dev/null | grep system_'
+    if data["include_vm"] and data["include_vm"] != '""':
+        cmd += '| grep -E "(%s)"' % data["include_vm"].replace('"', '')
+    if data["exclude_vm"] and data["exclude_vm"] != '""':
+        cmd += '| grep -v -E "(%s)"' % data["exclude_vm"].replace('"', '')
+
+    out = check_output(cmd, shell=True, text=True, universal_newlines=True)
+    for l in out.split('\n'):
+        if l:
+            name, prov, punit, used, uunit = l.split()
+            name = name.replace("system_","")
+            if '@' in name:
+                name = name[0:name.index('@')]
+            t = convert_mo(convert_size(used, uunit))
+            if name in volume:
+                volume[name] += t
+            else:
+                volume[name] = t
+    return volume
+
+
+def compute():
+    data = {}
+    data["include_vm"] = sys.argv[1]
+    data["exclude_vm"] = sys.argv[2]
+    volume = read_du_rbd(data)
+    pr_table(volume)
+
+if __name__ == "__main__":
+    compute()

--- a/src/debian/backup-restore/backup_full.sh
+++ b/src/debian/backup-restore/backup_full.sh
@@ -3,11 +3,19 @@
 local_dir=$1
 remote_shell=$2
 remote_dir=$3
+include_vm=$4
+exclude_vm=$5
 
 [ -z "$local_dir" ] && { echo "var local_dir empty"; exit 1; }
 [ -z "$remote_shell" ] && { echo "var remote_shell empty"; exit 2; }
 [ -z "$remote_dir" ] && { echo "var remote_dir empty"; exit 3; }
 
+echo "Include VM : $include_vm"
+echo "Exclude VM : $exclude_vm"
+echo "------------------------------------"
+L_VM=$( rbd list | grep -E "($include_vm)"  | grep -E -v "($exclude_vm)" | sed -e "s/system_//g" )
+echo "List of Guests to backup: " $L_VM
+echo "------------------------------------"
 echo Removing old full backups local dirs
 echo rm -rf "$local_dir"*, press enter to proceed
 read
@@ -16,7 +24,10 @@ rm -rf "$local_dir"*
 d=`date +%Y%m%d%H%M`
 f="$local_dir""$d"
 mkdir -p $f
-rbd list | while read i
+#rbd list | while read i
+CMD="rbd list"
+LIST_VM=$( $CMD | grep -E "($include_vm)"  | grep -E -v "($exclude_vm)" )
+for i in $LIST_VM
 do
   echo $i
   echo sparsifying

--- a/src/debian/backup-restore/backup_inc.sh
+++ b/src/debian/backup-restore/backup_inc.sh
@@ -3,6 +3,8 @@
 local_dir=$1
 remote_shell=$2
 remote_dir=$3
+include_vm=$4
+exclude_vm=$5
 
 [ -z "$local_dir" ] && { echo "var local_dir empty"; exit 1; }
 [ -z "$remote_shell" ] && { echo "var remote_shell empty"; exit 2; }
@@ -16,7 +18,19 @@ d=`date +%Y%m%d%H%M`
 latest_full=`ls -d "$local_dir"* | tail -n 1`
 [ ! -d "$latest_full" ] && { echo "latest full backup not found"; exit 3; }
 
-rbd list | while read i
+echo "Include VM : $include_vm"
+echo "Exclude VM : $exclude_vm"
+echo "------------------------------------"
+L_VM=$( rbd list | grep -E "($include_vm)"  | grep -E -v "($exclude_vm)" | sed -e "s/system_//g" )
+echo "List of Guests to backup: " $L_VM
+echo "------------------------------------"
+echo "press enter to proceed"
+read
+
+#rbd list | while read i
+CMD="rbd list"
+LIST_VM=$( $CMD | grep -E "($include_vm)"  | grep -E -v "($exclude_vm)" )
+for i in $LIST_VM
 do
   echo $i
   latest=`rbd snap list rbd/$i | tail -n 1 | awk '{ print $2 }'`


### PR DESCRIPTION
It might be useful for an administrators to more precisely select the Guests that needs backuping.
This commit introduces the include_vm and exclude_vm settings in backup-restore.sh, and a feature to estimate the associated needed storage.