### PR TITLE
add_vm_playbook_example: fix path of vm_template

### DIFF
--- a/examples/playbooks/add_vm_playbook_example.yaml
+++ b/examples/playbooks/add_vm_playbook_example.yaml
@@ -1,14 +1,14 @@
 # Copyright (C) 2020, RTE (http://www.rte-france.com)
 # SPDX-License-Identifier: Apache-2.0
 
-# Create the VM test0 based on examples/vm_template_example.xml.j2.
+# Create the VM test0 based on examples/vm_templates/vm_template_example.xml.j2.
 
 ---
 - hosts: hypervisors
   vars:
      - vm_name: test0
      - state: create
-     - xml_template: ./examples/vm_template_example.xml.j2
+     - xml_template: ./examples/vm_templates/vm_template_example.xml.j2
      - rbd_pool: rbd
      - os_disk: os0
      - data_disk: data0


### PR DESCRIPTION
The vm_template_example.xml.j2 template file added on this playbook is now in the ./examples/vm_templates path. Thus, the old path is replace is in this commit.