### PR TITLE
README.adoc: correct typo

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -162,7 +162,7 @@ all:
         host1:
     vars:
         my_global_var: variable_content
-    chlidren:
+    children:
         group1:
             hosts:
                 host2:


### PR DESCRIPTION
Typo on the word children in the Inventory section.