### PR TITLE
cluster_setup_network: make syslog optional

### DIFF
--- a/examples/inventories/advanced_inventory_cluster_example.yaml
+++ b/examples/inventories/advanced_inventory_cluster_example.yaml
@@ -214,6 +214,7 @@ all:
     # Change the Ansible working folder to a rw accessible folder
     ansible_remote_tmp: /tmp/.ansible/tmp
     # The syslog server IP address where logs are centralized
+    # Optional, if not given, no log will be sent
     syslog_server_ip: "192.168.220.6"
     # The vlan ID of the PTP. Remove the variable if the ptp frames
     # are not in a VLAN

--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -196,6 +196,7 @@
         state: present
       notify:
         - Restart systemd syslog-ng
+      when: syslog_server_ip is defined
   handlers:
     - name: Restart systemd syslog-ng
       vars:


### PR DESCRIPTION
The variable `syslog_server_ip` is now optional. When not given, no logs will be sent.