### PR TITLE
Make snmp optional

### DIFF
--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -15,8 +15,8 @@ all:
                             subnet: 25 #default is 24, override if necessary
                             #br0vlan: 159 #if the main interface on br0 is on a vlan that the host must manage
 
-                            # Admin network settings
-                            admin_ip_addr: 10.10.11.1 #used for snmp
+                            # snmp network settings
+                            snmp_admin_ip_addr: 10.10.11.1 #used to listen to snmp requests
 
                             # PTP network settings
                             ptp_interface: "eno12419" #OPTIONAL PTP Interface
@@ -57,8 +57,8 @@ all:
                             ip_addr: "{{ ansible_host }}"
                             subnet: 25
 
-                            # Admin network settings
-                            admin_ip_addr: 10.10.11.2 #used for snmp
+                            # snmp network settings
+                            snmp_admin_ip_addr: 10.10.11.1 #used to listen to snmp requests
 
                             # PTP network settings
                             ptp_interface: "eno12419" #OPTIONAL PTP Interface
@@ -85,8 +85,8 @@ all:
                             ip_addr: "{{ ansible_host }}"
                             subnet: 25
 
-                            # Admin network settings
-                            admin_ip_addr: 10.10.11.3 #used for snmp
+                            # snmp network settings
+                            snmp_admin_ip_addr: 10.10.11.1 #used to listen to snmp requests
 
                              # PTP network settings
                             ptp_interface: "eno12419" #OPTIONAL PTP Interface

--- a/inventories/seapath_standalone_definition_example.yml
+++ b/inventories/seapath_standalone_definition_example.yml
@@ -12,8 +12,8 @@ all:
                     ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
                     ansible_remote_tmp: /tmp/.ansible/tmp
 
-                    # Admin network settings
-                    admin_ip_addr: 10.10.11.1 #used for snmp
+                    # snmp network settings
+                    snmp_admin_ip_addr: 10.10.11.1 #used to listen to snmp requests
 
                     # Main network configuration
                     network_interface: enp1s0

--- a/roles/debian-hardening/physical_machine/tasks/main.yml
+++ b/roles/debian-hardening/physical_machine/tasks/main.yml
@@ -30,15 +30,19 @@
     mode: '0440'
   when: not revert
 
-- name: adding sudo users to group privileged
+- name: adding ceph user to group privileged
   user:
-    name: "{{ item }}"
+    name: "ceph"
     groups: privileged
     append: yes
-  with_items:
-   - ceph
-   - Debian-snmp
   when: not revert
+
+- name: adding Debian-snmp user to group privileged
+  user:
+    name: "Debian-snmp"
+    groups: privileged
+    append: yes
+  when: not revert and snmp_admin_ip_addr is defined
 
 - name: Create systemd service.d directories
   file:

--- a/roles/debian/physical_machine/tasks/main.yml
+++ b/roles/debian/physical_machine/tasks/main.yml
@@ -316,75 +316,78 @@
     append: no
   when: livemigration_user is defined and livemigration_user != admin_user
 
-- name: get Debian-snmp uid
-  getent:
-    database: passwd
-    key: "Debian-snmp"
-- name: get Debian-snmp gid
-  getent:
-    database: group
-    key: "Debian-snmp"
-- debug:
-    msg:
-      - "user id {{ getent_passwd['Debian-snmp'][1] }}"
-      - "group id {{ getent_group['Debian-snmp'][1] }}"
-
-- name: Set Debian-snmp correct uid/gid
+- name: configure snmp
   block:
-    - name: stop snmpd if needed
-      ansible.builtin.systemd:
-        name: snmpd.service
-        state: stopped
-    - name: Ensure group "Debian-snmp" exists with correct gid
-      ansible.builtin.group:
-        name: Debian-snmp
-        state: present
-        gid: 902
-    - name: Ensure user Debian-snmp has correct uid and gid
-      user:
-        name: Debian-snmp
-        uid: 902
-        group: Debian-snmp
-  when: getent_passwd['Debian-snmp'][1] != "902" or getent_group['Debian-snmp'][1] != "902"
+  - name: get Debian-snmp uid
+    getent:
+      database: passwd
+      key: "Debian-snmp"
+  - name: get Debian-snmp gid
+    getent:
+      database: group
+      key: "Debian-snmp"
+  - debug:
+      msg:
+        - "user id {{ getent_passwd['Debian-snmp'][1] }}"
+        - "group id {{ getent_group['Debian-snmp'][1] }}"
 
-- name: Synchronization of snmp_ scripts
-  ansible.posix.synchronize:
-    src: ../src/debian/
-    dest: /usr/local/bin/
-    rsync_opts:
-    - "--include=snmp_*.sh"
-    - "--include=virt-df.sh"
-    - "--exclude=*"
-    - "--chmod=F755"
-    - "--chown=root:root"
-- name: Snmp config
-  ansible.builtin.template:
-    src: ../src/debian/snmpd.conf.j2
-    dest: /etc/snmp/snmpd.conf
-    mode: '0644'
-    owner: root
-    group: root
-  register: snmpd_conf
-- name: Wait for DHCP for SNMP
-  lineinfile:
-    dest: /lib/systemd/system/snmpd.service
-    regexp: "^After="
-    line: "After=network-online.target"
-    state: present
+  - name: Set Debian-snmp correct uid/gid
+    block:
+      - name: stop snmpd if needed
+        ansible.builtin.systemd:
+          name: snmpd.service
+          state: stopped
+      - name: Ensure group "Debian-snmp" exists with correct gid
+        ansible.builtin.group:
+          name: Debian-snmp
+          state: present
+          gid: 902
+      - name: Ensure user Debian-snmp has correct uid and gid
+        user:
+          name: Debian-snmp
+          uid: 902
+          group: Debian-snmp
+    when: getent_passwd['Debian-snmp'][1] != "902" or getent_group['Debian-snmp'][1] != "902"
 
-- name: restart snmpd
-  ansible.builtin.systemd:
-    name: snmpd.service
-    state: restarted
-    enabled: yes
+  - name: Synchronization of snmp_ scripts
+    ansible.posix.synchronize:
+      src: ../src/debian/
+      dest: /usr/local/bin/
+      rsync_opts:
+      - "--include=snmp_*.sh"
+      - "--include=virt-df.sh"
+      - "--exclude=*"
+      - "--chmod=F755"
+      - "--chown=root:root"
+  - name: Snmp config
+    ansible.builtin.template:
+      src: ../src/debian/snmpd.conf.j2
+      dest: /etc/snmp/snmpd.conf
+      mode: '0644'
+      owner: root
+      group: root
+    register: snmpd_conf
+  - name: Wait for DHCP for SNMP
+    lineinfile:
+      dest: /lib/systemd/system/snmpd.service
+      regexp: "^After="
+      line: "After=network-online.target"
+      state: present
 
-- name: Install sudo Debian-snmp user rules
-  copy:
-    src: ../src/debian/sudoers/Debian-snmp
-    dest: /etc/sudoers.d/Debian-snmp
-    owner: root
-    group: root
-    mode: '0440'
+  - name: restart snmpd
+    ansible.builtin.systemd:
+      name: snmpd.service
+      state: restarted
+      enabled: yes
+
+  - name: Install sudo Debian-snmp user rules
+    copy:
+      src: ../src/debian/sudoers/Debian-snmp
+      dest: /etc/sudoers.d/Debian-snmp
+      owner: root
+      group: root
+      mode: '0440'
+  when: snmp_admin_ip_addr is defined
 
 - name: Creating libvirt user with libvirtd permissions
   user: name=libvirt

--- a/src/debian/snmpd.conf.j2
+++ b/src/debian/snmpd.conf.j2
@@ -29,4 +29,4 @@ extend ipmisdrlist /usr/bin/timeout 10s /usr/bin/sudo /usr/local/bin/snmp_ipmito
 extend ipmisdrlistv /usr/bin/timeout 10s /usr/bin/sudo /usr/local/bin/snmp_ipmitool_sdrlist_v.sh
 extend lvs /usr/bin/timeout 2s /usr/bin/sudo /usr/local/bin/snmp_lvs.sh
 extend smartctl /usr/bin/timeout 2s /usr/bin/sudo /usr/local/bin/snmp_smartctl.sh
-agentAddress udp:{{ admin_ip_addr }}:161
+agentAddress udp:{{ snmp_admin_ip_addr }}:161


### PR DESCRIPTION
When the snmp administration ip is not provided, snmp is not configured on the host.