### PR TITLE
timemaster: Decrease ptp4l verbosity

### DIFF
--- a/templates/timemaster.conf.j2
+++ b/templates/timemaster.conf.j2
@@ -75,5 +75,6 @@ path /usr/sbin/phc2sys
 
 [ptp4l]
 path /usr/sbin/ptp4l
-# make ptp4l really verbose (to see synchro values)
-options -l 6 --step_threshold 0.00001
+# -l 4: "Reasonable" loglevel (synchronisation status change, init, ...)
+# -l 6: debug loglevel (PHC regulation values, offset every second)
+options --step_threshold 0.00001 -l 4


### PR DESCRIPTION
Verbosity level 6->4 prevent seeing regulation values once every second (Those can be enabled back locally for debug)