### PR TITLE
PTP refactor

### DIFF
--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -103,10 +103,32 @@
           name: systemd-timesyncd.service
           enabled: no
           state: stopped
+      - name: Add the ptp4l configuration file
+        copy:
+          src: ../src/ptp4l.conf
+          dest: /etc/ptp4l.conf
+          owner: root
+          group: root
+          mode: 0644
+      - name: Ensure /etc/systemd/system/ptp4l@.service.d directory exists
+        file:
+          path: /etc/systemd/system/ptp4l@.service.d
+          state: directory
+          owner: root
+          group: root
+          mode: 0755
+      - name: Configure ptp4l service to use a configuration file
+        copy:
+          src: ../src/ptp4l.service.override
+          dest: /etc/systemd/system/ptp4l@.service.d/override.conf
+          owner: root
+          group: root
+          mode: 0644
       - name: Enable ptp service
         ansible.builtin.systemd:
           name: ptp4l@ptp.service
           enabled: yes
+          daemon_reload: yes
       - name: Start ptp service
         ansible.builtin.systemd:
           name: ptp4l@ptp.service

--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -80,7 +80,6 @@
         - not apply_config
         - ptp_interface.changed
     when:
-      - ptp_vlan_interface is defined
       - ptp_vlan is defined
       - ptp_vlan_address is defined
   - name: Restart systemd-networkd
@@ -123,9 +122,7 @@
           state: started
         when: apply_config or (need_reboot is defined and not need_reboot)
 
-      when:
-        - ptp_vlan_interface is defined
-        - ptp_vlan is defined
+      when: ptp_vlan is defined
 
 - name: Configure hostname
   hosts:

--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -132,7 +132,7 @@
       - name: Start ptp service
         ansible.builtin.systemd:
           name: ptp4l@ptp.service
-          state: started
+          state: restarted
         when: apply_config or (need_reboot is defined and not need_reboot)
       - name: Enable phc2sys service
         ansible.builtin.systemd:
@@ -141,7 +141,7 @@
       - name: Start phc2sys service
         ansible.builtin.systemd:
           name: phc2sys@ptp.service
-          state: started
+          state: restarted
         when: apply_config or (need_reboot is defined and not need_reboot)
 
       when: ptp_vlan is defined

--- a/src/ptp4l.conf
+++ b/src/ptp4l.conf
@@ -1,0 +1,26 @@
+[Global]
+slaveOnly                1
+gmCapable                1
+
+domainNumber             0
+
+# Announce interval: 1s
+logAnnounceInterval      0
+
+# Sync interval: 1 s
+logSyncInterval          0
+
+# Pdelay interval: 1 s
+logMinPdelayReqInterval  0
+
+# Announce receipt time-out: 3 s (fixed)
+announceReceiptTimeout   3
+
+priority1                255
+priority2                255
+# Default clock class : any specialised clock will be better (ie a GPS Grand Master Clock)
+network_transport        L2
+delay_mechanism          P2P
+clockClass 248
+clockAccuracy 0xFE
+offsetScaledLogVariance 0xFFFF

--- a/src/ptp4l.service.override
+++ b/src/ptp4l.service.override
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/usr/sbin/ptp4l -q -m -f /etc/ptp4l.conf -i %I

--- a/vars/network_vars.yml
+++ b/vars/network_vars.yml
@@ -4,7 +4,7 @@
 _systemd_networkd_network_custom: ["{{ custom_network | default([]) }}"]
 _systemd_networkd_netdev_custom: ["{{ custom_netdev | default([]) }}"]
 
-_vlan_conditionnal: "{% if ptp_vlan is defined %}[{'VLAN': 'ptp'}]{% else %}[]{% endif %}"
+_vlan_conditionnal: "{% if ptp_vlan is defined and ptp_vlan_interface and ptp_vlan_interface == network_interface %}[{'VLAN': 'ptp'}]{% else %}[]{% endif %}"
 
 _network_common:
   - Gateway: "{{ gateway_addr }}"


### PR DESCRIPTION
* Allows the use of any interface for PTP, not only the main interface.
* Add a configure file for ptp4l which respects the IEC 61850-9-3 standard.
* Restart ptp4l and phc2sys services in case there are already started.