### PR TITLE
github/workflows: fix ansible-lint-yocto-weekly workflow

### DIFF
--- a/.github/workflows/ansible-lint-yocto-weekly.yml
+++ b/.github/workflows/ansible-lint-yocto-weekly.yml
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Savoir-faire Linux, Inc.
+# Copyright (C) 2023-2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 # This file will execute ansible-lint on the main branch every saturday
 # This ensure the main branch is always linted properly
@@ -12,4 +12,4 @@ on:
 
 jobs:
   call-workflow:
-    uses: ./.github/workflows/ansible-lint.yml
+    uses: ./.github/workflows/ansible-lint-yocto.yml


### PR DESCRIPTION
The ansible-lint-yocto-weekly workflow was using the wrong file to execute the ansible-lint action. This commit fixes the issue by using the correct file.