### PR TITLE
github/workflows: fix ansible-lint-debian-weekly workflow

### DIFF
--- a/.github/workflows/ansible-lint-debian-weekly.yml
+++ b/.github/workflows/ansible-lint-debian-weekly.yml
@@ -9,7 +9,8 @@ name: Ansible Lint Debian main
 on:
   schedule:
     - cron: '30 22 * * 6'
+  workflow_dispatch:
 
 jobs:
   call-workflow:
-    uses: ./.github/workflows/ansible-lint.yml
+    uses: ./.github/workflows/ansible-lint-debian.yml

--- a/.github/workflows/ansible-lint-debian-weekly.yml
+++ b/.github/workflows/ansible-lint-debian-weekly.yml
@@ -4,7 +4,7 @@
 # This ensure the main branch is always linted properly
 # A badge is derived from this workflow
 
-name: Ansible Lint Debian main
+name: Ansible Lint weekly Debian
 
 on:
   schedule:

--- a/.github/workflows/ci-debian-weekly.yml
+++ b/.github/workflows/ci-debian-weekly.yml
@@ -5,7 +5,7 @@
 # This ensure the main branch is always tested properly.
 # A badge is derived from this workflow.
 
-name: CI debian main
+name: CI debian weekly
 
 on:
   schedule:

--- a/.github/workflows/ci-debian-weekly.yml
+++ b/.github/workflows/ci-debian-weekly.yml
@@ -10,6 +10,7 @@ name: CI debian main
 on:
   schedule:
     - cron: '30 22 * * 6'
+  workflow_dispatch:
 
 jobs:
   call-workflow:


### PR DESCRIPTION
* Fix the ansible-lint-debian-weekly wrong workflow file.
* Renames the weekly workflows to be more explicit about their purpose.
* Allow to manually trigger weekly workflows from the github interface.