### PR TITLE
github/workflows: add workflow_dispatch to weekly workflows

### DIFF
--- a/.github/workflows/ansible-lint-yocto-weekly.yml
+++ b/.github/workflows/ansible-lint-yocto-weekly.yml
@@ -4,7 +4,7 @@
 # This ensure the main branch is always linted properly
 # A badge is derived from this workflow
 
-name: Ansible Lint Yocto main
+name: Ansible Lint weekly Yocto
 
 on:
   schedule:

--- a/.github/workflows/ansible-lint-yocto-weekly.yml
+++ b/.github/workflows/ansible-lint-yocto-weekly.yml
@@ -9,6 +9,7 @@ name: Ansible Lint Yocto main
 on:
   schedule:
     - cron: '30 22 * * 6'
+  workflow_dispatch:
 
 jobs:
   call-workflow:

--- a/.github/workflows/ci-yocto-weekly.yml
+++ b/.github/workflows/ci-yocto-weekly.yml
@@ -4,7 +4,7 @@
 # This ensure the main branch is always tested properly.
 # A badge is derived from this workflow.
 
-name: CI Yocto main
+name: CI weekly Yocto
 
 on:
   schedule:

--- a/.github/workflows/ci-yocto-weekly.yml
+++ b/.github/workflows/ci-yocto-weekly.yml
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Savoir-faire Linux, Inc.
+# Copyright (C) 2023-2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 # This file will execute the yocto-ci on the main branch every saturday.
 # This ensure the main branch is always tested properly.
@@ -9,6 +9,7 @@ name: CI Yocto main
 on:
   schedule:
     - cron: '30 22 * * 6'
+  workflow_dispatch:
 
 jobs:
   call-workflow:


### PR DESCRIPTION
This PR adds the workflow_dispatch event to the weekly workflows ansible-lint-yocto-weekly.yml and ci-yocto-weekly.yml. This will allow us to manually trigger the workflows from the GitHub Actions UI.

It also renames the weekly workflows to be more explicit about their purpose.