### PR TITLE
github/workflows: fix Debian weekly name

### DIFF
--- a/.github/workflows/ansible-lint-debian-weekly.yml
+++ b/.github/workflows/ansible-lint-debian-weekly.yml
@@ -2,7 +2,7 @@
 # Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-name: Ansible Lint weekly Yocto
+name: Ansible Lint weekly Debian
 
 env:
   WORK_DIR: /tmp/seapath_ci_${{ github.run_id }}_${{ github.run_attempt }}_${{ github.sha }}


### PR DESCRIPTION
The name of the weekly Debian workflow was wrong.