### PR TITLE
github/workflows: fix ci-debian-weekly fetch

### DIFF
--- a/.github/workflows/ci-debian-weekly.yml
+++ b/.github/workflows/ci-debian-weekly.yml
@@ -17,14 +17,11 @@ jobs:
   CI:
     runs-on: [self-hosted, runner-RTE-12]
     steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: debian-main
       - name: Initialize sources
         run: mkdir ${{ env.WORK_DIR }}; cd ${{ env.WORK_DIR }};
              git clone -q --depth 1 --recurse-submodules -b main https://github.com/seapath/ci ci;
              echo "CI sources downloaded successfully";
-             ci/launch.sh init;
+             GITHUB_REF=debian-main ci/launch.sh init;
 
       - name: Configure Debian
         id: conf


### PR DESCRIPTION
The ci-debian-weekly workflow use a custom way to fetch the sources, using the `GITHUB_REF` environment variable to fetch the correct branch.