### PR TITLE
hardening: disable requiretty for cockpit

### DIFF
--- a/roles/debian-hardening/tasks/main.yml
+++ b/roles/debian-hardening/tasks/main.yml
@@ -219,6 +219,24 @@
   ansible.builtin.meta:
     reset_connection
 
+- name: Check if cockpit is installed
+  command:
+    which cockpit-bridge
+  register: cockpit_status
+  ignore_errors: true
+
+- name: Disable require tty for cockpit
+  copy:
+    src: ../src/debian/sudoers/cockpit
+    dest: /etc/sudoers.d/cockpit
+  when: not revert and cockpit_status.rc == 0
+
+- name: Remove cockpit sudo configuration
+  ansible.builtin.file:
+    path: /etc/sudoers.d/cockpit
+    state: absent
+  when: revert and cockpit_status.rc == 0
+
 - name: Configure sudo to be run only users member of the privileged group
   file:
     path: /usr/bin/sudo

--- a/src/debian/sudoers/cockpit
+++ b/src/debian/sudoers/cockpit
@@ -1,0 +1,2 @@
+Cmnd_Alias    NOTTYCMDS = /usr/bin/cockpit-bridge --privileged
+Defaults!NOTTYCMDS    !requiretty


### PR DESCRIPTION
When hardening is enable, it is not possible to run command outside a tty. This cause Cockpit to not be able to be used with an administrator with the admin privilege.
Disable `require-tty` for command `/usr/bin/cockpit-bridge --privileged` in order to enable administrative access in cockpit, for authorized users.