### PR TITLE
Make isolcpus and workqueues optional and revertable

### DIFF
--- a/roles/debian/hypervisor/tasks/main.yml
+++ b/roles/debian/hypervisor/tasks/main.yml
@@ -103,12 +103,36 @@
     - cpufreq.default_governor=performance
     - intel_pstate=disable
     - nosoftlockup
-    - "rcu_nocbs={{ isolcpus }}"
     - rcu_nocb_poll
     - rcutree.kthread_prio=10
-    - "isolcpus=nohz,domain,managed_irq,{{ isolcpus }}"
     - skew_tick=1
     - tsc=reliable
+
+- name: "grub conf hypervisor isolcpus"
+  lineinfile:
+    dest: /etc/default/grub
+    regexp: '^(GRUB_CMDLINE_LINUX=(?:(?![" ]{{ item.split("=")[0] }}=?).)*"?)\s*(?:{{ item.split("=")[0] }}(?:=\S+)?\s*)?(.*")$'
+    line: '\1 {{ item.split("=")[0] + (("="+item.split("=")[1]) if item.split("=")|length>1 and item.split("=")[1] != None and item.split("=")[1] != "" else "") }} \2'
+    state: present
+    backrefs: yes
+  register: updategrub2
+  with_items:
+    - "rcu_nocbs={{ isolcpus }}"
+    - "isolcpus=nohz,domain,managed_irq,{{ isolcpus }}"
+  when: isolcpus is defined
+
+- name: "grub conf hypervisor isolcpus revert"
+  lineinfile:
+    dest: /etc/default/grub
+    regexp: '^(.*?)\b{{ item }}=\S+\b(.*)$'
+    line: '\1 \2'
+    state: present
+    backrefs: yes
+  register: updategrub2
+  with_items:
+    - "rcu_nocbs"
+    - "isolcpus"
+  when: isolcpus is not defined
 
 # Another way would be to use a dictionnary so that the regexp is a bit simpler
 #  lineinfile:
@@ -121,7 +145,7 @@
 
 - name: update-grub
   command: update-grub
-  when: updategrub1.changed
+  when: updategrub1.changed or updategrub2.changed
 
 - name: "irqbalance conf"
   lineinfile:
@@ -130,6 +154,16 @@
     line: 'IRQBALANCE_BANNED_CPULIST="{{ isolcpus }}"'
     state: present
   register: irqbalanceconf
+  when: isolcpus is defined
+- name: "irqbalance conf revert"
+  lineinfile:
+    dest: /etc/default/irqbalance
+    regexp: '^#?IRQBALANCE_BANNED_CPULIST=(.*)$'
+    line: '#IRQBALANCE_BANNED_CPULIST=\1'
+    state: present
+    backrefs: yes
+  register: irqbalanceconf
+  when: isolcpus is not defined
 - name: restart irqbalance
   ansible.builtin.systemd:
     name: irqbalance.service

--- a/templates/00-workqueue_cpumask.conf.j2
+++ b/templates/00-workqueue_cpumask.conf.j2
@@ -1,5 +1,7 @@
+{% if workqueuemask is defined %}
 bus/workqueue/devices/writeback/cpumask = {{ workqueuemask }}
 devices/virtual/workqueue/cpumask = {{ workqueuemask }}
 devices/virtual/workqueue/*/cpumask = {{ workqueuemask }}
+{% endif %}
 devices/system/machinecheck/machinecheck*/ignore_ce = 1
 module/kvm/parameters/halt_poll_ns = 0


### PR DESCRIPTION
This commit makes the isolcpus and workqueues configurations optional.
If they were previously set up and and unconfigured later in the inventory, this commit also deals with the revert operations.