### PR TITLE
Make chrony wait timeout sec optional

### DIFF
--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -319,7 +319,7 @@ all:
 
         iptables_rules_path: "../inventories/iptables_rules_example.txt" #when defined, it uploads this file to /etc/iptables/rules.v4 and loads those rules
         #cluster_protocol: "HSR" # RSTP or HSR, default is RSTP
-        chrony_wait_timeout_sec: 180 #time in seconds the boot sequence will wait for chrony to sync
+        chrony_wait_timeout_sec: 180 #time in seconds the boot sequence will wait for chrony to sync. Optional : default is 180
 
         #enable_vmmgr_http_api: false
         #admin_cluster_ip: "10.10.11.4"

--- a/inventories/seapath_standalone_definition_example.yml
+++ b/inventories/seapath_standalone_definition_example.yml
@@ -19,7 +19,7 @@ all:
                     network_interface: enp1s0
                     ip_addr: "{{ ansible_host }}"
                     subnet: 24
-                    dns_server: 10.10.2.1
+                    dns_servers: 10.10.2.1
                     gateway_addr: 10.0.0.1
                     ntp_servers: 
                       - "185.254.101.25"
@@ -83,3 +83,5 @@ all:
                     admin_ssh_keys:
                         - "ssh-rsa key1XXX"
                         - "ssh-rsa key2XXX"
+
+                    chrony_wait_timeout_sec: 180 #time in seconds the boot sequence will wait for chrony to sync. Optional : default is 180

--- a/src/debian/chrony-wait.service.j2
+++ b/src/debian/chrony-wait.service.j2
@@ -12,7 +12,7 @@ Type=oneshot
 # correction to be less than 0.1 seconds
 ExecStart=/usr/bin/chronyc -h 127.0.0.1,::1 waitsync 0 0.1 0.0 1
 # Wait for at most chrony_wait_timeout_sec seconds
-TimeoutStartSec={{ chrony_wait_timeout_sec }}
+TimeoutStartSec={{ chrony_wait_timeout_sec | default(180) }}
 RemainAfterExit=yes
 StandardOutput=null
 


### PR DESCRIPTION
Make the variable chrony_wait_timeout_sec optional. Default to 180 seconds