### PR TITLE
Upload custom files to machines

### DIFF
--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -331,3 +331,10 @@ all:
         #  allow  {{ admin_cluster_ip }}/32;
         #  deny   all;
         #vmmgr_http_local_auth_file: "/var/local/vmmgrapi/.htpasswd"
+
+        # Optional list of local files to upload to the remote machines
+        upload_files:
+          # for example you can override some script to add customizations
+          - { src: '../inventories_private/snmp_getdata.py', dest: '/usr/local/sbin/snmp_getdata.py', mode: "0755" }
+          # you can also upload arbitrary file you may need on your setup
+          - { src: '../inventories_private/toto.txt', dest: '/tmp/toto' }

--- a/inventories/seapath_standalone_definition_example.yml
+++ b/inventories/seapath_standalone_definition_example.yml
@@ -85,3 +85,10 @@ all:
                         - "ssh-rsa key2XXX"
 
                     chrony_wait_timeout_sec: 180 #time in seconds the boot sequence will wait for chrony to sync. Optional : default is 180
+
+                    # Optional list of local files to upload to the remote machines
+                    upload_files:
+                      # for example you can override some script to add customizations
+                      - { src: '../inventories_private/snmp_getdata.py', dest: '/usr/local/sbin/snmp_getdata.py', mode: "0755" }
+                      # you can also upload arbitrary file you may need on your setup
+                      - { src: '../inventories_private/toto.txt', dest: '/tmp/toto' }

--- a/playbooks/cluster_setup_prerequisdebian.yaml
+++ b/playbooks/cluster_setup_prerequisdebian.yaml
@@ -37,6 +37,24 @@
         enabled: no
         state: stopped
 
+- name: upload extra files
+  hosts:
+    - cluster_machines
+    - standalone_machine
+    - VMs
+  become: true
+  tasks:
+    - name: upload extra files
+      copy:
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
+        owner: "{{ item.owner | default('root') }}"
+        group: "{{ item.group | default('root') }}"
+        mode: "{{ item.mode | default('0644') }}"
+        backup: yes
+      with_items: "{{ upload_files }}"
+      when: upload_files is defined
+
 - name: Remove what is not needed after installation
   hosts:
     - cluster_machines


### PR DESCRIPTION
This commit allows the user to provide a list of local files to upload to the machines (upload_files variable in the inventory). This can allow to override a script or provide a file needed on a specific setup.
This task is called at the end of the prerequisite playbook so that it can override files created by this playbook.