### PR TITLE
Remove votp references

### DIFF
--- a/examples/inventories/advanced_inventory_cluster_example.yaml
+++ b/examples/inventories/advanced_inventory_cluster_example.yaml
@@ -13,7 +13,7 @@ all:
       children:
         hypervisors:
           hosts:
-            votp1:
+            hypervisor1:
               # Change IP address according to your setup
               ansible_host: 192.168.217.15
               # The network interface that will be used by the hypervisor to
@@ -60,7 +60,7 @@ all:
                   - Network:
                       - Address: "{{ cluster_ip_addr }}/24"
 
-            votp2:
+            hypervisor2:
               ansible_host: 192.168.217.16
               network_interface: br1
               dns_server: 9.9.9.9
@@ -171,22 +171,22 @@ all:
     # Ceph Monitor group where a Ceph monitor will be installed
     mons:
       hosts:
-        votp1:
-        votp2:
+        hypervisor1:
+        hypervisor2:
         observer:
     # Ceph OSD group where a Ceph OSD will be installed
     osds:
       hosts:
-        votp1:
-        votp2:
+        hypervisor1:
+        hypervisor2:
       vars:
         # Disk to use for Ceph OSD
         ceph_osd_disk: /dev/sdb
     # Ceph clients group where ceph will be used
     clients:
       hosts:
-        votp1:
-        votp2:
+        hypervisor1:
+        hypervisor2:
 
   vars:
     # Use Ansible through SSH

--- a/examples/inventories/advanced_inventory_standalone_example.yaml
+++ b/examples/inventories/advanced_inventory_standalone_example.yaml
@@ -14,7 +14,7 @@ all:
       children:
         hypervisors:
           hosts:
-            votp1:
+            standalone:
               # Change IP address according to your setup
               ansible_host: 192.168.216.15
               # The IP address to be set to enbridge0. Don't forget to change

--- a/examples/inventories/inventory_example.yaml
+++ b/examples/inventories/inventory_example.yaml
@@ -9,9 +9,9 @@ all:
             children:
                 hypervisors:
                     hosts:
-                        votp1:
+                        hypervisor1:
                             ansible_host: 192.168.217.15 # Change IP address according to your setup
-                        votp2:
+                        hypervisor2:
                             ansible_host: 192.168.217.16 # Change IP address according to your setup
                 observers:
                     hosts:

--- a/examples/playbooks/vm/create.yaml
+++ b/examples/playbooks/vm/create.yaml
@@ -7,10 +7,10 @@
   hosts: "{{ groups.hypervisors[0] }}"
   vars:
     - xml_template: >-
-        {{ vm_config | default('../../../templates/vm/votp_vm.xml.j2') }}
+        {{ vm_config | default('../../../templates/vm/vm.xml.j2') }}
     - disk_path: >-
         {{ image_directory }}/{{ guest_image |
-        default('seapath-guest-efi-image-votp-vm.wic.qcow2') }}
+        default('seapath-guest-efi-image.wic.qcow2') }}
   tasks:
     - name: Copy the disk on target
       copy:

--- a/examples/vm_templates/vm_template_example.xml.j2
+++ b/examples/vm_templates/vm_template_example.xml.j2
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright (C) 2020, RTE (http://www.rte-france.com) -->
+<!-- Copyright (C) 2024, SFL (https://savoirfairelinux.com) -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <!--
@@ -12,7 +13,7 @@ seapath_vm_manage role all variables must be defined before using this template.
 <domain type="{{ vm_domaine | default('kvm') }}">
     <name>{{ vm_name }}</name>
     <uuid>{{ vm_uuid }}</uuid>
-    <title>VOTP {{ vm_name }}</title>
+    <title>{{ vm_name }}</title>
     <description>
             Test template working with add_vm_playbook_example.yaml
     </description>

--- a/examples/vm_templates/vm_template_example_generic.xml.j2
+++ b/examples/vm_templates/vm_template_example_generic.xml.j2
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright (C) 2020, RTE (http://www.rte-france.com) -->
+<!-- Copyright (C) 2024, SFL (https://savoirfairelinux.com) -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <!--
@@ -17,7 +18,7 @@ seapath_vm_manage role all variables must be defined before using this template.
 <domain type="kvm">
     <name>{{ vm_name }}</name>
     <uuid>{{ vm_uuid }}</uuid>
-    <title>VOTP {{ vm_name }}</title>
+    <title>{{ vm_name }}</title>
     <metadata>
         <!--You can add custom metadata here -->
     </metadata>

--- a/roles/seapath_import_vm_disk/meta/main.yml
+++ b/roles/seapath_import_vm_disk/meta/main.yml
@@ -7,6 +7,6 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9
   platforms:
-    - name: VOTP
+    - name: SEAPATH
       versions: all
 dependencies: []

--- a/roles/seapath_manage_disks/meta/main.yml
+++ b/roles/seapath_manage_disks/meta/main.yml
@@ -8,6 +8,6 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9
   platforms:
-    - name: VOTP
+    - name: SEAPATH
       versions: all
 dependencies: []

--- a/roles/seapath_vm_manage/meta/main.yml
+++ b/roles/seapath_vm_manage/meta/main.yml
@@ -7,6 +7,6 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9
   platforms:
-    - name: VOTP
+    - name: SEAPATH
       versions: all
 dependencies: []

--- a/templates/vm/vm.xml.j2
+++ b/templates/vm/vm.xml.j2
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright (C) 2021, RTE (http://www.rte-france.com) -->
+<!-- Copyright (C) 2024, SFL (https://savoirfairelinux.com) -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <!--
@@ -9,7 +10,7 @@
 <domain type="{{ vm_domaine | default('kvm') }}">
     <title>{{ title }}</title>
     <description>
-            VOTP guest without DPDK
+            SEAPATH guest without DPDK or RT feature
     </description>
     <memory unit="MiB">256</memory>
     <currentMemory unit="MiB">256</currentMemory>

--- a/templates/vm/vm_dpdk.xml.j2
+++ b/templates/vm/vm_dpdk.xml.j2
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright (C) 2021, RTE (http://www.rte-france.com) -->
+<!-- Copyright (C) 2024, SFL (https://savoirfairelinux.com) -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <!--
@@ -9,7 +10,7 @@
 <domain type="{{ vm_domaine | default('kvm') }}">
     <title>{{ title }}</title>
     <description>
-            VOTP guest with DPDK support
+            SEAPATH guest with DPDK support
     </description>
     <memory unit="GiB">1</memory>
     <currentMemory unit="GiB">1</currentMemory>

--- a/templates/vm/vm_dpdk_isolated.xml.j2
+++ b/templates/vm/vm_dpdk_isolated.xml.j2
@@ -1,14 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright (C) 2021, RTE (http://www.rte-france.com) -->
+<!-- Copyright (C) 2024, SFL (https://savoirfairelinux.com) -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <domain type="{{ vm_domaine | default('kvm') }}">
     <title>{{ title }}</title>
     <description>
-            VOTP guest with RT tweak without DPDK
+            SEAPATH guest with DPDK support running on a dedicated CPU core
     </description>
-    <memory unit="MiB">256</memory>
-    <currentMemory unit="MiB">256</currentMemory>
+    <memory unit="GiB">1</memory>
+    <currentMemory unit="GiB">1</currentMemory>
+    <memoryBacking>
+        <hugepages/>
+    </memoryBacking>
     <vcpu placement="static">1</vcpu>
     <os firmware="efi">
         <type arch="x86_64" machine="pc-i440fx-4.1">hvm</type>
@@ -21,15 +25,14 @@
         <acpi />
         <apic />
         <vmport state="off" />
-        <pmu state="off" />
     </features>
     <cputune>
         <vcpupin vcpu="0" cpuset="{{ cpuset }}"/>
-        <vcpusched vcpus="0" scheduler="fifo" priority="1" />
     </cputune>
     <cpu mode="host-passthrough">
-        <topology sockets="1" dies="1" cores="1" threads="1" />
-        <feature policy="require" name="tsc-deadline" />
+        <numa>
+            <cell id="0" cpus="0" memory="1" unit="GiB" memAccess="shared" />
+        </numa>
     </cpu>
     <clock offset="utc">
         <timer name="rtc" tickpolicy="catchup" />
@@ -45,11 +48,13 @@
     </pm>
     <devices>
         <emulator>/usr/bin/qemu-system-x86_64</emulator>
-        <interface type="ethernet">
-            <mac address="{{ mac_address }}"/>
-            <target dev="{{ ovs_port }}" managed="no"/>
-            <model type="virtio"/>
-            <alias name="net0"/>
+        <interface type='vhostuser'>
+            <source type='unix' path='/var/run/openvswitch/vm-sockets/dpdkvhostuser_{{ ovs_port }}' mode='server'/>
+            <mac address="{{ mac_address }}" />
+            <model type='virtio'/>
+            <driver name='vhost' rx_queue_size='1024' tx_queue_size='1024'>
+                <host mrg_rxbuf='on'/>
+            </driver>
         </interface>
         <controller type="pci" index="0" model="pci-root" />
         <serial type="pty">

--- a/templates/vm/vm_rt_dpdk.xml.j2
+++ b/templates/vm/vm_rt_dpdk.xml.j2
@@ -1,16 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright (C) 2021, RTE (http://www.rte-france.com) -->
+<!-- Copyright (C) 2024, SFL (https://savoirfairelinux.com) -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <domain type="{{ vm_domaine | default('kvm') }}">
     <title>{{ title }}</title>
     <description>
-            VOTP guest with DPDK support running on a dedicated CPU core
+        SEAPATH guest with DPDK support, RT optimisation and CPU isolation
     </description>
     <memory unit="GiB">1</memory>
     <currentMemory unit="GiB">1</currentMemory>
     <memoryBacking>
-        <hugepages/>
+        <hugepages>
+            <page size="1" unit="G" />
+        </hugepages>
+        <locked />
+        <nosharepages />
     </memoryBacking>
     <vcpu placement="static">1</vcpu>
     <os firmware="efi">
@@ -24,14 +29,18 @@
         <acpi />
         <apic />
         <vmport state="off" />
+        <pmu state="off" />
     </features>
     <cputune>
         <vcpupin vcpu="0" cpuset="{{ cpuset }}"/>
+        <vcpusched vcpus="0" scheduler="fifo" priority="1" />
     </cputune>
     <cpu mode="host-passthrough">
         <numa>
             <cell id="0" cpus="0" memory="1" unit="GiB" memAccess="shared" />
         </numa>
+        <topology sockets="1" dies="1" cores="1" threads="1" />
+        <feature policy="require" name="tsc-deadline" />
     </cpu>
     <clock offset="utc">
         <timer name="rtc" tickpolicy="catchup" />
@@ -47,15 +56,16 @@
     </pm>
     <devices>
         <emulator>/usr/bin/qemu-system-x86_64</emulator>
-        <interface type='vhostuser'>
-            <source type='unix' path='/var/run/openvswitch/vm-sockets/dpdkvhostuser_{{ ovs_port }}' mode='server'/>
+        <interface type="vhostuser">
+            <source type="unix" path="/var/run/openvswitch/vm-sockets/dpdkvhostuser_{{ ovs_port }}" mode="server" />
             <mac address="{{ mac_address }}" />
-            <model type='virtio'/>
-            <driver name='vhost' rx_queue_size='1024' tx_queue_size='1024'>
-                <host mrg_rxbuf='on'/>
+            <model type="virtio" />
+            <driver name="vhost" rx_queue_size="1024" tx_queue_size="1024">
+                <host mrg_rxbuf="on" />
             </driver>
         </interface>
         <controller type="pci" index="0" model="pci-root" />
+        <controller type="usb" model="none" />
         <serial type="pty">
             <target type="isa-serial" port="0">
                 <model name="isa-serial" />
@@ -64,8 +74,7 @@
         <console type="pty">
             <target type="serial" port="0" />
         </console>
-        <memballoon model="virtio">
-        </memballoon>
+        <memballoon model="none" />
         <watchdog model="ib700" action="poweroff" />
     </devices>
 </domain>

--- a/templates/vm/vm_rt_isolated.xml.j2
+++ b/templates/vm/vm_rt_isolated.xml.j2
@@ -1,20 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright (C) 2021, RTE (http://www.rte-france.com) -->
+<!-- Copyright (C) 2024, SFL (https://savoirfairelinux.com) -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <domain type="{{ vm_domaine | default('kvm') }}">
     <title>{{ title }}</title>
-    <description>VOTP guest with DPDK support, RT optimisation and CPU isolation
+    <description>
+            SEAPATH guest with RT tweak without DPDK
     </description>
-    <memory unit="GiB">1</memory>
-    <currentMemory unit="GiB">1</currentMemory>
-    <memoryBacking>
-        <hugepages>
-            <page size="1" unit="G" />
-        </hugepages>
-        <locked />
-        <nosharepages />
-    </memoryBacking>
+    <memory unit="MiB">256</memory>
+    <currentMemory unit="MiB">256</currentMemory>
     <vcpu placement="static">1</vcpu>
     <os firmware="efi">
         <type arch="x86_64" machine="pc-i440fx-4.1">hvm</type>
@@ -34,9 +29,6 @@
         <vcpusched vcpus="0" scheduler="fifo" priority="1" />
     </cputune>
     <cpu mode="host-passthrough">
-        <numa>
-            <cell id="0" cpus="0" memory="1" unit="GiB" memAccess="shared" />
-        </numa>
         <topology sockets="1" dies="1" cores="1" threads="1" />
         <feature policy="require" name="tsc-deadline" />
     </cpu>
@@ -54,16 +46,13 @@
     </pm>
     <devices>
         <emulator>/usr/bin/qemu-system-x86_64</emulator>
-        <interface type="vhostuser">
-            <source type="unix" path="/var/run/openvswitch/vm-sockets/dpdkvhostuser_{{ ovs_port }}" mode="server" />
-            <mac address="{{ mac_address }}" />
-            <model type="virtio" />
-            <driver name="vhost" rx_queue_size="1024" tx_queue_size="1024">
-                <host mrg_rxbuf="on" />
-            </driver>
+        <interface type="ethernet">
+            <mac address="{{ mac_address }}"/>
+            <target dev="{{ ovs_port }}" managed="no"/>
+            <model type="virtio"/>
+            <alias name="net0"/>
         </interface>
         <controller type="pci" index="0" model="pci-root" />
-        <controller type="usb" model="none" />
         <serial type="pty">
             <target type="isa-serial" port="0">
                 <model name="isa-serial" />
@@ -72,7 +61,8 @@
         <console type="pty">
             <target type="serial" port="0" />
         </console>
-        <memballoon model="none" />
+        <memballoon model="virtio">
+        </memballoon>
         <watchdog model="ib700" action="poweroff" />
     </devices>
 </domain>

--- a/tests/add_vm_from_template.yaml
+++ b/tests/add_vm_from_template.yaml
@@ -1,4 +1,5 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
+# Copyright (C) 2024, SFL (https://savoirfairelinux.com)
 # SPDX-License-Identifier: Apache-2.0
 
 # Test VM creation.
@@ -44,7 +45,7 @@
   vars:
      - vm_name: test0
      - state: create
-     - xml_template: "../templates/vm/votp_vm_dpdk.xml.j2"
+     - xml_template: "../templates/vm/vm_dpdk.xml.j2"
      - rbd_pool: rbd
      - os_disk: os0
      - data_disk: data0

--- a/tests/vm_template.xml.j2
+++ b/tests/vm_template.xml.j2
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright (C) 2020, RTE (http://www.rte-france.com) -->
+<!-- Copyright (C) 2024, SFL (https://savoirfairelinux.com) -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <!--
@@ -9,7 +10,7 @@
 <domain type="{{ vm_domain | default('qemu') }}">
     <name>{{ vm_name }}</name>
     <uuid>{{ vm_uuid }}</uuid>
-    <title>VOTP {{ vm_name }}</title>
+    <title>{{ vm_name }}</title>
     <description>
             Test template working with test_add_vm.yaml
     </description>


### PR DESCRIPTION
Remove all votp references in files or file names.

Two references remains :
- votp-config_ovs service
- votp-test-sync service.
This must be changed in meta-seapath first.