### PR TITLE
playbooks: deploy_vms_standalone: add gziped image support

### DIFF
--- a/inventories/seapath_vm_definition_example.yml
+++ b/inventories/seapath_vm_definition_example.yml
@@ -6,7 +6,7 @@ all:
   children:
     VMs:
       hosts:
-        guest:
+        guest1:
           description: "example VM"
           ansible_host: 192.168.212.131 # Update the VM IP
           vm_template: "../templates/vm/guest.xml.j2"
@@ -34,6 +34,19 @@ all:
           sriov:
             - sriov_pool1
             - sriov_pool2
+        guest2:
+          description: "Simple VM with gzipped disk"
+          ansible_host: 192.168.212.132 # Update the VM IP
+          vm_template: "../templates/vm/guest.xml.j2"
+          vm_disk: "../vm_images/guest.img.gz"
+          disk_extract: true
+          local_disk:
+              - disk_file: guest2.qcow2
+          vm_features: []
+          preferred_host: pc3 # Optional
+          bridges:
+            - name: "br0" # Change the bridge name
+              mac_address: "52:54:00:c4:ff:05" # change the MAC address
       vars:
         ansible_user: virtu
         apply_network_config: true
@@ -53,6 +66,7 @@ all:
 #                vm-manager)
 #    ** disk_file: name of the disk, note that you must give the same name as
 #                  the vm name.
+#  * disk_extract: if the disk image is gzipped, set the value to true.
 #  * vm_features: the VM feature (list). Can contained one or more of the
 #                 following items.
 #    ** isolated: to enable CPU pinning

--- a/playbooks/deploy_vms_standalone.yaml
+++ b/playbooks/deploy_vms_standalone.yaml
@@ -34,7 +34,19 @@
         src: "{{ hostvars[item].vm_disk }}"
         dest: "{{ disk_pool }}/{{ hostvars[item].inventory_hostname }}.qcow2"
       with_items: "{{ groups['VMs'] }}"
-      when: disk_copy | bool
+      when: disk_copy | bool and (hostvars[item].disk_extract is not defined or not hostvars[item].disk_extract | bool)
+    - name: Copy the gziped disk on target
+      copy:
+        src: "{{ hostvars[item].vm_disk }}"
+        dest: "{{ disk_pool }}/{{ hostvars[item].inventory_hostname }}.img.gz"
+      with_items: "{{ groups['VMs'] }}"
+      when: disk_copy | bool and hostvars[item].disk_extract is defined and hostvars[item].disk_extract | bool
+    - name: Extract the gziped disk on target
+      command:
+        cmd: "gzip -d -f {{ disk_pool }}/{{ hostvars[item].inventory_hostname }}.img.gz"
+        creates: "{{ hostvars[item].inventory_hostname }}.img"
+      with_items: "{{ groups['VMs'] }}"
+      when: disk_copy | bool and hostvars[item].disk_extract is defined and hostvars[item].disk_extract | bool
     - name: export VM config for debug in /tmp
       template:
         src: guest.xml.j2

--- a/templates/vm/guest.xml.j2
+++ b/templates/vm/guest.xml.j2
@@ -97,7 +97,7 @@
 	{% if vm.local_disk is defined %}
         {% for disk in vm.local_disk %}
         <disk type="file" device="disk">
-           <driver name="qemu" type="qcow2"/>
+           <driver name="qemu" type="{{ 'raw' if vm.disk_extract is defined and vm.disk_extract | bool is defined else 'qcow2' }}"/>
            <source file="/var/lib/libvirt/images/{{ disk.disk_file }}"/>
            <target dev="vda" bus="virtio"/>
         </disk>


### PR DESCRIPTION
Some VM images can be archived using gzip to reduce the size during the deployment. When setting the ansible variable `disk_extract` to true, the image disk is copied and unarchived on the target.