### PR TITLE
ci_vms_standalone_ptp.yaml: add vm ptp clock synchronisation in the CI

### DIFF
--- a/playbooks/ci_vms_standalone_ptp.yaml
+++ b/playbooks/ci_vms_standalone_ptp.yaml
@@ -1,0 +1,31 @@
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-Licence-Identifier: Apache-2.0
+
+# Ansible playbook that deploy and set-up ptp on vms for a standalone machine
+
+- import_playbook: deploy_vms_standalone.yaml
+
+- name: Check if phc2sys service is already started
+  hosts: VMs
+  tasks:
+    - name: Populate service facts
+      service_facts:
+
+    - name: Ensure phc2sys service is stopped
+      systemd:
+        name: phc2sys
+        state: stopped
+      when: "'phc2sys' in services"
+
+    - name: Copy systemd service file to server
+      copy:
+        src: ../src/phc2sys.service
+        dest: /etc/systemd/system
+        owner: root
+        group: root
+
+    - name: Start phc2sys service if not started
+      service:
+        name: phc2sys
+        state: started
+

--- a/src/phc2sys.service
+++ b/src/phc2sys.service
@@ -1,0 +1,14 @@
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-Licence-Identifier: Apache-2.0
+
+[Unit]
+Description=Synchronize system clock or PTP hardware clock (PHC)
+Documentation=man:phc2sys
+Before=time-sync.target
+
+[Service]
+Type=simple
+ExecStart=/usr/sbin/phc2sys -s /dev/ptp0 -c CLOCK_REALTIME -O 0 -m -q
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Synchronize the system clock of each vms with phc2sys.