### PR TITLE
iptables: add the possibility to use a jinja2 template

### DIFF
--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -319,6 +319,7 @@ all:
           INTERFACE4: []        # no filtering, including untagged trafic
 
         iptables_rules_path: "../inventories/iptables_rules_example.txt" #when defined, it uploads this file to /etc/iptables/rules.v4 and loads those rules
+        #iptables_rules_template_path: "../inventories/iptables_rules_example.txt.j2" #when defined, it templates then uploads this file to /etc/iptables/rules.v4 and loads those rules
         #cluster_protocol: "HSR" # RSTP or HSR, default is RSTP
         chrony_wait_timeout_sec: 180 #time in seconds the boot sequence will wait for chrony to sync. Optional : default is 180
 

--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -400,19 +400,41 @@
 
 - name: push iptables rules
   hosts: cluster_machines
-  become: true
   tasks:
+    - name: check presence of iptables_rules_path file
+      delegate_to: localhost
+      stat:
+        path: "{{ iptables_rules_path }}"
+      when: iptables_rules_path is defined
+      register: iptables_rules_path_present
     - name: copy iptables rules file
+      become: true
       ansible.builtin.copy:
         src: "{{ iptables_rules_path }}"
         dest: /etc/iptables/rules.v4
         mode: "0644"
-      when: iptables_rules_path is defined
+      when: iptables_rules_path is defined and iptables_rules_path_present.stat.exists
       register: iptables_rules
+    - name: check presence of iptables_rules_template_path file
+      delegate_to: localhost
+      stat:
+        path: "{{ iptables_rules_template_path }}"
+      when: iptables_rules_template_path is defined
+      register: iptables_rules_template_path_present
+    - name: copy iptables rules template file
+      become: true
+      template:
+        src: "{{ iptables_rules_template_path }}"
+        dest: /etc/iptables/rules.v4
+        mode: "0644"
+      when: iptables_rules_template_path is defined and iptables_rules_template_path_present.stat.exists
+      register: iptables_rules_template
+
     - name: reload iptables rules if needed
+      become: true
       ansible.builtin.shell:
         cmd: "/usr/sbin/iptables-restore < /etc/iptables/rules.v4"
-      when: iptables_rules.changed
+      when: iptables_rules.changed or iptables_rules_template.changed
 
 - name: Restart machine if needed
   hosts:


### PR DESCRIPTION
This commits allow the seapath user to use a template instead of a static file for the iptables rules.