### PR TITLE
Wait for VM to be online     

### DIFF
--- a/playbooks/deploy_vms_cluster.yaml
+++ b/playbooks/deploy_vms_cluster.yaml
@@ -38,3 +38,10 @@
         path: "/tmp/os_{{ item }}.qcow2"
         state: absent
       with_items: "{{ groups['VMs'] }}"
+
+- hosts: VMs
+  name: Wait for VMs to be online
+  gather_facts: false
+  tasks:
+    - name: Wait for VM connections
+      wait_for_connection:

--- a/playbooks/deploy_vms_standalone.yaml
+++ b/playbooks/deploy_vms_standalone.yaml
@@ -68,3 +68,10 @@
         name: "{{ item }}"
         state: running
       with_items: "{{ groups['VMs'] }}"
+
+- hosts: VMs
+  name: Wait for VMs to be online
+  gather_facts: false
+  tasks:
+    - name: Wait for VM connections
+      wait_for_connection:


### PR DESCRIPTION
On :
- deploy_vms_cluster.yaml
- deploy_vms_standalone.yaml 

This is particularly useful when we want to start another playbook on the VM, directly after this one.