### PR TITLE
guest.xml.j2: correct vm slice

### DIFF
--- a/templates/vm/guest.xml.j2
+++ b/templates/vm/guest.xml.j2
@@ -16,11 +16,13 @@
     <description>
         {{ vm.description |default("Test VM") }}
     </description>
-    {% if "rt" in vm.vm_features %}
     <resource>
-        <partition>/machine-rt</partition>
-    </resource>
+    {% if "rt" in vm.vm_features %}
+        <partition>/machine/rt</partition>
+    {% else %}
+        <partition>/machine/nort</partition>
     {% endif %}
+    </resource>
     <vcpu placement="static">{{ cpu_nb }}</vcpu>
     {% if "dpdk" in vm.vm_features %}
     <memory unit="GiB">1</memory>


### PR DESCRIPTION
If a VM has the RT features, it has to be put in the cgroup `/machine.slice/machine-rt.slice`. If not, it has to be put in `/machine.slice/machine-nort.slice`.

This commit corrects a bug in the xml file, RT VMs were not put in the RT slice.
It also puts non-RT VMs in the nort slice.