### PR TITLE
README: add a subsection on Ansible repo branch

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -224,6 +224,16 @@ For more information about roles see:
 https://docs.ansible.com/ansible/2.9/user_guide/playbooks_reuse_roles.html
 
 == Using Ansible with SEAPATH in practice
+First, make sure you are using the git branch corresponding to your
+version of Seapath.
+
+On Seapath Debian:
+
+  $ git checkout debian-main
+
+On Seapath Yocto:
+
+  $ git checkout main
 
 === Write your inventory file
 


### PR DESCRIPTION
When using the repo there can be a misunderstanding of using the main branch with Seapath Debian and debian-mai branch with Seapath Yocto. This commit adds a subsection to ensure user is using the correct branch depending of it version of Seapath.