### PR TITLE
Correct network playbook reboot debian

### DIFF
--- a/ansible-requirements.yaml
+++ b/ansible-requirements.yaml
@@ -7,7 +7,7 @@ roles:
     - name: "systemd_networkd"
       src: "https://github.com/seapath/ansible-role-systemd-networkd"
       scm: git
-      version: "461fe1d2bb8e0307aa1ec4be6316cf5c6fb0af80"
+      version: "11db8650fdb2e0dce655d7b2d8db27ce36621191"
 
     - name: "corosync"
       src: "https://github.com/seapath/corosync-ansible"

--- a/ansible-requirements.yaml
+++ b/ansible-requirements.yaml
@@ -7,7 +7,7 @@ roles:
     - name: "systemd_networkd"
       src: "https://github.com/seapath/ansible-role-systemd-networkd"
       scm: git
-      version: "3af47e369c7013782e0c4740638927955646471b"
+      version: "461fe1d2bb8e0307aa1ec4be6316cf5c6fb0af80"
 
     - name: "corosync"
       src: "https://github.com/seapath/corosync-ansible"

--- a/inventories/README.md
+++ b/inventories/README.md
@@ -1,4 +1,5 @@
 // Copyright (C) 2020, RTE (http://www.rte-france.com)
+// Copyright (C) 2024, SFL (https://savoirfairelinux.com)
 // SPDX-License-Identifier: CC-BY-4.0
 
 Inventories directory
@@ -9,3 +10,23 @@ We recommend to have 3 kinds of inventories:
 - The cluster description inventory, where you will populate the details of your nodes (ip, interface, network details, disks, etc.): a template is provided (seapath_cluster_definition_example.yml)
 - The OpenVSwitch topology inventory, where you will describe the different bridges and ports configuration for OVS: a template is provided (seapath_ovstopology_definition_example.yml)
 - The VM inventory, where you will describe all variables related to the virtual machine (number of cores, features, ip, network interface, etc.): a template is provided (seapath_vm_definition_example.yml)
+
+== Optionnal variables ==
+
+You can find concrete examples of the variables in the inventories of this directory. Below are optionnal advanced variables that are not described in the examples.
+
+=== Network implementation ===
+
+[source, yaml]
+----
+apply_network_config: true
+# If set to true, the OVS and systemd-network configuration will be applied at runtime, without a reboot.
+skip_reboot_setup_network: true
+# If set to true, the reboot at the end of the network playbook will be skipped. This is useful in the CI to apply all changes done by ansible within the final reboot. However, it can lead to race conditions if the inventory is not handled correctly.
+# It must be used with apply_network_config set to false, otherwise the reboot is already avoided.
+skip_recreate_team0_config: true
+# If set to true, the team0 ovs bridge of the cluster won't be destroyed and recreated by the network playbook.
+remove_all_networkd_config: true
+# If set to true, the network playbook will start by wiping the /etc/systemd/network/ directory content, this can help cleaning old conflicting files.
+# THIS MUST NOT BE USED WITH skip_recreate_team0_config at the same time or the cluster network config won't be recreated.
+----

--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -227,11 +227,6 @@ all:
         # Main network configuration
         gateway_addr: 10.0.0.1
         dns_servers: "8.8.8.8 8.8.4.4"
-        apply_network_config: false # do we restart the ovs_config script to apply the changes to the ovs topology (default: false)
-        #skip_reboot_setup_network: true # if we do not apply the changes (apply_network_config=false), then the network playbook will reboot the servers at the end. You can choose to skip this reboot here (default: false). It is recommended to let it to false except if you fully understand the network configuration process.
-        skip_recreate_team0_config: false # if defined and true, the network playbook won't try to destroy and recreate the team0 (cluster) bridge configuration (default is false)
-        remove_all_networkd_config: true  # if defined and true, the network playbook will start by wiping the /etc/systemd/network/ directory content, this can help cleaning old conflicting files. THIS MUST NOT BE USED WITH skip_recreate_team0_config at the same time or the cluster network config won't be recreated
-
         ntp_servers:
             - "185.254.101.25"
             - "51.145.123.29"

--- a/inventories/seapath_standalone_definition_example.yml
+++ b/inventories/seapath_standalone_definition_example.yml
@@ -39,7 +39,6 @@ all:
                             logstash_server_ip: 10.10.10.10
 
                             # Other Network configuration
-                            apply_network_config: true # true to apply the network configuration without rebooting
                             ptp_interface: "enp1s0f1" #OPTIONAL PTP Interface
                             ptp_vlanid: 100 #OPTIONAL VlanID for PTP
                             ptp_delay_mechanism: P2P # OPTIONAL E2E or P2P defaut is P2P

--- a/inventories/seapath_vm_definition_example.yml
+++ b/inventories/seapath_vm_definition_example.yml
@@ -1,5 +1,5 @@
 # Copyright (C) 2020-2023, RTE (http://www.rte-france.com)
-# Copyright (C) 2023, SFL (http://www.rte-france.com)
+# Copyright (C) 2023, SFL (https://savoirfairelinux.com)
 # SPDX-License-Identifier: Apache-2.0
 
 all:

--- a/inventories/seapath_vm_definition_example.yml
+++ b/inventories/seapath_vm_definition_example.yml
@@ -49,7 +49,6 @@ all:
               mac_address: "52:54:00:c4:ff:05" # change the MAC address
       vars:
         ansible_user: virtu
-        apply_network_config: true
         ip_addr: "{{ ansible_host }}"
 
 # This inventory can be customize using those fields :
@@ -96,5 +95,3 @@ all:
 #  * ovs: a list containing dictionaries of the OVS ports to use.
 #    ** ovs_port: the OVS port name (string)
 #    ** mac_address: the OVS port MAC address (string)
-#  * apply_network_config: to apply the network configuration without rebooting
-#    (bool).

--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -46,11 +46,21 @@
   hosts:
     - cluster_machines
     - standalone_machine
-    - VMs
   vars_files:
     - ../vars/network_vars.yml
   vars:
     systemd_networkd_apply_config: "{{ apply_network_config | default(false) }}"
+  roles:
+    - systemd_networkd
+
+- name: Apply systemd-networkd config on VMs
+  become: true
+  hosts:
+    - VMs
+  vars_files:
+    - ../vars/network_vars.yml
+  vars:
+    systemd_networkd_apply_config: "true"
   roles:
     - systemd_networkd
 

--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -314,6 +314,7 @@
         name: "timemaster"
         state: restarted
         enabled: true
+        daemon_reload: true
       when: timemasterconf1.changed or timemasterconf2.changed or timemasterconf3.changed
 
 - name: Stop chrony service

--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -49,6 +49,8 @@
     - VMs
   vars_files:
     - ../vars/network_vars.yml
+  vars:
+    systemd_networkd_apply_config: "{{ apply_network_config | default(false) }}"
   roles:
     - systemd_networkd
 

--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -64,18 +64,6 @@
   roles:
     - systemd_networkd
 
-- name: Apply .link files change (udev)
-  become: true
-  hosts:
-    - cluster_machines
-    - standalone_machine
-    - VMs
-  tasks:
-    - name: Restart systemd-udev-trigger
-      ansible.builtin.systemd:
-        name: systemd-udev-trigger
-        state: restarted
-
 - name: Configure cluster network
   hosts: cluster_machines
   become: true

--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -133,22 +133,6 @@
         when: hsr1.changed or hsr2.changed or hsr3.changed or hsrservice.changed
       when: cluster_protocol is defined and cluster_protocol == "HSR" and hsr_mac_address is defined
 
-- name: Apply systemd-networkd configuration
-  hosts:
-    - cluster_machines
-    - standalone_machine
-    - VMs
-  become: true
-  vars:
-    apply_config: "{{ apply_network_config | default(false) }}"
-  tasks:
-    - name: Reload systemd-networkd configuration
-      ansible.builtin.service:
-        name: systemd-networkd
-        state: reloaded
-      when:
-        apply_config
-
 - name: Configure OVS
   hosts:
     - cluster_machines

--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -426,8 +426,6 @@
 - name: Restart machine if needed
   hosts:
     - cluster_machines
-    - standalone_machine
-    - VMs
   become: true
   tasks:
     - block:

--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -1,4 +1,5 @@
 # Copyright (C) 2020, RTE (http://www.rte-france.com)
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # This Ansible playbook configures the networks and defines the hostnames. It
@@ -11,8 +12,6 @@
     - standalone_machine
     - VMs
   become: true
-  vars:
-    apply_config: "{{ apply_network_config | default(false) }}"
   tasks:
     - block:
       - name: wipe the /etc/systemd/network/ directory content 1/2, list files
@@ -65,7 +64,7 @@
         name: systemd-udev-trigger
         state: restarted
 
-- name: configure cluster network
+- name: Configure cluster network
   hosts: cluster_machines
   become: true
   tasks:
@@ -272,6 +271,8 @@
     - cluster_machines
     - standalone_machine
   become: true
+  vars:
+    apply_config: "{{ apply_network_config | default(false) }}"
   tasks:
     - name: Populate service facts
       service_facts:
@@ -304,10 +305,9 @@
         src: ../templates/timemaster.service.j2
         dest: /etc/systemd/system/timemaster.service.d/override.conf
       register: timemasterconf3
-    - name: start and enable timemaster
+    - name: Enable timemaster
       service:
         name: "timemaster"
-        state: started
         enabled: true
     - name: restart timemaster if necessary
       service:
@@ -315,7 +315,9 @@
         state: restarted
         enabled: true
         daemon_reload: true
-      when: timemasterconf1.changed or timemasterconf2.changed or timemasterconf3.changed
+      when:
+        - timemasterconf1.changed or timemasterconf2.changed or timemasterconf3.changed
+        - apply_config or (need_reboot is defined and not need_reboot)
 
 - name: Stop chrony service
   hosts:


### PR DESCRIPTION
Reload systemd-network only when the configuration has changed.
Correct a bug where timemaster could wait for a interface that would be created later in the playbook.