### PR TITLE
Backport debian network configuration

### DIFF
--- a/ansible-requirements.yaml
+++ b/ansible-requirements.yaml
@@ -7,7 +7,7 @@ roles:
     - name: "systemd_networkd"
       src: "https://github.com/seapath/ansible-role-systemd-networkd"
       scm: git
-      version: "3af47e369c7013782e0c4740638927955646471b"
+      version: "c7c97094eeb8d6e262e04148876457293fcd023e"
 
     - name: "corosync"
       src: "https://github.com/seapath/corosync-ansible"

--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -178,6 +178,8 @@
     - cluster_machines
     - standalone_machine
   become: true
+  vars:
+    apply_config: "{{ apply_network_config | default(false) }}"
   tasks:
     - name: Populate service facts
       service_facts:
@@ -215,17 +217,19 @@
         src: ../templates/timemaster.service.j2
         dest: /etc/systemd/system/timemaster.service.d/override.conf
       register: timemasterconf3
-    - name: start and enable timemaster
+    - name: Enable timemaster
       service:
         name: "timemaster"
-        state: started
         enabled: true
     - name: restart timemaster if necessary
       service:
         name: "timemaster"
         state: restarted
         enabled: true
-      when: timemasterconf1.changed or timemasterconf2.changed or timemasterconf3.changed
+        daemon_reload: true
+      when:
+        - timemasterconf1.changed or timemasterconf2.changed or timemasterconf3.changed
+        - apply_config or (need_reboot is defined and not need_reboot)
 
 - name: Stop chrony service if running
   hosts:

--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -9,6 +9,29 @@
 
 ---
 
+- name: Apply systemd-networkd config with role
+  become: true
+  hosts:
+    - cluster_machines
+    - standalone_machine
+  vars_files:
+    - ../vars/network_vars.yml
+  vars:
+    systemd_networkd_apply_config: "{{ apply_network_config | default(false) }}"
+  roles:
+    - systemd_networkd
+
+- name: Apply systemd-networkd config on VMs
+  become: true
+  hosts:
+    - VMs
+  vars_files:
+    - ../vars/network_vars.yml
+  vars:
+    systemd_networkd_apply_config: "true"
+  roles:
+    - systemd_networkd
+
 - name: Configure cluster network
   hosts: cluster_machines
   tasks:
@@ -52,14 +75,10 @@
         - not apply_config
         - ovs_conf.changed
 
-- name: Configure Network
+- name: Configure PTP
   hosts:
     - cluster_machines
     - standalone_machine
-  vars_files:
-    - ../vars/network_vars.yml
-  roles:
-    - systemd_networkd
   vars:
     apply_config: "{{ apply_network_config | default(false) }}"
   tasks:


### PR DESCRIPTION
This PR backports the work done on Debian in #447 
It resolves a bug on timemaster launch #422 and correct the reboot behavior of the network playbooks