### PR TITLE
networkd-wait: allows the user to customize the interface to wait for

### DIFF
--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -313,6 +313,8 @@ all:
           INTERFACE3: [1-4094]  # no filtering, excluding untagged trafic
           INTERFACE4: []        # no filtering, including untagged trafic
 
+        #interface_to_wait_for: eth3 #by default, systemd-networkd-wait-online will only wait for the cluster_network interface (team0 or hsr0). In some setup it is useful to customize the network_interface the most relevant to wait for at boot time. This variable will add an interface networkd will wait for at boot time
+
         iptables_rules_path: "../inventories/iptables_rules_example.txt" #when defined, it uploads this file to /etc/iptables/rules.v4 and loads those rules
         #iptables_rules_template_path: "../inventories/iptables_rules_example.txt.j2" #when defined, it templates then uploads this file to /etc/iptables/rules.v4 and loads those rules
         #cluster_protocol: "HSR" # RSTP or HSR, default is RSTP

--- a/templates/systemd-networkd-wait-online.service.j2
+++ b/templates/systemd-networkd-wait-online.service.j2
@@ -1,3 +1,3 @@
 [Service]
 ExecStart=
-ExecStart=/lib/systemd/systemd-networkd-wait-online -i {{ 'vlan'+br0vlan|string if br0vlan is defined else 'br0' }} {% if cluster_protocol is defined and cluster_protocol == 'HSR' %} -i hsr0 {% elif cluster_ip_addr is defined %} -i team0 {% endif %}
+ExecStart=/lib/systemd/systemd-networkd-wait-online {{ "-i " + interface_to_wait_for if interface_to_wait_for is defined }}{% if cluster_protocol is defined and cluster_protocol == 'HSR' %} -i hsr0 {% elif cluster_ip_addr is defined %} -i team0 {% endif %}


### PR DESCRIPTION
By default, systemd-networkd-wait-online will wait for br0 (or the vlan on br0 if using br0vlan variable) and the cluster_network interface (team0 or hsr0).
In some setups it is useful to customize the network_interface the most relevant to wait for at boot time.
This new variable will override "br0" as the name of the interface we will wait for.