### PR TITLE
Harmonize livemigration yocto

### DIFF
--- a/examples/inventories/advanced_inventory_cluster_example.yaml
+++ b/examples/inventories/advanced_inventory_cluster_example.yaml
@@ -225,11 +225,6 @@ all:
     # The vlan ID of the PTP. Remove the variable if the ptp frames
     # are not in a VLAN
     ptp_vlanid: 100
-    # Set to true to authorize VMs livemigration (default is false)
-    livemigration: true
-    # The name of the user used for the livemigration (default is virtu)
-    livemigrationuser: username
-    # Set to true to create the livemigration user with ansible (default is
-    # false). Let the variable to false if the user was already created during
-    # the build process
-    create_livemigration_user: true
+    # The name of the user used for the livemigration
+    # If not set, livemigration will be disabled
+    livemigration_user: username

--- a/playbooks/cluster_setup_add_livemigration_user.yaml
+++ b/playbooks/cluster_setup_add_livemigration_user.yaml
@@ -1,4 +1,5 @@
 # Copyright (C) 2022, RTE (http://www.rte-france.com)
+# Copyright (C) 2024, SFL (https://savoirfairelinux.com)
 # SPDX-License-Identifier: Apache-2.0
 
 # This playbook adds and configures the virtu user. This user is used by libvirt
@@ -8,8 +9,6 @@
 - name: Configure ssh keys between hosts
   hosts: hypervisors
   gather_facts: true
-  vars:
-    livemigration_user: "{{ livemigrationuser | default('virtu') }}"
   tasks:
       - block:
         - name: Create live migration user
@@ -63,4 +62,4 @@
             name: "{{ item }}"
             key: "{{ item }} {{ lookup('file','buffer/' + item + '-ssh_host_ed25519_key.pub') }}"
           with_items: "{{ groups['hypervisors'] }}"
-        when: create_livemigration_user is defined
+        when: livemigration_user is defined

--- a/playbooks/deploy_vms_cluster.yaml
+++ b/playbooks/deploy_vms_cluster.yaml
@@ -21,8 +21,8 @@
         command: create
         system_image: /tmp/os_{{ item }}.qcow2
         force: true
-        live_migration: "{{ livemigration | default(false) }}"
-        migration_user: "{{ livemigration_user | default('root') }}"
+        live_migration: "{{ livemigration_user is defined }}"
+        migration_user: "{{ livemigration_user | default(omit) }}"
         migrate_to_timeout: "{{ hostvars[item].migrate_to_timeout | default('') }}"
         enable: true
         pinned_host: "{{ hostvars[item].pinned_host | default(omit) }}"


### PR DESCRIPTION
Correct a bug on the livemigration playbook.
Remove two variables in the inventory. The livemigration user is now only handled by the variable `livemigration_user`.