### PR TITLE
Inventories move cgroup to readme

### DIFF
--- a/inventories/README.md
+++ b/inventories/README.md
@@ -16,25 +16,13 @@ It is possible with Ansible to provides [multiple inventories files](https://doc
 * the physical machines
 * the cluster internal network (Open vSwitch topology)
 * the virtual machines
-## SEAPATH Ansible inventories examples description
 
-All inventories examples are in YAML format. The example inventories are:
-* `seapath_demo_cluster_definition_example.yml`: SEAPATH cluster demo
-* `seapath_standalone_definition_example.yml`: SEAPATH standalone hypervisor setup
-* The complex SEAPATH cluster inventories are:
-	* `seapath_cluster_definition_example.yml`: physical machines
-	* `seapath_ovstopology_definition_example.yml`: cluster internal network (Open vSwitch topology)
-	* `seapath_vm_definition_example.yml`: virtual machines
+## Advanced variables
 
-The directory also contains the firewall rules `iptables_rules_example.txt` which are referring in `seapath_cluster_definition_example.yml`.
+You can find concrete examples of the variables in the inventories of this directory.
+Below are optional advanced variables that are not described in the examples.
 
-The simple SEAPATH cluster inventory require only minor tweak to be adapted. In all other files described, all the options which do not match a realistic case and need to be modified are indicated.
-
-### Optional variables
-
-You can find concrete examples of the variables in the inventories of this directory. Below are optional advanced variables that are not described in the examples.
-
-#### Network implementation
+### Network implementation
 
 ```yaml
 apply_network_config: true
@@ -48,6 +36,20 @@ remove_all_networkd_config: true
 # If set to true, the network playbook will start by wiping the /etc/systemd/network/ directory content, this can help cleaning old conflicting files.
 # THIS MUST NOT BE USED WITH skip_recreate_team0_config at the same time or the cluster network config won't be recreated.
 ```
+
+## SEAPATH Ansible inventories examples description
+
+All inventories examples are in YAML format. The example inventories are:
+* `seapath_demo_cluster_definition_example.yml`: SEAPATH cluster demo
+* `seapath_standalone_definition_example.yml`: SEAPATH standalone hypervisor setup
+* The complex SEAPATH cluster inventories are:
+	* `seapath_cluster_definition_example.yml`: physical machines
+	* `seapath_ovstopology_definition_example.yml`: cluster internal network (Open vSwitch topology)
+	* `seapath_vm_definition_example.yml`: virtual machines
+
+The directory also contains the firewall rules `iptables_rules_example.txt` which are referring in `seapath_cluster_definition_example.yml`.
+
+The simple SEAPATH cluster inventory require only minor tweak to be adapted. In all other files described, all the options which do not match a realistic case and need to be modified are indicated.
 
 ### SEAPATH demo cluster inventory
 

--- a/inventories/README.md
+++ b/inventories/README.md
@@ -37,6 +37,28 @@ remove_all_networkd_config: true
 # THIS MUST NOT BE USED WITH skip_recreate_team0_config at the same time or the cluster network config won't be recreated.
 ```
 
+### Cgroup configuration
+
+These variables configures cgroup on an hypervisor. More information on the wiki : https://wiki.lfenergy.org/display/SEAP/Scheduling+and+priorization
+
+```yaml
+cpusystem: "0,12" # List of allowed CPUs for the system slice (default is all CPUs)
+cpuuser: "1,13" # List of allowed CPUs for the user slice (default is all CPUs)
+cpumachines: "2-11,14-23" # List of allowed CPUs for the machine slice (default is all CPUs)
+
+cpumachinesrt: "2-5,14-17" # Create the machine-rt slice and list all allowed CPUs for it.
+# This slice will be used for Real time virtual machines
+# If not provided, the machine-rt slice will not be created.
+cpumachinesnort: "6-11,18-23" # Create the machine-nort slice and list all allowed CPUs for it.
+# This slice will be used for virtual machines without real time needs
+# If not provided, the machine-nort slice will not be created.
+cpuovs: "23" # Create the ovs slice and list all allowed CPUs for it.
+# This slice will be used for ovs processes.
+# If not provided, the ovs slice will not be created.
+```
+
+More information on the format for a cpu list here : https://docs.kernel.org/admin-guide/kernel-parameters.html#cpu-lists
+
 ## SEAPATH Ansible inventories examples description
 
 All inventories examples are in YAML format. The example inventories are:

--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -136,16 +136,9 @@ all:
                         #OPTIONAL
                         logstash_server_ip: 10.10.10.10
 
-                        # Realtime/CPUs cgroups isolation configuration
-                        # All those parameters are optional.
-                        isolcpus: "2-5,14-17" # CPUs to isolate
-
-                        cpusystem: "0,12" # CPUs reserves for system
-                        cpuuser: "1,13" # CPUs reserves for user applications
-                        cpumachines: "2-11,14-23" # CPUs reserves for VMs
-                        cpumachinesrt: "2-5,14-17" # CPUs reserves for VMs realtime
-                        cpumachinesnort: "6-11,18-23" # CPUs reserves for VMs non realtime
-                        cpuovs: "23" # CPUs reserves for OVS
+                        isolcpus: "2-5,14-17" # List of CPU to isolate
+                        # No process or IRQs will run on these cores
+                        # They should be used by the real time virtual machines.
 
         # Ceph groups
         # All machines in the cluster must be part of mons groups

--- a/inventories/seapath_standalone_definition_example.yml
+++ b/inventories/seapath_standalone_definition_example.yml
@@ -48,15 +48,9 @@ all:
                             sriov:
                               'eno12429': 7
 
-                            # Realtime/CPUs cgroups isolation configuration
-                            isolcpus: "2-5,14-17" # CPUs to isolate
-
-                            cpusystem: "0,12" # CPUs reserves for system
-                            cpuuser: "1,13" # CPUs reserves for user applications
-                            cpumachines: "2-11,14-23" # CPUs reserves for VMs
-                            cpumachinesrt: "2-5,14-17" # CPUs reserves for VMs realtime
-                            cpumachinesnort: "6-11,18-23" # CPUs reserves for VMs non realtime
-                            cpuovs: "23" # CPUs reserves for OVS
+                            isolcpus: "2-5,14-17" # List of CPU to isolate
+                            # No process or IRQs will run on these cores
+                            # They should be used by the real time virtual machines.
 
                             # Affinity
                             nics_affinity: # Optional, only useful with RT containers or macvtag VMs


### PR DESCRIPTION
Move the description of the cgroups in the README instead of directly in the inventories