### PR TITLE
seapath_demo_cluster_example: add interface to wait for at boot time

### DIFF
--- a/inventories/seapath_demo_cluster_definition_example.yml
+++ b/inventories/seapath_demo_cluster_definition_example.yml
@@ -146,3 +146,4 @@ all:
           - "ssh-rsa key2XXX"
         # account used for libvirt live-migration
         livemigration_user: livemigration
+        interface_to_wait_for: br0


### PR DESCRIPTION
Modification corrolated to the commit 882ddd54a5f1152c628b903a25999b6a2d57816d
In the demo cluster, cluster_protocol and cluster_ip_addr are not defined. So, systemd-networkd-wait-online was waiting for all interfaces to be configured whereas it should only be waiting for br0.