### PR TITLE
tuned: change printk settings

### DIFF
--- a/src/tuned/tuned.conf.j2
+++ b/src/tuned/tuned.conf.j2
@@ -7,13 +7,13 @@ isolated_cores={{ isolcpus | default('') }}
 non_isolated_cores_expanded=${f:cpulist_unpack:${non_isolated_cores}}
 
 [sysctl]
-kernel.printk=3 3 3 3
+kernel.printk=3 1 1 7
 
 [sysfs]
 /sys/module/kvm/parameters/halt_poll_ns = 0
 
 [bootloader]
-cmdline_srh=+processor.max_cstate=1 intel_idle.max_cstate=1 cpufreq.default_governor=performance rcu_nocb_poll printk.devkmsg=off
+cmdline_srh=+processor.max_cstate=1 intel_idle.max_cstate=1 cpufreq.default_governor=performance rcu_nocb_poll
 
 [scheduler]
 # for i in `pgrep rcuc` ; do grep Cpus_allowed_list /proc/$i/status ; done


### PR DESCRIPTION
To limit the amount of kernel logging printing directly to the console
\+ the lvm snapshot rebooter in place in the CI is not compatible with printk.devkmsg=off, we need to remove this option asap for the CI to be functionnal again.