### PR TITLE
ci-yocto.yml: fix VMs tests call

### DIFF
--- a/.github/workflows/ci-yocto.yml
+++ b/.github/workflows/ci-yocto.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Launch VMs tests
         run: cd ${{ env.WORK_DIR }};
-             ci/launch-yocto.sh tests_vm;
+             ci/launch-yocto.sh test_vms;
 
       - name: Upload test report
         if: ${{ always() && steps.conf.conclusion == 'success' }}


### PR DESCRIPTION
Fixed the name of the VM test call that was changed in the launch-yocto.sh script.