### PR TITLE
pcap_loop: add longer latency test for the weekly CI

### DIFF
--- a/.github/workflows/ci-yocto-weekly.yml
+++ b/.github/workflows/ci-yocto-weekly.yml
@@ -6,6 +6,9 @@
 
 name: CI weekly Yocto
 
+env:
+    PCAP_LOOP: 6000
+
 on:
   schedule:
     - cron: '30 22 * * 6'

--- a/playbooks/ci_latency_tests.yaml
+++ b/playbooks/ci_latency_tests.yaml
@@ -96,8 +96,6 @@
 - name: Launch pcap sending
   hosts: publisher_machine
   become: true
-  vars:
-      pcap_loop: 10
   tasks:
     - name: "Create pcaps directory if it doesn't exist"
       file:


### PR DESCRIPTION
Delete the pcap_loop default value to a system where the number of loops must be supplied. And set of 6000 iterations for the weekly CI.