### PR TITLE
.github/workflows: restrict permissions

### DIFF
--- a/.github/workflows/ansible-lint-debian-weekly.yml
+++ b/.github/workflows/ansible-lint-debian-weekly.yml
@@ -13,6 +13,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  actions: write
+
 jobs:
   ansible-lint:
     runs-on: self-hosted

--- a/.github/workflows/ansible-lint-yocto-weekly.yml
+++ b/.github/workflows/ansible-lint-yocto-weekly.yml
@@ -11,6 +11,9 @@ on:
     - cron: '30 22 * * 6'
   workflow_dispatch:
 
+permissions:
+  actions: write
+
 jobs:
   call-workflow:
     uses: ./.github/workflows/ansible-lint-yocto.yml

--- a/.github/workflows/ansible-lint-yocto.yml
+++ b/.github/workflows/ansible-lint-yocto.yml
@@ -12,6 +12,9 @@ on:
     branches: [main]
   workflow_call:
 
+permissions:
+  checks: write
+
 jobs:
   ansible-lint:
     runs-on: self-hosted

--- a/.github/workflows/ci-debian-weekly.yml
+++ b/.github/workflows/ci-debian-weekly.yml
@@ -13,6 +13,10 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  actions: write
+  checks: write
+
 jobs:
   CI:
     runs-on: [self-hosted, runner-RTE-12]

--- a/.github/workflows/ci-yocto-weekly.yml
+++ b/.github/workflows/ci-yocto-weekly.yml
@@ -14,6 +14,10 @@ on:
     - cron: '30 22 * * 6'
   workflow_dispatch:
 
+permissions:
+  actions: write
+  checks: write
+
 jobs:
   call-workflow:
     uses: ./.github/workflows/ci-yocto.yml

--- a/.github/workflows/ci-yocto.yml
+++ b/.github/workflows/ci-yocto.yml
@@ -12,6 +12,10 @@ on:
     branches: [main]
   workflow_call:
 
+permissions:
+  actions: write
+  checks: write
+
 jobs:
   CI:
     runs-on: [self-hosted, runner-SFL]


### PR DESCRIPTION
Restrict permissions of the CI workflows:
- `actions: write` allows cancelling the workflow if a cukinia test fails
- `checks: write` allows validating the check.