### PR TITLE
.github/workflows: restrict permissions

### DIFF
--- a/.github/workflows/ansible-lint-debian-weekly.yml
+++ b/.github/workflows/ansible-lint-debian-weekly.yml
@@ -11,6 +11,9 @@ on:
     - cron: '30 22 * * 6'
   workflow_dispatch:
 
+permissions:
+  actions: write
+
 jobs:
   call-workflow:
     uses: ./.github/workflows/ansible-lint-debian.yml

--- a/.github/workflows/ansible-lint-debian.yml
+++ b/.github/workflows/ansible-lint-debian.yml
@@ -12,6 +12,9 @@ on:
     branches: [debian-main]
   workflow_call:
 
+permissions:
+  actions: write
+
 jobs:
   ansible-lint:
     runs-on: self-hosted

--- a/.github/workflows/ci-debian-weekly.yml
+++ b/.github/workflows/ci-debian-weekly.yml
@@ -12,6 +12,10 @@ on:
     - cron: '30 22 * * 6'
   workflow_dispatch:
 
+permissions:
+  actions: write
+  checks: write
+
 jobs:
   call-workflow:
     uses: ./.github/workflows/ci-debian.yml

--- a/.github/workflows/ci-debian.yml
+++ b/.github/workflows/ci-debian.yml
@@ -12,6 +12,10 @@ on:
     branches: [debian-main]
   workflow_call:
 
+permissions:
+  actions: write
+  checks: write
+
 jobs:
   CI:
     runs-on: [self-hosted, runner-RTE-12]


### PR DESCRIPTION
Restrict permissions of the CI workflows:
- `actions: write` allows cancelling the workflow if a cukinia test fails
- `checks: write` allows validating the check.