### PR TITLE
Correct standalone VM main disk creation

### DIFF
--- a/inventories/seapath_vm_definition_example.yml
+++ b/inventories/seapath_vm_definition_example.yml
@@ -39,7 +39,7 @@ all:
           vm_template: "../templates/vm/guest.xml.j2"
           vm_disk: "../vm_images/guest.img.gz"
           disk_extract: true
-          local_disk:
+          additionnal_disk:
               - disk_file: second_disk.qcow2
           vm_features: []
           preferred_host: pc3 # Optional
@@ -65,7 +65,7 @@ all:
 #                 templates/vm/guest.xml.j2. In most cases, you should not
 #                 change this.
 #  * vm_disk: the image to use for the VM creation
-#  * local_disk: list of additionnal VM disks.
+#  * additionnal_disk: list of additionnal VM disks.
 #    ** disk_file: name of the disk.
 #  * disk_extract: if the disk image is gzipped, set the value to true.
 #  * vm_features: the VM feature (list). Can contained one or more of the

--- a/playbooks/deploy_vms_standalone.yaml
+++ b/playbooks/deploy_vms_standalone.yaml
@@ -48,10 +48,9 @@
       with_items: "{{ groups['VMs'] }}"
       when: disk_copy | bool and hostvars[item].disk_extract is defined and hostvars[item].disk_extract | bool
     - name: Add main disk to disk list
-      # This task reuse the optional local_disk variable and put the qcow2 of the VM at the beginning of the list
-      # This allow the VM to boot on this disk without having to write it manually in the inventory
+      # This is only done in standalone because the disk is handled by vm-manager in the cluster
       set_fact:
-        local_disk: "{{ [{'disk_file': '{{ hostvars[item].inventory_hostname }}.qcow2'}] + (local_disk | default([])) }}"
+        standalone_main_disk: "{{ hostvars[item].inventory_hostname }}.qcow2"
       delegate_to: "{{ item }}"
       delegate_facts: true
       with_items: "{{ groups['VMs'] }}"

--- a/templates/vm/guest.xml.j2
+++ b/templates/vm/guest.xml.j2
@@ -103,8 +103,8 @@
            <target dev="vda" bus="virtio"/>
         </disk>
         {% endif %}
-        {% if vm.local_disk is defined %}
-        {% for disk in vm.local_disk %}
+        {% if vm.additionnal_disk is defined %}
+        {% for disk in vm.additionnal_disk %}
         <disk type="file" device="disk">
            <driver name="qemu" type="{{ 'raw' if vm.disk_extract is defined and vm.disk_extract | bool is defined else 'qcow2' }}"/>
            <source file="/var/lib/libvirt/images/{{ disk.disk_file }}"/>

--- a/templates/vm/guest.xml.j2
+++ b/templates/vm/guest.xml.j2
@@ -96,7 +96,14 @@
     </pm>
     <devices>
         <emulator>/usr/bin/qemu-system-x86_64</emulator>
-	{% if vm.local_disk is defined %}
+        {% if vm.standalone_main_disk is defined %}
+        <disk type="file" device="disk">
+           <driver name="qemu" type="{{ 'raw' if vm.disk_extract is defined and vm.disk_extract | bool is defined else 'qcow2' }}"/>
+           <source file="/var/lib/libvirt/images/{{ vm.standalone_main_disk }}"/>
+           <target dev="vda" bus="virtio"/>
+        </disk>
+        {% endif %}
+        {% if vm.local_disk is defined %}
         {% for disk in vm.local_disk %}
         <disk type="file" device="disk">
            <driver name="qemu" type="{{ 'raw' if vm.disk_extract is defined and vm.disk_extract | bool is defined else 'qcow2' }}"/>


### PR DESCRIPTION
Add the standalone main disk automatically to the libvirt XML.
Previous version use the `local_disk` variable, but the behaviour is not scalable to multiple VMs