### PR TITLE
workflows/ansible-lint: correct rigths

### DIFF
--- a/.github/workflows/ansible-lint-debian-weekly.yml
+++ b/.github/workflows/ansible-lint-debian-weekly.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  actions: write
+  checks: write
 
 jobs:
   ansible-lint:

--- a/.github/workflows/ansible-lint-yocto-weekly.yml
+++ b/.github/workflows/ansible-lint-yocto-weekly.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  actions: write
+  checks: write
 
 jobs:
   call-workflow:


### PR DESCRIPTION
The action right is not useful because ansible lint doesn't need to spawn or stop actions.
Checks write is needed to appear on SEAPATH main github page.