### PR TITLE
introducing conntrackd for conntrack table synchronization

### DIFF
--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -333,3 +333,8 @@ all:
         # optional extra permissions to add to Debian-snmp sudoers file
         extra_debiansnmp_sudoers: |
           Debian-snmp     ALL = (hacluster) NOPASSWD:EXEC: /usr/local/bin/snmp_crmstatus.sh ""
+
+        # optional conntrackd synchronization configuration. This is useful when using the hosts as routers if you want the conntrack tables to be synchronized among hosts. If conntrackd_ip_list is defined it will enable the appropriate portion of the playbook, and the content will be used as the list of IP addresses to enable conntrack synchronization on.
+        conntrackd_ip_list: |
+          IPv4_address 10.0.0.0/8
+          IPv4_address 192.168.99.0/24

--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -89,6 +89,11 @@
         command: "/usr/bin/ovs-vsctl set Bridge team0 rstp_enable=true"
       - name: Set RSTP priority on team0 bridge
         command: "/usr/bin/ovs-vsctl set Bridge team0 other_config=rstp-priority={{ br_rstp_priority }}"
+      - name: Restart conntrackd
+        ansible.builtin.systemd:
+          name: conntrackd
+          state: restarted
+        when: conntrackd_ip_list is defined
       when:
         - cluster_protocol is not defined or cluster_protocol != "HSR" or hsr_mac_address is not defined
         - skip_recreate_team0_config is not defined or skip_recreate_team0_config is not true
@@ -444,6 +449,32 @@
       ansible.builtin.shell:
         cmd: "/usr/sbin/iptables-restore < /etc/iptables/rules.v4"
       when: iptables_rules.changed or iptables_rules_template.changed
+
+- name: conntrackd
+  hosts: cluster_machines
+  become: true
+  tasks:
+    - block:
+        - name: copy conntrackd.conf file
+          template:
+            src: ../src/conntrackd/conntrackd.conf.j2
+            dest: /etc/conntrackd/conntrackd.conf
+            group: root
+            owner: root
+            mode: '0644'
+          register: conntrackdconf
+        - name: enable conntrackd.service
+          ansible.builtin.systemd:
+            name: conntrackd.service
+            enabled: yes
+            state: started
+        - name: enable conntrackd.service
+          ansible.builtin.systemd:
+            name: conntrackd.service
+            enabled: yes
+            state: restarted
+          when: conntrackdconf.changed
+      when: conntrackd_ip_list is defined
 
 - name: Configure snmp
   hosts:

--- a/roles/debian/hypervisor/tasks/main.yml
+++ b/roles/debian/hypervisor/tasks/main.yml
@@ -272,3 +272,10 @@
     name: ptp_vsock.service
     enabled: yes
     state: started
+
+- block:
+  - name: make sure conntrackd package is installed
+    ansible.builtin.apt:
+      name: conntrackd
+      state: present
+  when: conntrackd_ip_list is defined

--- a/src/conntrackd/conntrackd.conf.j2
+++ b/src/conntrackd/conntrackd.conf.j2
@@ -1,0 +1,50 @@
+Sync {
+        Mode NOTRACK {
+                DisableInternalCache on
+                DisableExternalCache on
+                StartupResync on
+        }
+        Multicast {
+                IPv4_address 225.0.0.50
+                Group 3780
+		IPv4_interface {{ cluster_ip_addr }}
+                Interface team0
+                SndSocketBuffer 1249280
+                RcvSocketBuffer 1249280
+                Checksum on
+        }
+        Options {
+                TCPWindowTracking Off
+                ExpectationSync On
+        }
+}
+General {
+        Systemd on
+        HashSize 32768
+        HashLimit 131072
+        Syslog on
+        LockFile /var/lock/conntrackd.lock
+        UNIX {
+                Path /var/run/conntrackd.sock
+        }
+        NetlinkBufferSize 2097152
+        NetlinkBufferSizeMaxGrowth 8388608
+        NetlinkOverrunResync On
+        NetlinkEventsReliable Off
+        EventIterationLimit 100
+        Filter From Kernelspace {
+                Protocol Accept {
+                        TCP
+                }
+                Address Accept {
+                        {{ conntrackd_ip_list | indent( width=24, first=False) }}
+                }
+                State Accept {
+                        ESTABLISHED CLOSED TIME_WAIT CLOSE_WAIT for TCP
+                }
+        }
+        Scheduler {
+                Type RR
+                Priority 0
+        }
+}


### PR DESCRIPTION
Adds optional conntrackd synchronization feature.
This is useful when using the hosts as routers (when using iptables for flow security between bridges), if you want the conntrack tables to be synchronized among hosts. This is necessary because when the default gateways for the routed networks migrate, the connection tracking status is lost.
If conntrackd_ip_list is defined it will enable the appropriate portion of the playbook, and the content will be used as the list of IP addresses to enable conntrack synchronization on.
