### PR TITLE
ci_latency_tests: fix synchronise machine with ptp play

### DIFF
--- a/playbooks/ci_latency_tests.yaml
+++ b/playbooks/ci_latency_tests.yaml
@@ -52,6 +52,7 @@
         daemon-reload: true
         state: restarted
 
+- name: Launch sv timestamp logger on publisher
   hosts: publisher_machine
   become: true
   tasks:


### PR DESCRIPTION
The next play had no name, so the play synchronized machine with ptp was skipped.