### PR TITLE
ci_latency_tests: launch with zero sv flag

### DIFF
--- a/playbooks/ci_latency_tests.yaml
+++ b/playbooks/ci_latency_tests.yaml
@@ -74,6 +74,7 @@
         -d {{ sv_interface }}
         -f "/tmp/latency_tests/ts_{{ inventory_hostname }}.txt"
         -t
+        -l
 
 - name: Launch sv timestamp logger on VMs
   hosts: VMs
@@ -94,6 +95,7 @@
         sv_timestamp_logger
         -d {{ sv_interface }}
         -f "/tmp/latency_tests/ts_{{ inventory_hostname }}.txt"
+        -l
 
 - name: Launch pcap sending
   hosts: publisher_machine


### PR DESCRIPTION
Launch sv_timestamp_logger with log_only_SV_cnt_0, wich will log only the SV with index 0, in order to save space.