### PR TITLE
conntrackd cleanup and bugfix

### DIFF
--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -475,6 +475,13 @@
             state: restarted
           when: conntrackdconf.changed
       when: conntrackd_ip_list is defined
+    - block:
+        - name: stop and disable conntrackd.service
+          ansible.builtin.systemd:
+            name: conntrackd.service
+            enabled: no
+            state: stopped
+      when: conntrackd_ip_list is defined
 
 - name: Configure snmp
   hosts:

--- a/roles/debian/hypervisor/tasks/main.yml
+++ b/roles/debian/hypervisor/tasks/main.yml
@@ -152,18 +152,6 @@
     - "ovs"
   when: removeslices.changed
 
-- name: make sure tuned package is installed
-  ansible.builtin.apt:
-    name: tuned
-    state: present
-
-- name: Remove tuna
-  ansible.builtin.apt:
-    autoremove: yes
-    purge: true
-    name: tuna
-    state: absent
-
 - name: Remove old isolation files
   file:
     state: absent
@@ -272,10 +260,3 @@
     name: ptp_vsock.service
     enabled: yes
     state: started
-
-- block:
-  - name: make sure conntrackd package is installed
-    ansible.builtin.apt:
-      name: conntrackd
-      state: present
-  when: conntrackd_ip_list is defined

--- a/roles/debian/hypervisor/tasks/main.yml
+++ b/roles/debian/hypervisor/tasks/main.yml
@@ -260,3 +260,25 @@
     name: ptp_vsock.service
     enabled: yes
     state: started
+
+- name: Create conntrackd.service.d directory
+  file:
+    path: /etc/systemd/system/conntrackd.service.d/
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+- name: Copy conntrackd.service drop-in
+  ansible.builtin.copy:
+    src: ../src/debian/conntrackd_override.conf
+    dest: /etc/systemd/system/conntrackd.service.d/override.conf
+    owner: root
+    group: root
+    mode: 0644
+  register: conntrackd
+- name: Restart conntrackd
+  ansible.builtin.systemd:
+    state: restarted
+    daemon_reload: yes
+    name: conntrackd
+  when: conntrackd.changed

--- a/src/debian/conntrackd_override.conf
+++ b/src/debian/conntrackd_override.conf
@@ -1,0 +1,3 @@
+[Unit]
+Requires=network-online.target
+After=network-online.target


### PR DESCRIPTION
remove apt dynamic installation of tuned and conntrackd
since the packages are preinstalled with build_debian_iso and that the CI has been upgraded with those packages

----
Make sure conntrackd is stopped/disabled if not useful

----
conntrackd.service: adds dependancy to network.online
to make sure team0 is up and running before starting conntrackd