### PR TITLE
cluster_setup_add_livemigration_user: use only hypervisors

### DIFF
--- a/playbooks/cluster_setup_add_livemigration_user.yaml
+++ b/playbooks/cluster_setup_add_livemigration_user.yaml
@@ -53,14 +53,14 @@
             state: present
             path: "/home/{{ livemigration_user }}/.ssh/authorized_keys"
             key: "{{ lookup('file','buffer/' + item + '-id_rsa.pub') }}"
-          with_items: "{{ groups['cluster_machines'] }}"
+          with_items: "{{ groups['hypervisors'] }}"
         - name: Copy the key to admin user's authorized_keys using Ansible module
           authorized_key:
             user: "{{ admin_user }}"
             state: present
             path: "/home/{{ admin_user }}/.ssh/authorized_keys"
             key: "{{ lookup('file','buffer/' + item + '-id_rsa.pub') }}"
-          with_items: "{{ groups['cluster_machines'] }}"
+          with_items: "{{ groups['hypervisors'] }}"
         - name: Fetch the ssh keyfile
           fetch:
             src: "/etc/ssh/ssh_host_ed25519_key.pub"
@@ -71,5 +71,5 @@
             path: "{{ root_home_dir.stdout }}/.ssh/known_hosts"
             name: "{{ item }}"
             key: "{{ item }} {{ lookup('file','buffer/' + item + '-ssh_host_ed25519_key.pub') }}"
-          with_items: "{{ groups['cluster_machines'] }}"
+          with_items: "{{ groups['hypervisors'] }}"
         when: livemigration_user is defined


### PR DESCRIPTION
The livemigration user is not created on observers. It's key should not be transmitted to observers.