### PR TITLE
ansible.cfg: set gathering to explicit

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -19,7 +19,7 @@ collections_paths = ./collections:~/.ansible/collections:/usr/share/ansible/coll
 # Uncomment this if you want disable the ssh key check. It is useful in
 # developement but must not be set in production.
 #host_key_checking = False
-gathering = False
+gathering = explicit
 nocows = 1
 callback_whitelist = profile_tasks
 stdout_callback = yaml


### PR DESCRIPTION
False is not a valid value for the gathering option. The correct value is explicit. Ansible version greater than 2.10 will raise an error if the value is set to False.