### PR TITLE
cluster_setup_ceph: fix installation on NVMe disks

### DIFF
--- a/playbooks/cluster_setup_ceph_expansion.yaml
+++ b/playbooks/cluster_setup_ceph_expansion.yaml
@@ -12,21 +12,23 @@
             list_pvs: "{{ ansible_lvm['pvs'] | dict2items | community.general.json_query(query) }}"
           vars:
             query: "[?value.vg=='{{ lvm_volumes[0].data_vg }}'].key"
-        - name: get parted info
+        - name: get parted info for SD devices
           community.general.parted:
-            device: "{{ item | regex_replace('[0-9]*', '') }}"
+            # Get the name of the device by escaping the partition number
+            device: "{{ item | regex_replace('(p?\\d+)$', '') }}"
             unit: "{{ unit }}"
           loop: "{{ list_pvs }}"
           register: parted_info
         - set_fact:
             part_info: "{{ parted_info.results | community.general.json_query(query) | first | first }}"
           vars:
-            query: "[?item=='{{ item }}'] | [].partitions[?num==`{{ item | regex_replace('[A-Za-z/]*', '') }}`].{oldsize: size, end: end, newsize: `{{ new_pv_size }}` }"
+            # The regex gets the number of the partition (Ex: /dev/nvme0n1p3 -> 3)
+            query: "[?item=='{{ item }}'] | [].partitions[?num==`{{ item | regex_search('[0-9.]*$') }}`].{oldsize: size, end: end, newsize: `{{ new_pv_size }}` }"
           register: parts
           loop: "{{ list_pvs }}"
         - name: Extend partitions
           command:
-            cmd: "/usr/sbin/parted -s {{ item.item | regex_replace('[0-9.]*', '') }} resizepart  {{ item.item | regex_replace('[A-Za-z/]*', '') }} {{ item.ansible_facts.part_info.end + (item.ansible_facts.part_info.newsize | int) - (item.ansible_facts.part_info.oldsize | int) }}{{ unit }}"
+            cmd: "/usr/sbin/parted -s {{ item.item | regex_replace('(p?\\d+)$', '') }} resizepart  {{ item.item | regex_search('[0-9.]*$') }} {{ item.ansible_facts.part_info.end + (item.ansible_facts.part_info.newsize | int) - (item.ansible_facts.part_info.oldsize | int) }}{{ unit }}"
           loop: "{{ parts.results }}"
           when: (item.ansible_facts.part_info.newsize|int) > (item.ansible_facts.part_info.oldsize|int)
         - name: Resize PVs


### PR DESCRIPTION
Regex were not designed to handle devices with numbers in the middle, making it impossible to install Ceph on nvme disks.