### PR TITLE
prepare.sh: fix expansion in subshells

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -7,7 +7,7 @@
 
 set -e
 
-cd "$(dirname "$(readlink -f \\"$0\\")")"
+cd "$(dirname "$(readlink -f "$0")")"
 
 if [ $# -ne 0 ] ; then
     echo "prepare.sh take no argument" 1>&2


### PR DESCRIPTION
Bash doesn't perform expansion inside a $() sub-shell. Characters between the parentheses are not treated specially, they are all passed to the sub-shell.
Therefore, inner quotes must not be escaped.

Backslashes are given as-is to the inner sub-shell, and the readlink command will get \"$0"\ as parameter, and not "$0". When calling this script from a different directory, readlink will return an empty string, and dirname will return ".", no matter the original working directory.