### PR TITLE
templates: timemaster.conf.j2: only configure NTP with ntp_servers

### DIFF
--- a/templates/timemaster.conf.j2
+++ b/templates/timemaster.conf.j2
@@ -30,9 +30,6 @@ include /etc/chrony.conf
 {%- for line in ntp_servers %}{% if ptp_interface is not defined and loop.index==1 %}server {{ line }} prefer iburst maxsamples 10
 {% else %}server {{ line }} iburst maxsamples 10
 {% endif %}{% endfor %}
-{% else %}{% if ptp_interface is defined %}server {{ ntp_primary_server }} iburst maxsamples 10
-{% else %}server {{ ntp_primary_server }} prefer iburst maxsamples 10 prefer trust
-{% endif %}server {{ ntp_secondary_server }} iburst maxsamples 10
 {% endif %}
 
 [ntp.conf]


### PR DESCRIPTION
Remove use of obsolete ntp_primary_server and ntp_secondary_server variables.
The list ntp_servers should be used instead.