### PR TITLE
Add hosts file upload to cluster and standalone architecture and iptables rules feature to standalone architecture

### DIFF
--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -305,6 +305,7 @@ all:
         #interfaces_to_wait_for:#by default, systemd-networkd-wait-online will only wait for the cluster_network interface (team0 or hsr0). In some setup it is useful to customize the network_interface the most relevant to wait for at boot time. This variable will add interfaces networkd will wait for at boot time
         #  - br0
 
+        #hosts_path: "../inventories/hosts.j2" #when defined, it templates then uploads this file at the bottom of /etc/hosts
         iptables_rules_path: "../inventories/iptables_rules_example.txt" #when defined, it uploads this file to /etc/iptables/rules.v4 and loads those rules
         #iptables_rules_template_path: "../inventories/iptables_rules_example.txt.j2" #when defined, it templates then uploads this file to /etc/iptables/rules.v4 and loads those rules
         #cluster_protocol: "HSR" # RSTP or HSR, default is RSTP

--- a/inventories/seapath_standalone_definition_example.yml
+++ b/inventories/seapath_standalone_definition_example.yml
@@ -86,6 +86,8 @@ all:
                                 - "ssh-rsa key1XXX"
                                 - "ssh-rsa key2XXX"
 
+                            iptables_rules_path: "../inventories/iptables_rules_example.txt" #when defined, it uploads this file to /etc/iptables/rules.v4 and loads those rules
+                            #iptables_rules_template_path: "../inventories/iptables_rules_example.txt.j2" #when defined, it templates then uploads this file to /etc/iptables/rules.v4 and loads those rules
                             chrony_wait_timeout_sec: 180 #time in seconds the boot sequence will wait for chrony to sync. Optional : default is 180
 
                             # Optional list of local files to upload to the remote machines

--- a/inventories/seapath_standalone_definition_example.yml
+++ b/inventories/seapath_standalone_definition_example.yml
@@ -86,6 +86,7 @@ all:
                                 - "ssh-rsa key1XXX"
                                 - "ssh-rsa key2XXX"
 
+                            #hosts_path: "../inventories/hosts.j2" #when defined, it templates then uploads this file at the bottom of /etc/hosts
                             iptables_rules_path: "../inventories/iptables_rules_example.txt" #when defined, it uploads this file to /etc/iptables/rules.v4 and loads those rules
                             #iptables_rules_template_path: "../inventories/iptables_rules_example.txt.j2" #when defined, it templates then uploads this file to /etc/iptables/rules.v4 and loads those rules
                             chrony_wait_timeout_sec: 180 #time in seconds the boot sequence will wait for chrony to sync. Optional : default is 180

--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -413,7 +413,9 @@
       when: interfaces_br0_netdev.changed or interfaces_br0_netdev.changed
 
 - name: push iptables rules
-  hosts: cluster_machines
+  hosts:
+    - cluster_machines
+    - standalone_machine
   tasks:
     - name: check presence of iptables_rules_path file
       delegate_to: localhost

--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -221,6 +221,54 @@
         state: absent
         regexp: '^127.*debian'
 
+- name: Push hosts file
+  hosts:
+    - cluster_machines
+    - standalone_machine
+  become: true
+  tasks:
+    - block:
+        - name: Check if the hosts file exists
+          delegate_to: localhost
+          stat:
+            path: "{{ hosts_path }}"
+          register: hosts_file_exists
+          become: false
+        - name: Read the hosts file content if it exists
+          delegate_to: localhost
+          slurp:
+            src: "{{ hosts_path }}"
+          register: hosts_content
+          when: hosts_file_exists.stat.exists
+          become: false
+        - name: Create a temporary file with the hosts content
+          template:
+            src: "{{ hosts_path }}"
+            dest: /tmp/hosts_temp
+          vars:
+            hosts_content: "{{ (hosts_content.content | b64decode).splitlines() }}"
+          when: hosts_file_exists.stat.exists
+        - name: Read the temporary hosts file content
+          slurp:
+            src: /tmp/hosts_temp
+          register: temp_hosts_content
+          when: hosts_file_exists.stat.exists
+        - name: Ensure /etc/hosts contains the updated user hosts content
+          blockinfile:
+            path: /etc/hosts
+            block: |
+              {% for line in (temp_hosts_content.content | b64decode).splitlines() %}
+              {{ line }}
+              {% endfor %}
+            marker: "# {mark} user hosts file"
+          when: hosts_file_exists.stat.exists
+        - name: Remove the temporary hosts file
+          file:
+            path: /tmp/hosts_temp
+            state: absent
+          when: hosts_file_exists.stat.exists
+      when: hosts_path is defined
+
 - name: Configure DNS with resolved
   hosts:
     - cluster_machines


### PR DESCRIPTION
Add iptables feature to standalone

The iptables feature that allows the seapath user to use a template or a static file to load iptables rules was not available for standalone architecture. This fixes this issue.

----
Add option to upload user hosts file

A hosts file can be provided to add local name resolution. Indeed there will most probably be no DNS in a substation.
This file is specified using the hosts_path variable and can be either a plain text file or a Jinja template.