### PR TITLE
ci-yocto: add workflow dispatching

### DIFF
--- a/.github/workflows/ci-yocto.yml
+++ b/.github/workflows/ci-yocto.yml
@@ -11,6 +11,7 @@ on:
     types: [opened, reopened, synchronize]
     branches: [main]
   workflow_call:
+  workflow_dispatch:
 
 permissions:
   actions: write


### PR DESCRIPTION
Allows to trigger the ci without making a pull request