### PR TITLE
fix Savoir-faire Linux copyright

### DIFF
--- a/examples/inventories/advanced_inventory_cluster_example.yaml
+++ b/examples/inventories/advanced_inventory_cluster_example.yaml
@@ -1,5 +1,5 @@
 # Copyright (C) 2020, RTE (http://www.rte-france.com)
-# Copyright (C) 2024, SFL (https://savoirfairelinux.com)
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # Ansible inventory example containing a description of the variables used.

--- a/examples/inventories/advanced_inventory_standalone_example.yaml
+++ b/examples/inventories/advanced_inventory_standalone_example.yaml
@@ -1,5 +1,5 @@
 # Copyright (C) 2020, RTE (http://www.rte-france.com)
-# Copyright (C) 2024, SFL (https://savoirfairelinux.com)
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # Ansible inventory example containing a description of the variables used.

--- a/examples/inventories/netplan_admin_br0_example.yaml.j2
+++ b/examples/inventories/netplan_admin_br0_example.yaml.j2
@@ -1,4 +1,4 @@
-# Copyright (C) 2024, SFL (https://savoirfairelinux.com)
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 # This netplan file defines a bridge on the admin network interface.
 # When defined on a VM xml file, this bridge can be used to administrate both

--- a/examples/inventories/netplan_cluster_example.yaml.j2
+++ b/examples/inventories/netplan_cluster_example.yaml.j2
@@ -1,4 +1,4 @@
-# Copyright (C) 2024, SFL (https://savoirfairelinux.com)
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 # This netplan files defines the path of the cluster network which is managed
 # by systemd. Especially, it attributes its cluster IP addr to each node.

--- a/examples/inventories/netplan_ptp_interface_example.yaml.j2
+++ b/examples/inventories/netplan_ptp_interface_example.yaml.j2
@@ -1,4 +1,4 @@
-# Copyright (C) 2024, SFL (https://savoirfairelinux.com)
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 # This netplan file defines an interface for receiving PTP frames
 # If ptp_vlanid is define, this interface will be on a vlan

--- a/examples/inventories/vms_inventory_example.yaml
+++ b/examples/inventories/vms_inventory_example.yaml
@@ -1,5 +1,5 @@
 # Copyright (C) 2020-2023, RTE (http://www.rte-france.com)
-# Copyright (C) 2024, SFL (https://savoirfairelinux.com)
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 all:

--- a/examples/vm_templates/vm_template_example.xml.j2
+++ b/examples/vm_templates/vm_template_example.xml.j2
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright (C) 2020, RTE (http://www.rte-france.com) -->
-<!-- Copyright (C) 2024, SFL (https://savoirfairelinux.com) -->
+<!-- Copyright (C) 2024 Savoir-faire Linux, Inc. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <!--

--- a/examples/vm_templates/vm_template_example_generic.xml.j2
+++ b/examples/vm_templates/vm_template_example_generic.xml.j2
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright (C) 2020, RTE (http://www.rte-france.com) -->
-<!-- Copyright (C) 2024, SFL (https://savoirfairelinux.com) -->
+<!-- Copyright (C) 2024 Savoir-faire Linux, Inc. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <!--

--- a/playbooks/cluster_setup_add_livemigration_user.yaml
+++ b/playbooks/cluster_setup_add_livemigration_user.yaml
@@ -1,5 +1,5 @@
 # Copyright (C) 2022, RTE (http://www.rte-france.com)
-# Copyright (C) 2024, SFL (https://savoirfairelinux.com)
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # This playbook adds and configures the virtu user. This user is used by libvirt

--- a/playbooks/cluster_setup_ceph.yaml
+++ b/playbooks/cluster_setup_ceph.yaml
@@ -1,5 +1,5 @@
 # Copyright (C) 2020, RTE (http://www.rte-france.com)
-# Copyright (C) 2024, SFL (https://savoirfairelinux.com)
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # This playbook configures and sets up Ceph. It is called by the playbook

--- a/playbooks/cluster_setup_configure_hugepages.yaml
+++ b/playbooks/cluster_setup_configure_hugepages.yaml
@@ -1,5 +1,5 @@
 # Copyright (C) 2022, RTE (http://www.rte-france.com)
-# Copyright (C) 2024, SFL (https://savoirfairelinux.com)
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # This Ansible playbook configures the number of hugepages available.

--- a/playbooks/cluster_setup_libvirt.yaml
+++ b/playbooks/cluster_setup_libvirt.yaml
@@ -1,5 +1,5 @@
 # Copyright (C) 2022, RTE (http://www.rte-france.com)
-# Copyright (C) 2024, SFL (https://savoirfairelinux.com)
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # This Ansible playbook configures libvirt to work with Ceph. It is

--- a/playbooks/deploy_vms_cluster.yaml
+++ b/playbooks/deploy_vms_cluster.yaml
@@ -1,5 +1,5 @@
 # Copyright (C) 2023, RTE (http://www.rte-france.com)
-# Copyright (C) 2024, SFL (https://savoirfairelinux.com)
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 # Deploy all VMs define in the VMs group
 

--- a/templates/vm/vm.xml.j2
+++ b/templates/vm/vm.xml.j2
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright (C) 2021, RTE (http://www.rte-france.com) -->
-<!-- Copyright (C) 2024, SFL (https://savoirfairelinux.com) -->
+<!-- Copyright (C) 2024 Savoir-faire Linux, Inc. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <!--

--- a/templates/vm/vm_dpdk.xml.j2
+++ b/templates/vm/vm_dpdk.xml.j2
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright (C) 2021, RTE (http://www.rte-france.com) -->
-<!-- Copyright (C) 2024, SFL (https://savoirfairelinux.com) -->
+<!-- Copyright (C) 2024 Savoir-faire Linux, Inc. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <!--

--- a/templates/vm/vm_dpdk_isolated.xml.j2
+++ b/templates/vm/vm_dpdk_isolated.xml.j2
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright (C) 2021, RTE (http://www.rte-france.com) -->
-<!-- Copyright (C) 2024, SFL (https://savoirfairelinux.com) -->
+<!-- Copyright (C) 2024 Savoir-faire Linux, Inc. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <domain type="{{ vm_domaine | default('kvm') }}">

--- a/templates/vm/vm_rt_dpdk.xml.j2
+++ b/templates/vm/vm_rt_dpdk.xml.j2
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright (C) 2021, RTE (http://www.rte-france.com) -->
-<!-- Copyright (C) 2024, SFL (https://savoirfairelinux.com) -->
+<!-- Copyright (C) 2024 Savoir-faire Linux, Inc. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <domain type="{{ vm_domaine | default('kvm') }}">

--- a/templates/vm/vm_rt_isolated.xml.j2
+++ b/templates/vm/vm_rt_isolated.xml.j2
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright (C) 2021, RTE (http://www.rte-france.com) -->
-<!-- Copyright (C) 2024, SFL (https://savoirfairelinux.com) -->
+<!-- Copyright (C) 2024 Savoir-faire Linux, Inc. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <domain type="{{ vm_domaine | default('kvm') }}">

--- a/tests/add_vm_from_template.yaml
+++ b/tests/add_vm_from_template.yaml
@@ -1,5 +1,5 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
-# Copyright (C) 2024, SFL (https://savoirfairelinux.com)
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # Test VM creation.

--- a/tests/vm_template.xml.j2
+++ b/tests/vm_template.xml.j2
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright (C) 2020, RTE (http://www.rte-france.com) -->
-<!-- Copyright (C) 2024, SFL (https://savoirfairelinux.com) -->
+<!-- Copyright (C) 2024 Savoir-faire Linux, Inc. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <!--

--- a/vars/network_vars.yml
+++ b/vars/network_vars.yml
@@ -1,5 +1,5 @@
 # Copyright (C) 2021-2024, RTE (http://www.rte-france.com)
-# Copyright (C) 2024, SFL (https://savoirfairelinux.com)
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 ---
 


### PR DESCRIPTION
The copyright of the files was not correct. It was written as SFL instead of Savoir-faire Linux, Inc.