### PR TITLE
fix Savoir-faire Linux copyright

### DIFF
--- a/examples/vm_templates/vm_template_example.xml.j2
+++ b/examples/vm_templates/vm_template_example.xml.j2
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright (C) 2020, RTE (http://www.rte-france.com) -->
-<!-- Copyright (C) 2024, SFL (https://savoirfairelinux.com) -->
+<!-- Copyright (C) 2024 Savoir-faire Linux, Inc. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <!--

--- a/examples/vm_templates/vm_template_example_generic.xml.j2
+++ b/examples/vm_templates/vm_template_example_generic.xml.j2
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright (C) 2020, RTE (http://www.rte-france.com) -->
-<!-- Copyright (C) 2024, SFL (https://savoirfairelinux.com) -->
+<!-- Copyright (C) 2024 Savoir-faire Linux, Inc. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <!--

--- a/inventories/README.md
+++ b/inventories/README.md
@@ -1,5 +1,5 @@
 <!-- Copyright (C) 2020, RTE (http://www.rte-france.com) -->
-<!-- Copyright (C) 2024, SFL (https://savoirfairelinux.com) -->
+<!-- Copyright (C) 2024 Savoir-faire Linux, Inc. -->
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
 # Inventories directory

--- a/inventories/netplan_admin_br0_example.yaml.j2
+++ b/inventories/netplan_admin_br0_example.yaml.j2
@@ -1,4 +1,4 @@
-# Copyright (C) 2024, SFL (https://savoirfairelinux.com)
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 # This netplan file defines a bridge on the admin network interface.
 # When defined on a VM xml file, this bridge can be used to administrate both

--- a/inventories/netplan_cluster_example.yaml.j2
+++ b/inventories/netplan_cluster_example.yaml.j2
@@ -1,4 +1,4 @@
-# Copyright (C) 2024, SFL (https://savoirfairelinux.com)
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 # This netplan files defines the path of the cluster network which is managed
 # by systemd. Especially, it attributes its cluster IP addr to each node.

--- a/inventories/netplan_ptp_interface_example.yaml.j2
+++ b/inventories/netplan_ptp_interface_example.yaml.j2
@@ -1,4 +1,4 @@
-# Copyright (C) 2024, SFL (https://savoirfairelinux.com)
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 # This netplan file defines an interface for receiving PTP frames
 # If ptp_vlanid is define, this interface will be on a vlan

--- a/playbooks/cluster_setup_add_livemigration_user.yaml
+++ b/playbooks/cluster_setup_add_livemigration_user.yaml
@@ -1,5 +1,5 @@
 # Copyright (C) 2022, RTE (http://www.rte-france.com)
-# Copyright (C) 2024, SFL (https://savoirfairelinux.com)
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # This playbook adds and configures the virtu user. This user is used by libvirt

--- a/playbooks/deploy_vms_cluster.yaml
+++ b/playbooks/deploy_vms_cluster.yaml
@@ -1,5 +1,5 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
-# Copyright (C) 2024, SFL (https://savoirfairelinux.com)
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 # Deploy all VMs define in the VMs group
 

--- a/tests/add_vm_from_template.yaml
+++ b/tests/add_vm_from_template.yaml
@@ -1,5 +1,5 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
-# Copyright (C) 2024, SFL (https://savoirfairelinux.com)
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # Test VM creation.

--- a/tests/vm_template.xml.j2
+++ b/tests/vm_template.xml.j2
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright (C) 2020, RTE (http://www.rte-france.com) -->
-<!-- Copyright (C) 2024, SFL (https://savoirfairelinux.com) -->
+<!-- Copyright (C) 2024 Savoir-faire Linux, Inc. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <!--


### PR DESCRIPTION
The copyright of the files was not correct. It was written as SFL instead of Savoir-faire Linux, Inc.