### PR TITLE
module_documentation_source: bump Pygments version to 2.18.0 or greater

### DIFF
--- a/module_documentation_sources/requirements.txt
+++ b/module_documentation_sources/requirements.txt
@@ -3,5 +3,5 @@ PyYAML
 rstcheck
 sphinx
 sphinx-notfound-page
-Pygments >= 2.4.0
+Pygments >= 2.18.0
 ansible >= 2.9,<2.10


### PR DESCRIPTION
Old Pygments version have vulnerabilities:
* CVE-2021-20270
* CVE-2021-27291
* CVE-2022-40896