### PR TITLE
Changes in cluster_setup_network and prerequisdebian + Refactor playbook deploy_vms_standalone

### DIFF
--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -260,6 +260,7 @@
   hosts:
     - cluster_machines
     - standalone_machine
+    - VMs
   become: true
   tasks:
     - block:

--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -248,7 +248,7 @@
     - name: Build hosts file
       lineinfile:
         dest: /etc/hosts
-        line: "{{ ip_addr }} {{ inventory_hostname }} {{ hostname | default('') }}"
+        line: "{{ ip_addr | default( ansible_host ) }} {{ inventory_hostname }} {{ hostname | default('') }}"
         state: present
     - name: remove 'debian' from hosts file
       lineinfile:

--- a/playbooks/cluster_setup_prerequisdebian.yaml
+++ b/playbooks/cluster_setup_prerequisdebian.yaml
@@ -26,6 +26,17 @@
   roles:
     - debian/hypervisor
 
+- name: Add admin user to haclient group
+  hosts:
+    - cluster_machines
+  become: true
+  tasks:
+    - name: Add admin user to haclient group
+      user:
+        name: "{{ admin_user }}"
+        groups: haclient
+        append: yes
+
 - name: Disable libvirt-guests.service
   hosts:
     - cluster_machines

--- a/playbooks/deploy_vms_standalone.yaml
+++ b/playbooks/deploy_vms_standalone.yaml
@@ -7,28 +7,38 @@
   gather_facts: false
   become: true
   vars:
-    - disk_pool: "/var/lib/libvirt/images"
-    - disk_copy: true
+    disk_pool: "/var/lib/libvirt/images"
+    disk_copy: true
   tasks:
     - name: List all VMs
       virt:
         command: list_vms
       register: all_vms
+
     - name: Stop VM
       virt:
         state: destroyed
         name: "{{ item }}"
-      with_items: "{{ groups['VMs'] }}"
-      when: item in all_vms.list_vms
-    - name: Undefined VM
+      when:
+        - item in all_vms.list_vms
+        - hostvars[item].force is defined
+        - hostvars[item].force
+      loop: "{{ groups['VMs'] }}"
+
+    - name: Undefine VM
       command: "virsh undefine --nvram {{ item }}"
-      with_items: "{{ groups['VMs'] }}"
-      when: item in all_vms.list_vms
+      when:
+        - item in all_vms.list_vms
+        - hostvars[item].force is defined
+        - hostvars[item].force
+      loop: "{{ groups['VMs'] }}"
+
     - name: Print info
       debug:
         var: hostvars[item]
         verbosity: 2
-      with_items: "{{ groups['VMs'] }}"
+      loop: "{{ groups['VMs'] }}"
+
     - name: Check tmp folder permission
       file:
         path: "{{ qcow2tmpuploadfolder }}"
@@ -37,41 +47,59 @@
         group: "{{ ansible_user }}"
         mode: '0755'
       when: qcow2tmpuploadfolder is defined
+
     - name: Copy the disk on target
       copy:
         src: "{{ hostvars[item].vm_disk }}"
         dest: "{{ disk_pool }}/{{ hostvars[item].inventory_hostname }}.qcow2"
       vars:
         ansible_remote_tmp: "{{ qcow2tmpuploadfolder | default(omit) }}"
-      with_items: "{{ groups['VMs'] }}"
-      when: disk_copy | bool and (hostvars[item].disk_extract is not defined or not hostvars[item].disk_extract | bool)
-    - name: Copy the gziped disk on target
+      when:
+        - disk_copy | bool
+        - hostvars[item].disk_extract is not defined or not hostvars[item].disk_extract | bool
+        - item not in all_vms.list_vms or (item in all_vms.list_vms and hostvars[item].force is defined and hostvars[item].force)
+      loop: "{{ groups['VMs'] }}"
+
+    - name: Copy the gzipped disk on target
       copy:
         src: "{{ hostvars[item].vm_disk }}"
         dest: "{{ disk_pool }}/{{ hostvars[item].inventory_hostname }}.img.gz"
-      with_items: "{{ groups['VMs'] }}"
-      when: disk_copy | bool and hostvars[item].disk_extract is defined and hostvars[item].disk_extract | bool
-    - name: Extract the gziped disk on target
+      when:
+        - disk_copy | bool
+        - hostvars[item].disk_extract is defined
+        - hostvars[item].disk_extract | bool
+        - item not in all_vms.list_vms or (item in all_vms.list_vms and hostvars[item].force is defined and hostvars[item].force)
+      loop: "{{ groups['VMs'] }}"
+
+    - name: Extract the gzipped disk on target
       command:
         cmd: "gzip -d -f {{ disk_pool }}/{{ hostvars[item].inventory_hostname }}.img.gz"
         creates: "{{ hostvars[item].inventory_hostname }}.img"
-      with_items: "{{ groups['VMs'] }}"
-      when: disk_copy | bool and hostvars[item].disk_extract is defined and hostvars[item].disk_extract | bool
+      when:
+        - disk_copy | bool
+        - hostvars[item].disk_extract is defined
+        - hostvars[item].disk_extract | bool
+        - item not in all_vms.list_vms or (item in all_vms.list_vms and hostvars[item].force is defined and hostvars[item].force)
+      loop: "{{ groups['VMs'] }}"
+
     - name: Add main disk to disk list
       # This is only done in standalone because the disk is handled by vm-manager in the cluster
       set_fact:
         standalone_main_disk: "{{ hostvars[item].inventory_hostname }}.qcow2"
       delegate_to: "{{ item }}"
       delegate_facts: true
-      with_items: "{{ groups['VMs'] }}"
-    - name: export VM config for debug in /tmp
+      loop: "{{ groups['VMs'] }}"
+      when: item not in all_vms.list_vms or (item in all_vms.list_vms and hostvars[item].force is defined and hostvars[item].force)
+
+    - name: Export VM config for debug in /tmp
       template:
         src: "{{ hostvars[item].vm_template }}"
         dest: "/tmp/{{ hostvars[item].inventory_hostname }}.xml"
       vars:
         vm: "{{ hostvars[item] }}"
-      with_items: "{{ groups['VMs'] }}"
       when: ansible_verbosity >= 2
+      loop: "{{ groups['VMs'] }}"
+
     - name: Create VMs
       virt:
         command: define
@@ -79,12 +107,15 @@
           {{ lookup('template',
           hostvars[item].vm_template,
           template_vars=dict(vm=hostvars[item])) }}
-      with_items: "{{ groups['VMs'] }}"
+      loop: "{{ groups['VMs'] }}"
+      when: item not in all_vms.list_vms or (item in all_vms.list_vms and hostvars[item].force is defined and hostvars[item].force)
+
     - name: Start VMs
       virt:
         name: "{{ item }}"
         state: running
-      with_items: "{{ groups['VMs'] }}"
+      loop: "{{ groups['VMs'] }}"
+      when: hostvars[item].enable | default(true)
 
 - hosts: VMs
   name: Wait for VMs to be online

--- a/roles/debian/physical_machine/tasks/main.yml
+++ b/roles/debian/physical_machine/tasks/main.yml
@@ -331,10 +331,10 @@
     line: "{{ item }}"
   with_items: "{{ extra_kernel_modules | default([]) }}"
 
-- name: Add admin user to libvirt and haclient groups
+- name: Add admin user to libvirt group
   user:
     name: "{{ admin_user }}"
-    groups: libvirt,haclient
+    groups: libvirt
     append: yes
 
 - name: Creating libvirt user with libvirtd permissions


### PR DESCRIPTION
- Build the hosts file, and use ansible_host as a fallback if ip_addr is not defined.
- Push hosts file is now available for VMs.
- haclient group is only in cluster_machines: Moved out from physical_machines.
- Refactor playbook deploy_vms_standalone to use loop and fix variable usage
  - Changed with_items to loop for consistency and modern Ansible practices
  - Use force variable to upload an already running VM as in deploy_vms_cluster
  - Use enable variable to start a VM as in deploy_vms_cluster