### PR TITLE
ignore errors when restarting conntrackd after recreating team0

### DIFF
--- a/playbooks/cluster_setup_network.yaml
+++ b/playbooks/cluster_setup_network.yaml
@@ -128,6 +128,7 @@
           name: conntrackd
           state: restarted
         when: conntrackd_ignore_ip_list is defined
+        failed_when: false
       when:
         - cluster_protocol is not defined or cluster_protocol != "HSR" or hsr_mac_address is not defined
         - skip_recreate_team0_config is not defined or skip_recreate_team0_config is not true


### PR DESCRIPTION
When removing and recreating team0, conntrackd needs to be restarted to take the new team0 into account.
If at the same time the configuration has changed, the change in configuration will only occur later in the playbook, so this restart will be done with the previous version of the configuration, which can be not working (hence the need to change the configuration).
This commit will make this first conntrackd restart operation ignore the error just in this case.