### PR TITLE
team0 subnet: split from br0 subnet

### DIFF
--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -20,7 +20,7 @@ all:
                             # Main network configuration
                             network_interface: eno8303 #admin interface
                             ip_addr: "{{ ansible_host }}"
-                            subnet: 25 #default is 24, override if necessary
+                            subnet: 25 #subnet for main interface (br0), default is 24, override if necessary
                             #br0vlan: 159 #if the main interface on br0 is on a vlan that the host must manage
 
                             # snmp network settings
@@ -39,6 +39,7 @@ all:
                             cluster_next_ip_addr : "192.168.55.2" #node 2 cluster network ip
                             cluster_previous_ip_addr : "192.168.55.3" #node 3 cluster network ip
                             cluster_ip_addr: "192.168.55.1"
+                            #team0subnet: 24 #subnet for cluster interface (team0), default is 24, override if necessary
 
                             # OVS configuration (see ovs_topology inventory)
                             br_rstp_priority: 12288
@@ -82,6 +83,7 @@ all:
                             cluster_next_ip_addr : "192.168.55.3" #node 3 cluster network ip
                             cluster_previous_ip_addr :  "192.168.55.1" #node 1 cluster network ip
                             cluster_ip_addr: "192.168.55.2"
+                            #team0subnet: 24 #subnet for cluster interface (team0), default is 24, override if necessary
                             br_rstp_priority: 16384
                             brBRIDGE1_ext: eno1234 #physical nic to use with BRIDGE1 (see the ovs topology inventory)
 
@@ -120,6 +122,7 @@ all:
                             cluster_next_ip_addr : "192.168.55.1" #ip de hyperviseur 1
                             cluster_previous_ip_addr :  "192.168.55.2" #ip de l'hyperviseur 2
                             cluster_ip_addr: "192.168.55.3"
+                            #team0subnet: 24 #subnet for cluster interface (team0), default is 24, override if necessary
                             br_rstp_priority: 16384
                             brBRIDGE1_ext: eno1234 #physical nic to use with BRIDGE1 (see the ovs topology inventory)
 

--- a/inventories/seapath_standalone_definition_example.yml
+++ b/inventories/seapath_standalone_definition_example.yml
@@ -26,7 +26,7 @@ all:
                             # Main network configuration
                             network_interface: enp1s0 #admin interface
                             ip_addr: "{{ ansible_host }}"
-                            subnet: 25 #default is 24, override if necessary
+                            subnet: 25 #subnet for main interface (br0), default is 24, override if necessary
                             dns_servers: #remove this variable to disable dns, leave this variable empty for DNS via DHCP
                               - 10.10.2.1
                             gateway_addr: 10.0.0.1

--- a/vars/network_vars.yml
+++ b/vars/network_vars.yml
@@ -69,7 +69,7 @@ team0_systemd_networkd_network:
     - Match:
         - Name: "team0"
     - Network:
-        - Address: "{{ cluster_ip_addr|default('0') }}/{{ subnet | default(24) }}"
+        - Address: "{{ cluster_ip_addr|default('0') }}/{{ team0subnet | default(24) }}"
   79-team0_0:
     - Match:
         - Name: "{{ team0_0|default('0') }}"


### PR DESCRIPTION
The "subnet" variable is used for 2 distincts interfaces : br0 and team0.
This commit creates the team0subnet variable to be used for team0 (cluster network).