### PR TITLE
allow the user to run commands after uploading custom files

### DIFF
--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -339,6 +339,8 @@ all:
           - { src: '../inventories_private/toto.txt', dest: '/tmp/toto' }
           # you can also upload and uncompress an archive file (set extract: true), in that case the destination must be a folder
           - { src: '../inventories_private/toto.tar.bz2', dest: '/tmp/folder1', extract: true }
+        commands_to_run_after_upload:
+          - "/usr/bin/systemctl restart snmpd"
 
         # optional extra directives to add to snmpd.conf
         extra_snmpd_directives: |

--- a/inventories/seapath_standalone_definition_example.yml
+++ b/inventories/seapath_standalone_definition_example.yml
@@ -114,6 +114,9 @@ all:
                               - { src: '../inventories_private/toto.txt', dest: '/tmp/toto' }
                               # you can also upload and uncompress an archive file (set extract: true), in that case the destination must be a folder
                               - { src: '../inventories_private/toto.tar.bz2', dest: '/tmp/folder1', extract: true }
+                            commands_to_run_after_upload:
+                              - "/usr/bin/systemctl restart snmpd"
+
 
                             # optional extra directives to add to snmpd.conf
                             extra_snmpd_directives: |

--- a/playbooks/cluster_setup_prerequisdebian.yaml
+++ b/playbooks/cluster_setup_prerequisdebian.yaml
@@ -78,6 +78,11 @@
       when:
         - upload_files is defined
         - item.extract is defined and item.extract is true
+    - name: run extra commands after upload
+      command: "{{ item }}"
+      loop: "{{ commands_to_run_after_upload }}"
+      when: commands_to_run_after_upload is defined
+
 
 - name: Remove what is not needed after installation
   hosts:


### PR DESCRIPTION
If the user uses the upload_files variable to upload custom files at the end of the playbook, he might need to restart a service or something similar.
This commits allow the user to use the commands_to_run_after_upload to run any commands he likes after uploading custom files.