### PR TITLE
timemaster: limit PTP->NTP fallback time

### DIFF
--- a/templates/timemaster.conf.j2
+++ b/templates/timemaster.conf.j2
@@ -24,8 +24,8 @@ ntp_program chronyd
 [chrony.conf]
 include {{ path_chrony_conf }}
 {% if ntp_servers is defined %}
-{%- for line in ntp_servers %}{% if ptp_interface is not defined and loop.index==1 %}server {{ line }} trust iburst maxsamples 10
-{% else %}server {{ line }} iburst maxsamples 10
+{%- for line in ntp_servers %}{% if ptp_interface is not defined and loop.index==1 %}server {{ line }} trust iburst maxsamples 10 minsamples 10 maxpoll 6 minpoll 6
+{% else %}server {{ line }} iburst maxsamples 10 minsamples 10 maxpoll 6 minpoll 6
 {% endif %}{% endfor %}
 {% endif %}
 


### PR DESCRIPTION
After PTP becomes unavaillable, chrony still selects it for a time period :
> Reachability is not a requirement for selection. An unreachable source
> can still be selected if its newest sample is not older than the oldest
> sample from reachable sources.

This period is defined by the number of samples and the polling period and is, by default, highly variable (up to 10*1024s=~3h).

Set min/max for poll and sample for make this period more predictable:
* poll = 6 => 2^6=64 seconds poll periode
* sample = 10

So, the PTP->NTP fallback time around 11 minutes (10*64s)

CC: @insatomcat 