### PR TITLE
Apply tuned profile to VM

### DIFF
--- a/playbooks/ci_prepare_VMs.yaml
+++ b/playbooks/ci_prepare_VMs.yaml
@@ -22,3 +22,18 @@
         name: systemd-resolved
         state: stopped
         enabled: false
+
+    - name: remove tuned dynamic tuning
+      lineinfile:
+        path: /etc/tuned/tuned-main.conf
+        state: present
+        regexp: '^#?dynamic_tuning = .*$'
+        line: 'dynamic_tuning = 0'
+    - name: enable tuned.service
+      ansible.builtin.systemd:
+        name: tuned.service
+        enabled: yes
+        state: restarted
+    - name: load realtime-virtual-guest tuned profile
+      ansible.builtin.command: tuned-adm profile realtime-virtual-guest
+      when: "'rt' in vm_features"


### PR DESCRIPTION
Apply realtime-virtual-guest inside the Debian virtual machines. When not applied, hours-long cyclictest have a maximum latency over 10ms.

This commit also creates a new debian/vm roles for this purpose.

Closes #529 