### PR TITLE
Correct boot mount

### DIFF
--- a/examples/inventories/advanced_inventory_standalone_example.yaml
+++ b/examples/inventories/advanced_inventory_standalone_example.yaml
@@ -33,15 +33,12 @@ all:
                - inventories/netplan_admin_br0_example.yaml.j2
                - inventories/netplan_ptp_interface_example.yaml.j2
                - inventories/netplan_cluster_example.yaml.j2
+              # Optional variable to append extra kernel parameters.
+              extra_kernel_parameters: >-
+                vfio_iommu_type1.allow_unsafe_interrupts=1
               # Set true to restart after setting kernel parameters (default is
               # false)
               kernel_parameters_restart: true
-              # Automatic creation of a Linux bridge. The hypervisor is
-              # connnected to the bridge via the interface "network interface".
-              # VMs can therefore communicate with the hypervisor via this
-              # bridge, and it also allows hypervisors and VMs to be configured
-              # via a single interface.
-              create_br0_bridge: true
               # Configure Host NICs IRQs affinity.
               # Optional, only useful with RT containers or macvtag VMs
               nics_affinity:

--- a/playbooks/cluster_setup_kernel_params.yaml
+++ b/playbooks/cluster_setup_kernel_params.yaml
@@ -28,10 +28,16 @@
         - extra_param_raw.rc == 1
   tasks:
     - block:
-        - name: Mount /boot partition if not mounted
-          shell:
-            cmd: mount | grep '/boot ' || mount /dev/disk/by-label/boot /boot
-            warn: false
+        - name: Find the boot partition path
+          ansible.builtin.script:
+            cmd: ../src/find_boot_partition.sh
+          register: boot_partition_path
+        - name: Mount the partition
+          mount:
+            path: /boot
+            fstype: vfat
+            src: "{{ boot_partition_path.stdout | trim }}"
+            state: mounted
         - name: "Check that {{ config_file }} exists"
           command: test -f "{{ config_file }}"
           changed_when: false

--- a/src/find_boot_partition.sh
+++ b/src/find_boot_partition.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+rootfs_part=$(mount | awk '/\/ / { print $1 }')
+disk_name="${rootfs_part: : -1}"
+part_num="${rootfs_part:(-1)}"
+
+if [[ "${part_num}" == "3" ]] ; then
+    bootloader_p="${disk_name}1"
+else
+    bootloader_p="${disk_name}2"
+fi
+
+echo $bootloader_p


### PR DESCRIPTION
The boot partition was search with the boot label. This works on BIOS
setup, but not on uefi setup.

This PR corrects this behavior and add documentation.

Closes #361