### PR TITLE
add qDevice and qNetd configuration

### DIFF
--- a/ansible-lint.conf
+++ b/ansible-lint.conf
@@ -8,6 +8,7 @@ exclude_paths:
   - roles/systemd_networkd
   - roles/corosync
   - playbooks/update_machine_*
+  - playbooks/cluster_setup_ha_qdevice.yaml
   - roles/yocto/kernel_params/tasks/tasks/soft_restart_machine.yaml
 
 # ceph-ansible, systemd_networkd and corosync are submodules and seapath don't

--- a/ansible-requirements.yaml
+++ b/ansible-requirements.yaml
@@ -12,7 +12,7 @@ roles:
     - name: "corosync"
       src: "https://github.com/seapath/corosync-ansible"
       scm: git
-      version: "d7e30a7ad979e08af5e9a5696deb8039e6f52d78"
+      version: "5a99ca31b82b5d416ce3ee21f251411b4f461d5c"
 
 collections:
     - name: "community.libvirt"

--- a/playbooks/cluster_setup_ha.yaml
+++ b/playbooks/cluster_setup_ha.yaml
@@ -6,8 +6,21 @@
 # also be called independently.
 
 ---
-- name: Configure SEAPATH specific files
+- name: Search for corosync nodes
   hosts: cluster_machines
+  become: true
+  tasks:
+    - name: Create a group with corosync_machines
+      add_host:
+        name: "{{ item }}"
+        groups: corosync_machines
+      changed_when: false
+      run_once: true
+      loop: "{{ groups['cluster_machines'] }}"
+      when: item not in groups['observers'] or corosync_use_qdevice is undefined or not corosync_use_qdevice
+
+- name: Configure SEAPATH specific files
+  hosts: corosync_machines
   become: true
   tasks:
   - name: Save cluster machine informations
@@ -15,8 +28,9 @@
         src: ../templates/cluster.conf.j2
         dest: /etc/cluster.conf
 
+
 - name: Check if corosync is already setup
-  hosts: cluster_machines
+  hosts: corosync_machines
   become: true
   tasks:
     - name: check corosync service status
@@ -30,7 +44,7 @@
         name: "{{ item }}"
         groups: unconfigured_machine_group
       run_once: true
-      loop: "{{ groups['cluster_machines'] }}"
+      loop: "{{ groups['corosync_machines'] }}"
       changed_when: false
       when: hostvars[item].corosync_service_status.changed
     - name: Create a group with valid_machines
@@ -38,12 +52,14 @@
         name: "{{ item }}"
         groups: valid_machine
       run_once: true
-      loop: "{{ groups['cluster_machines'] }}"
+      loop: "{{ groups['corosync_machines'] }}"
       changed_when: false
       when: not hostvars[item].corosync_service_status.changed
 
+
+
 - name: Setup Corosync from scratch
-  hosts: cluster_machines
+  hosts: corosync_machines
   become: true
   vars_files:
       - ../vars/corosync_vars.yaml
@@ -93,12 +109,16 @@
             owner: root
             group: root
             mode: '0400'
-        - name: Start pacemaker
+        - name: Start corosync
           ansible.builtin.systemd:
               name: corosync
               state: started
               enabled: true
       when: groups['valid_machine'] is defined
+
+- name: Run qdevice setup
+  import_playbook: cluster_setup_ha_qdevice.yaml
+  when: corosync_use_qdevice is defined and corosync_use_qdevice
 
 - name: Setup Pacemaker
   hosts: unconfigured_machine_group
@@ -121,7 +141,7 @@
         when: groups['valid_machine'] is undefined
 
 - name: run extra CRM commands
-  hosts: cluster_machines
+  hosts: corosync_machines
   become: true
   tasks:
       - name: run extra CRM configuration commands

--- a/playbooks/cluster_setup_ha.yaml
+++ b/playbooks/cluster_setup_ha.yaml
@@ -145,9 +145,10 @@
   become: true
   tasks:
       - name: run extra CRM configuration commands
-        command: "/usr/sbin/crm configure {{ item }}"
+        command: "/usr/bin/crm configure {{ item }}"
         when: extra_crm_cmd_to_run is defined
         run_once: true
-        no_log: true
-        failed_when: 0 == 1
         loop: "{{ extra_crm_cmd_to_run }}"
+        register: crm_cmd_result
+        changed_when: crm_cmd_result.rc == 0
+        failed_when: crm_cmd_result.rc != 0 and crm_cmd_result.stderr.find('same ID') == -1

--- a/playbooks/cluster_setup_ha.yaml
+++ b/playbooks/cluster_setup_ha.yaml
@@ -1,4 +1,4 @@
-# Copyright (C) 2022, RTE (http://www.rte-france.com)
+# Copyright (C) 2022-2024, RTE (http://www.rte-france.com)
 # SPDX-License-Identifier: Apache-2.0
 
 # Ansible playbook that creates the cluster by configuring Corosync and
@@ -58,14 +58,14 @@
     tmpdir: "/tmp"
   tasks:
     - block:
-        - name: Fetch corosync configuration 
-          fetch: 
+        - name: Fetch corosync configuration
+          fetch:
             src: "/etc/corosync/corosync.conf"
             dest: "{{ tmpdir }}/corosync.conf"
             flat: true
           run_once: true
-        - name: Fetch corosync key 
-          fetch: 
+        - name: Fetch corosync key
+          fetch:
             src: "/etc/corosync/authkey"
             dest: "{{ tmpdir }}/authkey"
             flat: true
@@ -79,14 +79,14 @@
     tmpdir: "/tmp"
   tasks:
     - block:
-        - name: Install corosync configuration 
+        - name: Install corosync configuration
           copy:
             src: "{{ tmpdir }}/corosync.conf"
             dest: /etc/corosync/corosync.conf
             owner: root
             group: root
             mode: '0644'
-        - name: Install corosync key 
+        - name: Install corosync key
           copy:
             src: "{{ tmpdir }}/authkey"
             dest: /etc/corosync/authkey

--- a/playbooks/cluster_setup_ha_qdevice.yaml
+++ b/playbooks/cluster_setup_ha_qdevice.yaml
@@ -1,0 +1,173 @@
+# Copyright (C) 2022-2024, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+# Ansible playbook that configure corosync to use a qDevice for the cluster.
+
+---
+
+- name: Initialize qNetd
+  hosts: observers
+  become: true
+  run_once: true
+  tasks:
+    - name: Create qNetd certificate
+      command: "corosync-qnetd-certutil -i"
+      register: qnetd_cert_cmd
+      failed_when: qnetd_cert_cmd.rc > 0 and qnetd_cert_cmd.stderr.find('already exists') == -1
+      changed_when: qnetd_cert_cmd.rc == 0
+      notify:
+        - restart qnetd
+      when: corosync_use_qdevice is defined and corosync_use_qdevice
+    - block:
+      - name: fetch qnetd certificate
+        command: "cat /etc/corosync/qnetd/nssdb/qnetd-cacert.crt"
+        register: qnetd_cert_cmd
+      - name: Export qNetd certificate inside corosync nodes variables
+        add_host:
+          name: "{{ item }}"
+          qnetd_cert: "{{ qnetd_cert_cmd.stdout }}"
+        with_items: "{{ groups['corosync_machines'] }}"
+      when: qnetd_cert_cmd.changed
+  handlers:
+    - name: restart qnetd
+      systemd:
+        name: corosync-qnetd
+        state: restarted
+        enabled: true
+
+- name: import qNetd certificate
+  hosts: corosync_machines
+  become: true
+  vars:
+    corosync_cluster_name: "{{ cluster_name | default('seapath') }}"
+  tasks:
+    - block:
+        - name: Copy the certificate
+          copy:
+            content: "{{ qnetd_cert }}"
+            dest: "{{ ansible_remote_tmp }}/qnetd-cacert.crt"
+            owner: root
+            group: root
+            mode: '0644'
+        - name: Import the certificate
+          command: "corosync-qdevice-net-certutil -i -c {{ ansible_remote_tmp }}/qnetd-cacert.crt"
+        - name: Generate the certificate request
+          command: "corosync-qdevice-net-certutil -r -n {{ corosync_cluster_name }}"
+          run_once: true
+        - name: fetch the certificate request
+          command: "cat /etc/corosync/qdevice/net/nssdb/qdevice-net-node.crq"
+          register: qdevice_crq_cmd
+          run_once: true
+        - name: Export certificate request inside a observer variable
+          add_host:
+            name: "{{ groups['observers'][0] }}"
+            qdevice_crq: "{{ qdevice_crq_cmd.stdout }}"
+          run_once: true
+      when: qnetd_cert is defined
+  post_tasks:
+    - name: Remove temporary files
+      file:
+        path: "{{ ansible_remote_tmp }}/qnetd-cacert.crt"
+        state: absent
+      when: qnetd_cert is defined
+
+- name: import qDevice certificate request
+  hosts: observers
+  become: true
+  run_once: true
+  vars:
+    corosync_cluster_name: "{{ cluster_name | default('seapath') }}"
+  tasks:
+    - block:
+        - name: Copy the certificate request
+          copy:
+            content: "{{ qdevice_crq }}"
+            dest: "{{ ansible_remote_tmp }}/qdevice-net-node.crq"
+            owner: root
+            group: root
+            mode: '0644'
+        - name: sign certificate request
+          command: >-
+           corosync-qnetd-certutil -s
+            -c {{ ansible_remote_tmp }}/qdevice-net-node.crq
+            -n {{ corosync_cluster_name }}
+        - name: fetch the certificate
+          command: "cat /etc/corosync/qnetd/nssdb/cluster-{{ corosync_cluster_name }}.crt"
+          register: qdevice_cert_cmd
+        - name: Export certificate inside corosync nodes variables
+          add_host:
+            name: "{{ item }}"
+            qdevice_cert: "{{ qdevice_cert_cmd.stdout }}"
+          with_items: "{{ groups['corosync_machines'] }}"
+      when: qdevice_crq is defined
+  post_tasks:
+    - name: Remove temporary files
+      file:
+        path: "{{ ansible_remote_tmp }}qdevice-net-node.crq"
+        state: absent
+      when: qdevice_crq is defined
+
+- name: import qDevice certificate
+  hosts: corosync_machines
+  become: true
+  run_once: true
+  tasks:
+    - block:
+        - name: Copy the certificate
+          copy:
+            content: "{{ qdevice_cert }}"
+            dest: "{{ ansible_remote_tmp }}/cluster.crt"
+            owner: root
+            group: root
+            mode: '0644'
+        - name: Import the certificate
+          command: "corosync-qdevice-net-certutil -M -c {{ ansible_remote_tmp }}/cluster.crt"
+        - name: fetch p12 file
+          command: "cat /etc/corosync/qdevice/net/nssdb/qdevice-net-node.p12"
+          register: qdevice_p12_cmd
+        - name: Export certificate and key inside corosync nodes variables
+          add_host:
+            name: "{{ item }}"
+            qdevice_p12: "{{ qdevice_p12_cmd.stdout }}"
+          with_items: "{{ groups['corosync_machines'] }}"
+      when: qdevice_cert is defined
+  post_tasks:
+    - name: Remove temporary files
+      run_once: true
+      file:
+        path: "{{ ansible_remote_tmp }}/cluster.crt"
+        state: absent
+      when: qdevice_cert is defined
+
+- name: import qDevice p12 file
+  hosts: "{{ groups['corosync_machines'][1:] }}"
+  become: true
+  tasks:
+    - block:
+        - name: Copy the p12 file
+          copy:
+            content: "{{ qdevice_p12 }}"
+            dest: "{{ ansible_remote_tmp }}/qdevice-net-node.p12"
+            owner: root
+            group: root
+            mode: '0644'
+        - name: Import the p12 file
+          command: "corosync-qdevice-net-certutil -m -c {{ ansible_remote_tmp }}/qdevice-net-node.p12"
+      when: qdevice_p12 is defined
+  post_tasks:
+    - name: Remove temporary files
+      file:
+        path: "{{ ansible_remote_tmp }}/qdevice-net-node.p12"
+        state: absent
+      when: qdevice_p12 is defined
+
+- name: Start corosync-qdevice
+  hosts: corosync_machines
+  become: true
+  tasks:
+    - name: Start the qdevice service
+      systemd:
+        name: corosync-qdevice
+        state: started
+        enabled: true
+      when: corosync_use_qdevice is defined and corosync_use_qdevice

--- a/templates/cluster.conf.j2
+++ b/templates/cluster.conf.j2
@@ -1,8 +1,7 @@
 [machines]
-hypervisor1 = {{ groups['hypervisors'][0] }}
-hypervisor2 = {{ groups['hypervisors'][1] }}
-{% if ( groups['observers'] is defined) and groups['observers'] %}
+{% for hypervisor in groups['hypervisors'] %}
+hypervisor{{loop.index}} = {{ hypervisor }}
+{% endfor %}
+{% if ( groups['observers'] is defined) and groups['observers'] and (corosync_use_qdevice is undefined or not corosync_use_qdevice) %}
 observer = {{ groups['observers'][0] }}
-{% else %}
-hypervisor3 = {{ groups['hypervisors'][2] }}
 {% endif %}

--- a/vars/corosync_vars.yaml
+++ b/vars/corosync_vars.yaml
@@ -5,7 +5,10 @@
 corosync_cluster_name: "{{ cluster_name | default('seapath') }}"
 corosync_expected_votes: "{{ groups['cluster_machines'] | length }}"
 corosync_transport: 'udpu'
-corosync_node_list: "{{ groups['cluster_machines'] | list }}"
+_corosync_use_qdevice: "{{ corosync_use_qdevice | default(false) }}"
+corosync_node_group: "{{ 'hypervisors' if _corosync_use_qdevice else 'cluster_machines' }}"
+corosync_node_list: "{{ groups[corosync_node_group] | list }}"
 corosync_force_regenerate_authkey: false
 corosync_interfaces:
     ringnumber: 0
+corosync_qdevice: "{{ groups['observers'][0] if _corosync_use_qdevice else omit }}"


### PR DESCRIPTION
This PR adds the configuration of qDevice and qNetd daemons to the cluster_setup_ha playbook. The qDevice and qNetd daemons are used to provide a quorum without the need of a third corosync node. This is useful when the cluster has only two or an even number of nodes.