### PR TITLE
timemaster/ptp4l: increase timeout to avoid warnings on loaded systems

### DIFF
--- a/roles/timemaster/templates/timemaster.conf.j2
+++ b/roles/timemaster/templates/timemaster.conf.j2
@@ -60,6 +60,11 @@ priority2                255
 # Default clock class : any specialised clock will be better (ie a GPS Grand Master Clock)
 clockClass               248
 
+# Default timeout to get the TX timestamp (1 ms) might be low on a loaded system
+# For example, with IGB driver, a kworker (SCHED_OTHER) wakeup is on the critical
+# path and may have to wait a tick to be scheduled.
+tx_timestamp_timeout    10
+
 [chronyd]
 path /usr/sbin/chronyd
 


### PR DESCRIPTION
In ptp4l, the default timeout to get the TX timestamp (1 ms) might be low on a loaded system For example, with IGB driver, a kworker (SCHED_OTHER) wakeup is on the critical path and may have to wait a tick to be scheduled.

Increase this timeout to 10ms to give the kworker thread a chance to be schedule at a tick.