### PR TITLE
Solves VMs autostart on standalone

### DIFF
--- a/roles/centos_physical_machine/tasks/main.yml
+++ b/roles/centos_physical_machine/tasks/main.yml
@@ -80,13 +80,6 @@
     name: chrony-wait.service
     enabled: yes
 
-- name: Create libvirtd.service.d directory
-  file:
-    path: /etc/systemd/system/libvirtd.service.d/
-    state: directory
-    owner: root
-    group: root
-    mode: 0755
 - name: Create pacemaker.service.d directory
   file:
     path: /etc/systemd/system/pacemaker.service.d/

--- a/roles/centos_physical_machine/templates/pacemaker_override.conf.j2
+++ b/roles/centos_physical_machine/templates/pacemaker_override.conf.j2
@@ -6,5 +6,6 @@ After=libvirtd.service
 WantedBy=corosync.service
 
 [Service]
+ExecStartPre=/usr/bin/virsh list
 TimeoutStopSec={{ pacemaker_shutdown_timeout | default("2min") }}
 TimeoutStartSec=60s

--- a/roles/debian_physical_machine/files/libvirtd_override.conf
+++ b/roles/debian_physical_machine/files/libvirtd_override.conf
@@ -1,2 +1,0 @@
-[Service]
-ExecStartPost=/usr/bin/virsh list

--- a/roles/debian_physical_machine/tasks/main.yml
+++ b/roles/debian_physical_machine/tasks/main.yml
@@ -244,21 +244,6 @@
     name: chrony-wait.service
     enabled: yes
 
-- name: Create libvirtd.service.d directory
-  file:
-    path: /etc/systemd/system/libvirtd.service.d/
-    state: directory
-    owner: root
-    group: root
-    mode: 0755
-- name: Copy libvirtd.service drop-in
-  ansible.builtin.copy:
-    src: libvirtd_override.conf
-    dest: /etc/systemd/system/libvirtd.service.d/override.conf
-    owner: root
-    group: root
-    mode: 0644
-  notify: daemon-reload
 - name: Create pacemaker.service.d directory
   file:
     path: /etc/systemd/system/pacemaker.service.d/

--- a/roles/debian_physical_machine/templates/pacemaker_override.conf.j2
+++ b/roles/debian_physical_machine/templates/pacemaker_override.conf.j2
@@ -6,5 +6,6 @@ After=libvirtd.service
 WantedBy=corosync.service
 
 [Service]
+ExecStartPre=/usr/bin/virsh list
 TimeoutStopSec={{ pacemaker_shutdown_timeout | default("2min") }}
 TimeoutStartSec=60s


### PR DESCRIPTION
On standalone, the VMs are not started/shutdown with pacemaker, so we need to use the autostart feature of libvirtd. It seems that this "virsh list" as ExecStartPost makes libvirtd choke on autostart.
This "virsh list" was there to make sure libvirtd is properly started before we start pacemaker.

This commits moves this check as an ExecStartPre of pacemaker, so that it does not meddle with libvirtd startup.

This will solves #613.