### PR TITLE
pacemaker_ra/VirtualDomain: add support of sync_config_on_stop

### DIFF
--- a/roles/debian_physical_machine/files/pacemaker_ra/VirtualDomain
+++ b/roles/debian_physical_machine/files/pacemaker_ra/VirtualDomain
@@ -819,7 +819,15 @@ save_config(){
 			if virt-xml-validate ${CFGTMP} domain 2>/dev/null ;	then
 				ocf_log info "Saving domain $DOMAIN_NAME to ${OCF_RESKEY_config}. Please make sure it's present on all nodes or sync_config_on_stop is on."
 				if cat ${CFGTMP} > ${OCF_RESKEY_config} ; then
-					ocf_log info "Saved $DOMAIN_NAME domain's configuration to ${OCF_RESKEY_config}."
+					if ocf_is_true "$OCF_RESKEY_seapath" ; then
+						if rbd image-meta set system_${DOMAIN_NAME} xml "$(cat ${CFGTMP})" ; then
+							ocf_log info "Saved $DOMAIN_NAME domain's configuration to ${OCF_RESKEY_config} and rbd system_${DOMAIN_NAME} metadata"
+						else
+							ocf_log warn "Saving $DOMAIN_NAME domain's configuration to rbd system_${DOMAIN_NAME} metadata failed."
+						fi
+					else
+						ocf_log info "Saved $DOMAIN_NAME domain's configuration to ${OCF_RESKEY_config}."
+					fi
 					if ocf_is_true "$OCF_RESKEY_sync_config_on_stop"; then
 						sync_config
 					fi


### PR DESCRIPTION
This patch adds the support of the "sync_config_on_stop parameter" when "seapath" parameter is set to "true".

When the "sync_config_on_stop" parameter is set to "true", the domain configuration is saved to the rbd image metadata when the resource is stopped.

The sync config validates the XML configuration and requires libxml2-utils packages installed by this PR: https://github.com/seapath/build_debian_iso/pull/117.