### PR TITLE
OVS management through Netplan and Libvirt

### DIFF
--- a/inventories/netplan_ovs_bridge_example.yaml.j2
+++ b/inventories/netplan_ovs_bridge_example.yaml.j2
@@ -1,0 +1,14 @@
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+network:
+  version: 2
+  renderer: networkd
+  openvswitch:
+    protocols: [OpenFlow13, OpenFlow14, OpenFlow15]
+  ethernets:
+    {{ ovs_ext_interface }}: {}
+  bridges:
+    ovs0:
+      interfaces: [{{ ovs_ext_interface }}]
+      openvswitch:
+        protocols: [OpenFlow10, OpenFlow11, OpenFlow12]

--- a/inventories/seapath_vm_definition_example.yml
+++ b/inventories/seapath_vm_definition_example.yml
@@ -15,8 +15,10 @@ all:
           preferred_host: pc1 # Optional
           force: true
           bridges:
-            - name: "br0" # Change the bridge name
+            - name: "ovs0" # Change the bridge name
               mac_address: "52:54:00:c4:ff:02" # change the MAC address
+              vlan:
+                vlan: 100 # Add a VLAN on the OVS port created
         guest1:
           description: "Complex VM"
           ansible_host: 192.168.212.131 # Update the VM IP

--- a/templates/vm/guest.xml.j2
+++ b/templates/vm/guest.xml.j2
@@ -145,6 +145,11 @@
             {% if bridge.type is defined %}
                 <virtualport type='{{ bridge.type }}'/>
             {% endif %}
+            {% if bridge.vlan is defined %}
+                <vlan>
+                    <tag id='{{ bridge.vlan.vlan_tag }}'/>
+                </vlan>
+            {% endif %}
         </interface>
         {% endfor %}
         {% endif %}

--- a/templates/vm/guest.xml.j2
+++ b/templates/vm/guest.xml.j2
@@ -142,6 +142,9 @@
             <source bridge="{{ bridge.name }}"/>
             <mac address="{{ bridge.mac_address }}"/>
             <model type="virtio"/>
+            {% if bridge.type is defined %}
+                <virtualport type='{{ bridge.type }}'/>
+            {% endif %}
         </interface>
         {% endfor %}
         {% endif %}


### PR DESCRIPTION
This PR adds new ways to managed OVS bridges and virtual port through Netplan and Libvirt, on a standalone Seapath machine.
* Using Netplan configuration file [inventories/netplan_ovs_bridge_example.yaml.j2](https://github.com/seapath/ansible/compare/debiancentos...netplan_ovs?expand=1#diff-4ddaad927cd1722f5584e18d4e721c6983495a0cc458ee47d77712c3170e040b), it is now possible to create an OVS bridge from Netplan.
* Using Libvirt <virtualport> field, it is now possible to create OVS virtual port directly from Libvirt XML configuration file. The modification adds also the possibility to configure a VLAN. 
These modifications are based on the current inventory OVS bridge  syntax.