### PR TITLE
Allow advanced commands after file upload

### DIFF
--- a/playbooks/seapath_setup_prerequisdebian.yaml
+++ b/playbooks/seapath_setup_prerequisdebian.yaml
@@ -78,7 +78,9 @@
         - upload_files is defined
         - item.extract is defined and item.extract is true
     - name: run extra commands after upload
-      command: "{{ item }}"
+      shell: "{{ item }}"
+      tags:
+        - skip_ansible_lint
       loop: "{{ commands_to_run_after_upload }}"
       when: commands_to_run_after_upload is defined
 


### PR DESCRIPTION
The command module does not support advanced Bash operations such as pipes (|), redirections, or if conditionals. That’s why the use of the shell module is necessary in this case.

My use case was: I need to restart a pacemaker resource after file upload and needed this command to run only on node 1. "if [[ $(hostname) == 'node1' ]] && crm_mon -1 | grep 'my_resource'; then crm_resource --resource my_resource --restart; fi"