### PR TITLE
ceph-ansible: move to ceph 16

### DIFF
--- a/.cqfd/docker/Dockerfile
+++ b/.cqfd/docker/Dockerfile
@@ -22,7 +22,15 @@ RUN set -x \
         vim \
     && sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen \
     && python3 -m venv --system-site-packages /env \
-    && /env/bin/pip install ansible==2.10.7 ansible-lint==5.4.0 yamllint six netaddr jmespath \
+    && /env/bin/pip install \
+        ansible==2.10.7 \
+        ansible-lint==5.4.0 \
+        yamllint \
+        six \
+        netaddr \
+        jmespath \
+    && cp /env/lib/python3.11/site-packages/pip/_vendor/six.py \
+        /env/lib/python3.11/site-packages/ansible/module_utils/six/__init__.py \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/*
 
 ENV PATH="/env/bin:/env/usr/bin:/env/sbin:/env/usr/sbin:$PATH"

--- a/.cqfd/docker/Dockerfile
+++ b/.cqfd/docker/Dockerfile
@@ -1,42 +1,30 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubuntu:22.04
+FROM debian:12
 
-ENV DEBIAN_FRONTEND noninteractive
-
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US.UTF-8
-ENV LC_ALL en_US.UTF-8
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8
 
 RUN set -x \
     && apt-get update \
     && apt-get install -y \
-        ansible-lint \
-        bash \
-        docker.io \
-        docker-compose \
-        git \
         locales \
-        python3-docutils \
-        python3-libvirt \
-        python3-netaddr \
-        python3-pip \
-        python3-pygments \
-        python3-sphinx \
-	python3-matplotlib \
-        python3-sphinx-notfound-page \
+        git \
+        python3-full \
+        python3-matplotlib \
         rstcheck \
         rsync \
         ruby-asciidoctor-pdf \
-        ssh \
+        npm \
         vim \
-        yamllint \
-        gnuplot \
-    && sed -i "s/# en_US\.UTF-8 UTF-8/en_US\.UTF-8 UTF-8/" /etc/locale.gen \
-    && locale-gen \
-    && dpkg-reconfigure locales \
-    && pip install "ansible>=2.9,<2.10,!=2.9.10" \
+    && sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen \
+    && python3 -m venv --system-site-packages /env \
+    && /env/bin/pip install ansible==2.10.7 ansible-lint==5.4.0 yamllint six netaddr jmespath \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/*
+
+ENV PATH="/env/bin:/env/usr/bin:/env/sbin:/env/usr/sbin:$PATH"
 
 COPY check_yaml.sh /usr/bin/check_yaml

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,4 +2,4 @@
 	path = ceph-ansible
 	url = https://github.com/ceph/ceph-ansible.git
 	ignore = dirty
-	branch = stable-5.0
+	branch = stable-6.0

--- a/ansible-requirements.yaml
+++ b/ansible-requirements.yaml
@@ -17,3 +17,6 @@ roles:
 collections:
     - name: "community.libvirt"
       version: "1.0.2"
+    - name: "community.general"
+      version: "4.5.0"
+    - name: "ansible.utils"

--- a/prepare.sh
+++ b/prepare.sh
@@ -21,8 +21,8 @@ if ! command -v ansible &>/dev/null ; then
     exit 1
 fi
 
-echo "Test Ansible version is 2.9"
-if ! ansible --version | grep -q 'ansible 2.9' ; then
+echo "Test Ansible version is 2.10"
+if ! ansible --version | grep -q 'ansible 2.10' ; then
     echo "Error: Installed version of ansible must match 2.9" 1>&2
     echo "See README.adoc for instructions" 1>&2
 fi

--- a/src/ceph-ansible-patches/distro_not_supported.diff
+++ b/src/ceph-ansible-patches/distro_not_supported.diff
@@ -1,11 +1,11 @@
 diff --git a/roles/ceph-validate/tasks/check_system.yml b/roles/ceph-validate/tasks/check_system.yml
-index d4f927d9..777869a9 100644
+index dc8cdd6fd..62412ac6c 100644
 --- a/roles/ceph-validate/tasks/check_system.yml
 +++ b/roles/ceph-validate/tasks/check_system.yml
 @@ -19,11 +19,6 @@
      msg: "Architecture not supported {{ ansible_facts['architecture'] }}"
    when: ansible_facts['architecture'] not in ['x86_64', 'ppc64le', 'armv7l', 'aarch64']
-
+ 
 -- name: fail on unsupported distribution
 -  fail:
 -    msg: "Distribution not supported {{ ansible_facts['os_family'] }}"
@@ -13,4 +13,4 @@ index d4f927d9..777869a9 100644
 -
  - name: fail on unsupported CentOS release
    fail:
-     msg: "CentOS release not supported {{ ansible_facts['distribution_major_version'] }} with dashboard"
+     msg: "CentOS release {{ ansible_facts['distribution_major_version'] }} not supported with dashboard"

--- a/src/ceph-ansible-patches/osd_no_package.diff
+++ b/src/ceph-ansible-patches/osd_no_package.diff
@@ -1,5 +1,5 @@
 diff --git a/roles/ceph-osd/tasks/main.yml b/roles/ceph-osd/tasks/main.yml
-index 18595055..ee298a10 100644
+index 623731ddd..88d97f623 100644
 --- a/roles/ceph-osd/tasks/main.yml
 +++ b/roles/ceph-osd/tasks/main.yml
 @@ -15,16 +15,6 @@
@@ -19,10 +19,3 @@ index 18595055..ee298a10 100644
  - name: install numactl when needed
    package:
      name: numactl
-@@ -129,4 +119,4 @@
-     - not rolling_update | default(False) | bool
-     - openstack_config | bool
-     - inventory_hostname == groups[osd_group_name] | last
--  tags: wait_all_osds_up
-\ No newline at end of file
-+  tags: wait_all_osds_up


### PR DESCRIPTION
The Ceph and ceph-ansible have to be in the same version. This patch moves ceph-ansible to the ceph 16 version to match the ceph version.

This patch upadtes the ceph-ansible submodule, the ansible-requirements.yaml file to match the new ceph-ansible requirements and update the patches.