### PR TITLE
yocto/kernel_params: add missing soft_restart_machine.yaml file

### DIFF
--- a/roles/yocto/kernel_params/tasks/main.yaml
+++ b/roles/yocto/kernel_params/tasks/main.yaml
@@ -40,7 +40,7 @@
         regexp: '(root=.*)'
         replace: '\1 {{ extra_kernel_parameters }}'
       when: extra_param_needed is defined
-    - include_tasks: tasks/soft_restart_machine.yaml
+    - include_tasks: soft_restart_machine.yaml
       when:
         - kernel_parameters_restart is defined
         - kernel_parameters_restart

--- a/roles/yocto/kernel_params/tasks/soft_restart_machine.yaml
+++ b/roles/yocto/kernel_params/tasks/soft_restart_machine.yaml
@@ -1,0 +1,14 @@
+# Copyright (C) 2022, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+---
+
+- name: Restart
+  reboot:
+- name: Wait for host to be online
+  wait_for_connection:
+- name: Wait systemd has finished to boot
+  command: systemctl is-system-running --wait
+  register: system_status
+  tags:
+    - skip_ansible_lint
+  failed_when: system_status.rc != 0 and system_status.rc != 1


### PR DESCRIPTION
The soft_restart_machine.yaml file was missing in the kernel_params role and the path was not correct in the main.yaml file.