### PR TITLE
prepare: fix error message for Ansible version

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -23,7 +23,7 @@ fi
 
 echo "Test Ansible version is 2.10"
 if ! ansible --version | grep -q 'ansible 2.10' ; then
-    echo "Error: Installed version of ansible must match 2.9" 1>&2
+    echo "Error: Installed version of ansible must match 2.10" 1>&2
     echo "See README.adoc for instructions" 1>&2
 fi
 


### PR DESCRIPTION
The error message for the Ansible version check was incorrect. It was checking for version 2.10 but the error message was saying that the version must match 2.9.