### PR TITLE
replace node: allow for custom hostname different than inventory hostname

### DIFF
--- a/playbooks/replace_machine_remove_machine_from_cluster.yaml
+++ b/playbooks/replace_machine_remove_machine_from_cluster.yaml
@@ -17,7 +17,7 @@
   become: true
   tasks:
     - name: get OSD to shrink
-      script: "../scripts/get_osd.py {{ machine_to_remove }}"
+      script: "../scripts/get_osd.py {{ hostvars[machine_to_remove].get('hostname', machine_to_remove) }}"
       register: raw_osd
       delegate_to: "{{ groups['mon_host'][0] }}"
     - debug:
@@ -35,7 +35,7 @@
 
 - import_playbook: replace_machine_shrink_mon.yaml
   vars:
-    mon_to_kill: "{{ machine_to_remove }}"
+    mon_to_kill: "{{ hostvars[machine_to_remove].get('hostname', machine_to_remove) }}"
 
 - import_playbook: replace_machine_shrink_pacemaker.yaml
   vars:

--- a/playbooks/replace_machine_shrink_mon.yaml
+++ b/playbooks/replace_machine_shrink_mon.yaml
@@ -59,7 +59,9 @@
     - name: exit playbook, if the monitor is not part of the inventory
       fail:
         msg: "It seems that the host given is not part of your inventory, please make sure it is."
-      when: mon_to_kill not in groups[mon_group_name]
+      when:
+        - mon_to_kill not in groups[mon_group_name]
+        - machine_to_remove not in groups[mon_group_name]
 
     - import_role:
         name: ceph-defaults


### PR DESCRIPTION
This commits uses the "hostname" variable to remove the ceph components in the replace machine playbook, in case the actual hostname of the node is different from the inventory hostname (in which case the ceph component will not be called after the inventory hostname)