### PR TITLE
livemigration_user: use default path for authorized_keys

### DIFF
--- a/playbooks/cluster_setup_add_livemigration_user.yaml
+++ b/playbooks/cluster_setup_add_livemigration_user.yaml
@@ -49,7 +49,6 @@
           authorized_key:
             user: "{{ livemigration_user }}"
             state: present
-            path: "/etc/ssh/{{ livemigration_user }}/authorized_keys"
             key: "{{ lookup('file','buffer/' + item + '-id_rsa.pub') }}"
           with_items: "{{ groups['hypervisors'] }}"
         - name: Fetch the ssh keyfile


### PR DESCRIPTION
The authorized_keys file is now created in the default path for the livemigration_user. This is done to avoid the need to specify the path in the playbook.