### PR TITLE
purge_cluster: add playbook to purge Ceph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ playbooks/*
 !playbooks/standalone*
 !playbooks/deploy_*.yaml
 !playbooks/seapath_setup_*.yaml
+!playbooks/purge_ceph.yaml
 inventories/*
 !inventories/README.adoc
 !inventories/*example*

--- a/playbooks/purge_ceph.yaml
+++ b/playbooks/purge_ceph.yaml
@@ -1,0 +1,37 @@
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Remove the Ceph configuration on the cluster
+
+# This playbook is intended to be used if Ceph configuration fails during cluster setup
+# Using it on a fully configured cluster does not allow redeployment of a fresh cluster
+
+---
+- import_playbook: ../ceph-ansible/infrastructure-playbooks/purge-cluster.yml
+
+- name: Re-create Ceph folders
+  hosts: cluster_machines
+  become: true
+  tasks:
+    - name: Re-create Ceph folders
+      file:
+        path: "{{ item }}"
+        state: directory
+        owner: ceph
+        group: ceph
+        mode: '0755'
+      with_items:
+        - /etc/ceph
+        - /var/lib/ceph/
+        - /var/lib/ceph/mon
+        - /var/lib/ceph/osd
+        - /var/lib/ceph/mds
+        - /var/lib/ceph/tmp
+        - /var/lib/ceph/radosgw
+        - /var/lib/ceph/bootstrap-rgw
+        - /var/lib/ceph/bootstrap-mgr
+        - /var/lib/ceph/bootstrap-mds
+        - /var/lib/ceph/bootstrap-osd
+        - /var/lib/ceph/bootstrap-rbd
+        - /var/lib/ceph/bootstrap-rbd-mirror
+        - /var/run/ceph /var/log/ceph


### PR DESCRIPTION
This playbook allows to remove configurations related to Ceph to re-deploy a cluster.