### PR TITLE
github/workflows: keep running tests even if the previous step failed

### DIFF
--- a/.github/workflows/ci-debian-weekly.yml
+++ b/.github/workflows/ci-debian-weekly.yml
@@ -33,14 +33,17 @@ jobs:
              ci/launch.sh conf;
 
       - name: Launch system tests
+        if: ${{ always() && steps.conf.conclusion == 'success' }}
         run: cd ${{ env.WORK_DIR }};
              ci/launch.sh system;
 
       - name: Launch VM tests
+        if: ${{ always() && steps.conf.conclusion == 'success' }}
         run: cd ${{ env.WORK_DIR }};
              ci/launch.sh vm;
 
       - name: Launch latency tests
+        if: ${{ always() && steps.conf.conclusion == 'success' }}
         run: cd ${{ env.WORK_DIR }};
              ci/launch.sh latency;
 

--- a/.github/workflows/ci-yocto-weekly.yml
+++ b/.github/workflows/ci-yocto-weekly.yml
@@ -36,18 +36,22 @@ jobs:
              ci/launch-yocto.sh conf;
 
       - name: Launch system tests
+        if: ${{ always() && steps.conf.conclusion == 'success' }}
         run: cd ${{ env.WORK_DIR }};
              ci/launch-yocto.sh system;
 
       - name: Deploy VMs
+        if: ${{ always() && steps.conf.conclusion == 'success' }}
         run: cd ${{ env.WORK_DIR }};
             ci/launch-yocto.sh deploy_vms;
 
       - name: Launch VMs tests
+        if: ${{ always() && steps.conf.conclusion == 'success' }}
         run: cd ${{ env.WORK_DIR }};
              ci/launch-yocto.sh test_vms;
 
       - name: Launch latency tests
+        if: ${{ always() && steps.conf.conclusion == 'success' }}
         run: cd ${{ env.WORK_DIR }};
             ci/launch-yocto.sh test_latency
 

--- a/.github/workflows/ci-yocto.yml
+++ b/.github/workflows/ci-yocto.yml
@@ -34,18 +34,22 @@ jobs:
              ci/launch-yocto.sh conf;
 
       - name: Launch system tests
+        if: ${{ always() && steps.conf.conclusion == 'success' }}
         run: cd ${{ env.WORK_DIR }};
              ci/launch-yocto.sh system;
 
       - name: Deploy VMs
+        if: ${{ always() && steps.conf.conclusion == 'success' }}
         run: cd ${{ env.WORK_DIR }};
             ci/launch-yocto.sh deploy_vms;
 
       - name: Launch VMs tests
+        if: ${{ always() && steps.conf.conclusion == 'success' }}
         run: cd ${{ env.WORK_DIR }};
              ci/launch-yocto.sh test_vms;
 
       - name: Launch latency tests
+        if: ${{ always() && steps.conf.conclusion == 'success' }}
         run: cd ${{ env.WORK_DIR }};
             ci/launch-yocto.sh test_latency
 


### PR DESCRIPTION
This patch adds a condition to the jobs that launch the tests to make sure all the tests are run even if the previous step failed. Without this condition, the tests would not run if the previous step failed and the report generation would fail.