### PR TITLE
ansible-requirements: bump systemd_networkd role to latest commit

### DIFF
--- a/ansible-requirements.yaml
+++ b/ansible-requirements.yaml
@@ -7,7 +7,7 @@ roles:
     - name: "systemd_networkd"
       src: "https://github.com/seapath/ansible-role-systemd-networkd"
       scm: git
-      version: "f5eb4d21d76cc1fd67d1f21340ff39dc9f42d4f7"
+      version: "003589d4ce3957a28cf3084032b199cb30372a3c"
 
 collections:
     - name: "community.libvirt"


### PR DESCRIPTION
The latest commit of the systemd_networkd role use udevadm trigger to re-trigger udev rules after the networkd configuration is applied instead restarting the udev service.