### PR TITLE
playbooks/seapath_setup_main.yaml: detect seapath distro for VMs

### DIFF
--- a/playbooks/seapath_setup_main.yaml
+++ b/playbooks/seapath_setup_main.yaml
@@ -13,6 +13,7 @@
   hosts:
     - cluster_machines
     - standalone_machine
+    - VMs
   roles:
     - detect_seapath_distro
 


### PR DESCRIPTION
Currently, seapath_setup_prerequiscentos.yaml and
seapath_setup_prerequisdebian.yaml playbooks have tasks applying to VMs. As "when" conditions on "import_playbook" are evaluated for every task in the playbook, "when" conditions on seapath_distro in seapath_setup_main.yaml will be evaluated on VMs tasks. To prevent undefined variable errors, also detect the seapath distro on VMs.

If VMs in the inventory are not reachable because not yet deployed, or doesn't match any seapath_dsitro criteria, they should be ignored with the appropriate `--limit` option when executing seapath_setup_main.yaml, as stated in README.adoc.