### PR TITLE
Improve latency tests

### DIFF
--- a/.github/workflows/ci-yocto-weekly.yml
+++ b/.github/workflows/ci-yocto-weekly.yml
@@ -19,3 +19,5 @@ permissions:
 jobs:
   call-workflow:
     uses: ./.github/workflows/ci-yocto.yml
+    with:
+      pcap_loop: 900 # 15 min

--- a/.github/workflows/ci-yocto.yml
+++ b/.github/workflows/ci-yocto.yml
@@ -11,6 +11,11 @@ on:
     types: [opened, reopened, synchronize]
     branches: [main]
   workflow_call:
+    inputs:
+      pcap_loop:
+        default: 60
+        required: false
+        type: number
   workflow_dispatch:
 
 permissions:
@@ -20,6 +25,8 @@ permissions:
 jobs:
   CI:
     runs-on: [self-hosted, runner-SFL]
+    env:
+      PCAP_LOOP: ${{ inputs.pcap_loop == '' && '60' || inputs.pcap_loop  }}
     steps:
 
       - name: Initialize sources

--- a/playbooks/ci_latency_tests.yaml
+++ b/playbooks/ci_latency_tests.yaml
@@ -103,6 +103,7 @@
   tasks:
     - name: "Send pcap from publisher"
       command: >-
+        {% if bittwist_cpu is defined %} taskset -c {{ bittwist_cpu }} {% endif %}
           bittwist
             -i {{ sv_interface }}
             -l {{ pcap_loop }}

--- a/playbooks/ci_latency_tests.yaml
+++ b/playbooks/ci_latency_tests.yaml
@@ -74,6 +74,7 @@
         -d {{ sv_interface }}
         -f "/tmp/latency_tests/ts_{{ inventory_hostname }}.txt"
         -t
+        -s svID0000
 
 - name: Launch sv timestamp logger on VMs
   hosts: VMs
@@ -94,6 +95,7 @@
         sv_timestamp_logger
         -d {{ sv_interface }}
         -f "/tmp/latency_tests/ts_{{ inventory_hostname }}.txt"
+        -s svID0000
 
 - name: Launch pcap sending
   hosts: publisher_machine


### PR DESCRIPTION
- Run latency test for 5H
- Save only the latency of the first SV of each 4000 iteration as a temporary workaround due to current memory limitations