### PR TITLE
github/workflows/ci-debian: add workflow_dispatch

### DIFF
--- a/.github/workflows/ci-debian.yml
+++ b/.github/workflows/ci-debian.yml
@@ -11,6 +11,7 @@ on:
     types: [opened, reopened, synchronize]
     branches: [debiancentos]
   workflow_call:
+  workflow_dispatch:
 
 permissions:
   actions: write


### PR DESCRIPTION
The `workflow_dispatch` allows to manually trigger the CI, in particular on a specific branch of the CI repository.