### PR TITLE
Bugfixes

### DIFF
--- a/roles/add_livemigration_user/tasks/main.yml
+++ b/roles/add_livemigration_user/tasks/main.yml
@@ -38,7 +38,7 @@
       user: "{{ livemigration_user }}"
       state: present
       key: "{{ lookup('file','buffer/' + item + '-id_rsa.pub') }}"
-    with_items: "{{ groups['hypervisors'] }}"
+    loop: "{{ groups['hypervisors'] | intersect(groups['cluster_machines']) }}"
   - name: Fetch the ssh keyfile
     fetch:
       src: "/etc/ssh/ssh_host_ed25519_key.pub"
@@ -49,5 +49,5 @@
       path: "{{ root_home_dir.stdout }}/.ssh/known_hosts"
       name: "{{ item }}"
       key: "{{ item }} {{ lookup('file','buffer/' + item + '-ssh_host_ed25519_key.pub') }}"
-    with_items: "{{ groups['hypervisors'] }}"
+    loop: "{{ groups['hypervisors'] | intersect(groups['cluster_machines']) }}"
   when: livemigration_user is defined

--- a/roles/configure_admin_user/tasks/main.yml
+++ b/roles/configure_admin_user/tasks/main.yml
@@ -16,5 +16,5 @@
         user: "{{ admin_user }}"
         state: present
         key: "{{ lookup('file','buffer/' + item + '-id_rsa.pub') }}"
-      with_items: "{{ groups['hypervisors'] }}"
+      loop: "{{ groups['hypervisors'] | intersect(groups['cluster_machines']) }}"
   when: seapath_distro in [ "CentOS", "Debian" ]

--- a/roles/configure_libvirt/tasks/main.yml
+++ b/roles/configure_libvirt/tasks/main.yml
@@ -11,10 +11,11 @@
   changed_when: false
 - debug:
     var: secret_defined
+
 - name: Check if a secret pool has to be created
   set_fact:
     create_secret_pool: "{% if hostvars[item]['secret_defined'].stdout == '' %}true{% else %}{{ create_secret_pool | default(false) }}{% endif %}"
-  loop: "{{ groups['hypervisors'] }}"
+  loop: "{{ groups['hypervisors'] | intersect(groups['cluster_machines']) }}"
 
 - block:
     - name: Check if the secret is already defined

--- a/roles/debian_physical_machine/tasks/main.yml
+++ b/roles/debian_physical_machine/tasks/main.yml
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
+- name: Populate service facts
+  service_facts:
+
 - name: Copy sysctl rules
   ansible.builtin.copy:
     src: "{{ item }}"
@@ -62,6 +65,8 @@
     rsync_opts:
     - "--chmod=F755"
     - "--chown=root:root"
+  when:
+    - "'cluster_machines' in group_names"
 
 - name: Copy chrony-wait.service
   template:
@@ -80,36 +85,39 @@
     name: chrony-wait.service
     enabled: yes
 
-- name: Create pacemaker.service.d directory
-  file:
-    path: /etc/systemd/system/pacemaker.service.d/
-    state: directory
-    owner: root
-    group: root
-    mode: 0755
-- name: Copy pacemaker.service drop-in
-  template:
-    src: pacemaker_override.conf.j2
-    dest: /etc/systemd/system/pacemaker.service.d/override.conf
-    owner: root
-    group: root
-    mode: 0644
-  notify: daemon-reload
-  register: pacemaker_corosync
-- name: Get Pacemaker service Status
-  ansible.builtin.systemd:
-    name: "pacemaker.service"
-  register: pacemaker_service_status
-- name: disable pacemaker (reinstall step 1/2)
-  ansible.builtin.systemd:
-    name: pacemaker.service
-    enabled: no
-  when: pacemaker_corosync.changed and pacemaker_service_status.status.UnitFileState == "enabled"
-- name: enable pacemaker (reinstall step 2/2)
-  ansible.builtin.systemd:
-    name: pacemaker.service
-    enabled: yes
-  when: pacemaker_corosync.changed and pacemaker_service_status.status.UnitFileState == "enabled"
+- block:
+    - name: Create pacemaker.service.d directory
+      file:
+        path: /etc/systemd/system/pacemaker.service.d/
+        state: directory
+        owner: root
+        group: root
+        mode: 0755
+    - name: Copy pacemaker.service drop-in
+      template:
+        src: pacemaker_override.conf.j2
+        dest: /etc/systemd/system/pacemaker.service.d/override.conf
+        owner: root
+        group: root
+        mode: 0644
+      notify: daemon-reload
+      register: pacemaker_corosync
+    - name: Get Pacemaker service Status
+      ansible.builtin.systemd:
+        name: "pacemaker.service"
+      register: pacemaker_service_status
+    - name: disable pacemaker (reinstall step 1/2)
+      ansible.builtin.systemd:
+        name: pacemaker.service
+        enabled: no
+      when: pacemaker_corosync.changed and pacemaker_service_status.status.UnitFileState == "enabled"
+    - name: enable pacemaker (reinstall step 2/2)
+      ansible.builtin.systemd:
+        name: pacemaker.service
+        enabled: yes
+      when: pacemaker_corosync.changed and pacemaker_service_status.status.UnitFileState == "enabled"
+  when:
+    - services['pacemaker.service'] is defined
 
 - name: Add extra modules to the kernel
   lineinfile:


### PR DESCRIPTION
debian_physical_machine: no pacemaker on standalones
This commit will prevent the playbook to try to disable pacemaker on standalone servers, when it's not even supposed to be installed.

----
fix bug in loops on cluster hypervisors
When running tasks on cluster hypervisors (members of cluster_machines and hypervisors groups), any "looped" action must also be restricted to the same intersection of groups.