### PR TITLE
Bug fixs from CI testing

### DIFF
--- a/roles/centos/tasks/main.yml
+++ b/roles/centos/tasks/main.yml
@@ -201,3 +201,23 @@
 - name: update-grub
   command: grub2-mkconfig -o /boot/grub2/grub.cfg
   when: updategrub1.changed or updategrub2.changed
+
+- name: Stop and Disable NetworkManager
+  service:
+    name: NetworkManager
+    state: stopped
+    enabled: no
+  register: nm_stop
+
+- name: Start and Enable systemd-networkd
+  service:
+    name: systemd-networkd
+    state: started
+    enabled: yes
+  register: sd_start
+
+
+- name: Set need_reboot to true if any change was made
+  set_fact:
+    need_reboot: true
+  when: nm_stop is changed or sd_start is changed

--- a/roles/ci_restore_snapshot/tasks/main.yml
+++ b/roles/ci_restore_snapshot/tasks/main.yml
@@ -25,6 +25,14 @@
 - name: Refresh LVM
   command:
     cmd:  lvchange --refresh vg1
+
+- name: wait until snapshot is cleared
+  command: lvs -a
+  register: result
+  until: result.stdout | regex_search('root-snap', ignorecase=True) is none
+  retries: 6
+  delay: 10
+
 - name: Recreate the snapshot
   lvol:
     vg: vg1


### PR DESCRIPTION
1. When restoring the LVM snapshot the snapshot partition is not immediately gone after reboot, a race condition exists between the ansible runner getting to the "Recreate the snapshot" stage and the target machine syncing the LVM partitions and removing the snapshot, on a slower machine this will cause the ansible to try and create an root-snapshot partition and receiving the error  "Operation not permitted on hidden LV vg1/root-snap", the solution is to wait for the root-snap partition to be cleared.
2. CentOS natively uses NetworkManager as the network service, SEAPATH does not at the moment support this, we use systemd-networkd, for the network to be properly configured NetworkManager must be shot down and systemd-networkd enabled and started, if that was not the case to begin with, a restart will be needed.

