### PR TITLE
cluster_setup_ceph: disable PrivateTmp for ssh during Ceph configuration

### DIFF
--- a/playbooks/cluster_setup_ceph.yaml
+++ b/playbooks/cluster_setup_ceph.yaml
@@ -29,7 +29,45 @@
   roles:
     - ceph_expansion_lv
 
+- name: Ceph OSD hosts pre-configuration
+  hosts: osds
+  tasks:
+    - name: Disable private tmpfs for ceph configuration
+      when: seapath_distro == "Yocto"
+      block:
+        - name: Create /run/systemd/system/sshd@.service.d directory
+          file:
+            path: /run/systemd/system/sshd@.service.d
+            state: directory
+        - name: Temporarily disable private tmpfs for ssh sessions
+          copy:
+            dest: /run/systemd/system/sshd@.service.d/99-temp-disable-private-tmp.conf
+            content: |
+              [Service]
+              PrivateTmp=no
+        - name: Reload systemd daemon
+          systemd:
+            daemon_reload: true
+    - name: Reset Ansible SSH connection
+      meta: reset_connection
+
 - import_playbook: ../ceph-ansible/site.yml
+
+- name: Ceph OSD hosts post-configuration
+  hosts: osds
+  tasks:
+    - name: Enable again private tmpfs after ceph installation
+      when: seapath_distro == "Yocto"
+      block:
+        - name: Delete temporary sshd service override
+          file:
+            path: /run/systemd/system/sshd@.service.d/99-temp-disable-private-tmp.conf
+            state: absent
+        - name: Reload systemd daemon
+          systemd:
+            daemon_reload: true
+    - name: Reset Ansible SSH connection
+      meta: reset_connection
 
 # Ceph mgr module which is enabled by default is not supported by SEAPATH.
 - name: Disable unwanted Ceph mgr module

--- a/roles/timemaster/templates/timemaster.service.j2
+++ b/roles/timemaster/templates/timemaster.service.j2
@@ -1,12 +1,14 @@
 [Unit]
 After=network-online.target
+{% if ptp_interface is defined and ptp_vlanid is not defined %}
+After=sys-subsystem-net-devices-{{ ptp_interface }}.device
+{% endif %}
 Wants=network-online.target
 
 [Service]
 {% if ptp_interface is defined %}{% if ptp_vlanid is defined %}
 ExecStartPre=bash -c "while true; do ip addr show {{ ptp_interface + '.' + ptp_vlanid|string }} && break; sleep 1; done"
 {% else %}
-After=sys-subsystem-net-devices-{{ ptp_interface }}.device
 ExecStartPre=bash -c "while true; do ip addr show {{ ptp_interface }} && break; sleep 1; done"
 {% endif %}
 {% endif %}


### PR DESCRIPTION
Commit [1] in meta-seapath enabled the PrivateTmp systemd option for every ssh sessions with SEAPATH Yocto.
This means that every ssh sessions, including ansible ones, will use a separate mount namespace. Any new files in /tmp or new tmpfs during ansible tasks are deleted once the ssh session closes.

This is a problem regarding Ceph and ceph-ansible. Directories in /var/lib/ceph/osd/, which contains multiple OSD files, are in fact tmpfs created by ceph-ansible. With the PrivateTmp option, these directories are then lost once the Ansible ssh session closes.

As a workaround, temporarily disable the PrivateTmp option for the Ceph configuration.
Note that this only affects SEAPATH Yocto.

[1]: https://github.com/seapath/meta-seapath/commit/22cddd356d2dbb387c76049ae80eb91a982f8082