### PR TITLE
prevent removal of /tmp sticky bit + debian vm: do not disable chrony

### DIFF
--- a/playbooks/ci_prepare_VMs.yaml
+++ b/playbooks/ci_prepare_VMs.yaml
@@ -12,17 +12,6 @@
     - VMs
   become: true
   tasks:
-    - name: Stop and disable chrony
-      ansible.builtin.systemd:
-        name: "chrony"
-        state: stopped
-        enabled: false
-    - name: Stop and disable systemd-resolved
-      ansible.builtin.systemd:
-        name: systemd-resolved
-        state: stopped
-        enabled: false
-
     - name: remove tuned dynamic tuning
       lineinfile:
         path: /etc/tuned/tuned-main.conf

--- a/roles/debian/tasks/main.yml
+++ b/roles/debian/tasks/main.yml
@@ -249,14 +249,3 @@
 - name: update-grub
   command: update-grub
   when: updategrub0.changed or updategrub1.changed or updategrub2.changed
-
-- name: Stop and disable chrony
-  ansible.builtin.systemd:
-    name: "chrony"
-    state: stopped
-    enabled: false
-- name: Stop and disable systemd-resolved
-  ansible.builtin.systemd:
-    name: systemd-resolved
-    state: stopped
-    enabled: false

--- a/roles/deploy_vms_cluster/tasks/main.yml
+++ b/roles/deploy_vms_cluster/tasks/main.yml
@@ -18,7 +18,9 @@
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
     mode: '0755'
-  when: qcow2tmpuploadfolder is defined
+  when:
+    - qcow2tmpuploadfolder is defined
+    - qcow2tmpuploadfolder != "/tmp"
 
 - block:
       - name: "Copy {{ item }} system disk on target"

--- a/roles/deploy_vms_standalone/tasks/main.yml
+++ b/roles/deploy_vms_standalone/tasks/main.yml
@@ -38,7 +38,9 @@
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
     mode: '0755'
-  when: qcow2tmpuploadfolder is defined
+  when:
+    - qcow2tmpuploadfolder is defined
+    - qcow2tmpuploadfolder != "/tmp"
 
 - name: Copy the disk on target
   copy:


### PR DESCRIPTION
prevent removal of /tmp sticky bit

----
debian vm: do not disable chrony
In the CI, the VMs need to be synchronised with ptp-kvm, which requires chrony