### PR TITLE
ci_yocto: add support for Aaeon I.MX8 board

### DIFF
--- a/playbooks/ci_all_machines_tests.yaml
+++ b/playbooks/ci_all_machines_tests.yaml
@@ -15,6 +15,7 @@
 - hosts:
     - cluster_machines
     - standalone_machine
+  gather_facts: false
   roles:
     - ci_yocto/get_system_info
 ...

--- a/playbooks/ci_all_machines_tests.yaml
+++ b/playbooks/ci_all_machines_tests.yaml
@@ -8,6 +8,7 @@
     - cluster_machines
     - standalone_machine
     - VMs
+  gather_facts: false
   roles:
     - ci_yocto/run_tests
 

--- a/playbooks/ci_standalone_setup.yaml
+++ b/playbooks/ci_standalone_setup.yaml
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 Savoir-faire Linux, Inc.
+# Copyright (C) 2023-2025 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 ---
@@ -11,5 +11,14 @@
   roles:
      - role: ci_yocto/reboot_on_usb_drive
        when: ansible_facts['architecture'] == "x86_64"
+
+- name: Swupdate and wipe persistent data
+  hosts:
+    - standalone_machine
+  gather_facts: true
+  become: true
+  roles:
+      - role: ci_yocto/clean_arm_machines
+        when: ansible_facts['architecture'] == "aarch64"
 
 - import_playbook: seapath_setup_main.yaml

--- a/playbooks/ci_standalone_setup.yaml
+++ b/playbooks/ci_standalone_setup.yaml
@@ -7,8 +7,9 @@
   hosts:
     - cluster_machines
     - standalone_machine
-  gather_facts: false
+  gather_facts: true
   roles:
-    - ci_yocto/reboot_on_usb_drive
+     - role: ci_yocto/reboot_on_usb_drive
+       when: ansible_facts['architecture'] == "x86_64"
 
 - import_playbook: seapath_setup_main.yaml

--- a/roles/ci_yocto/clean_arm_machines/tasks/main.yaml
+++ b/roles/ci_yocto/clean_arm_machines/tasks/main.yaml
@@ -1,0 +1,40 @@
+# Copyright (C) 2025 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# This role allows to clean the hypervisor.
+# It performs a software update and removes persistent data.
+
+---
+- name: Create /tmp/update folder
+  file:
+    path: /tmp/update
+    state: directory
+    mode: '0755'
+- name: Mount the USB key
+  mount:
+    src: "{{ usb_device }}"
+    path: /tmp/update
+    fstype: vfat
+    state: mounted
+- name: Execute Swupdate
+  command: /usr/bin/swupdate -i /tmp/update/{{ swupdate_image }}
+- name: Unmount the USB key
+  mount:
+    path: /tmp/update
+    state: unmounted
+- name: Get overlay mounts
+  command: awk '$3 == "overlay" {print $2}' /proc/mounts
+  register: overlay_mounts
+- name: Unmount overlays
+  command: umount -l {{ item }}
+  with_items: "{{ overlay_mounts.stdout_lines }}"
+- name: Remove persistent data
+  file:
+    path: '{{ item }}'
+    state: absent
+  with_items:
+    - /mnt/persistent/etc
+    - /mnt/persistent/home
+    - /mnt/persistent/var
+- name: Reboot the system
+  reboot:

--- a/roles/ci_yocto/get_system_info/tasks/main.yaml
+++ b/roles/ci_yocto/get_system_info/tasks/main.yaml
@@ -13,6 +13,6 @@
 - name: Fetch results
   fetch:
     src: '{{ tmp_test_dir.path }}/system_info.adoc'
-    dest: "{{ cukinia_test_prefix | default('..') }}/system_info.adoc"
+    dest: "{{ cukinia_test_prefix | default('..') }}/system_info_{{ inventory_hostname }}.adoc"
     flat: yes
 ...

--- a/roles/ci_yocto/run_tests/tasks/main.yaml
+++ b/roles/ci_yocto/run_tests/tasks/main.yaml
@@ -23,11 +23,14 @@
       }}.xml
     flat: yes
 
-- name: Execute cyclitect script
-  script: run_cyclictest.py '{{ tmp_test_dir.path }}/cyclictest.txt'
-- name: Fetch results
-  fetch:
-    src: '{{ tmp_test_dir.path }}/cyclictest.txt'
-    dest: "{{ cukinia_test_prefix | default('..') }}/cyclictest_{{ inventory_hostname }}.txt"
-    flat: yes
+- name: Cyclictest
+  block:
+    - name: Execute cyclitect script
+      script: run_cyclictest.py '{{ tmp_test_dir.path }}/cyclictest.txt'
+    - name: Fetch results
+      fetch:
+        src: '{{ tmp_test_dir.path }}/cyclictest.txt'
+        dest: "{{ cukinia_test_prefix | default('..') }}/cyclictest_{{ inventory_hostname }}.txt"
+        flat: yes
+  when: skip_cyclictest is not defined or not skip_cyclictest
 ...


### PR DESCRIPTION
The reboot_on_usb_drive have been replaced by clean_arm_machines on arm machines. This is mandatory since there is no solution to flash the board yet.

The cyclictest have been removed since the kernel is not RT.

Get_system_info have been modified so that multiple system_info can be generated with different names.