### PR TITLE
debian_hypervisor: add missing team0 condition

### DIFF
--- a/roles/debian_hypervisor/tasks/main.yml
+++ b/roles/debian_hypervisor/tasks/main.yml
@@ -210,6 +210,7 @@
     group: root
     mode: 0644
   register: ovsvswitchd
+  when: team0_0 is defined and team0_1 is defined
 - name: Copy team0_x@.service file
   ansible.builtin.copy:
     src: team0_x@.service
@@ -218,6 +219,7 @@
     group: root
     mode: 0644
   register: team0_x_service
+  when: team0_0 is defined and team0_1 is defined
 - name: Restart ovs-vswitchd
   ansible.builtin.systemd:
     state: restarted


### PR DESCRIPTION
Currently, when deploying a SEAPATH Debian standalone configuration some tasks failed has it requires team0 network, which is not used on a standalone configuration (only cluster).
This issue has been introduced with commit
3691fb2f8896c573a962b8ee3714340e53e7d2d7 from PR
https://github.com/seapath/ansible/pull/666.

A missing `when` condition is needed to run these tasks only if team0 network is used.