### PR TITLE
Ansible Lint: adapt to newest version

### DIFF
--- a/ansible-lint.conf
+++ b/ansible-lint.conf
@@ -4,6 +4,7 @@
 # This file handle the configuration of ansible-lint
 
 exclude_paths:
+  - /etc/ansible/roles    # This is the inside container path for ceph-ansible
   - ceph-ansible
   - roles/systemd_networkd
   - roles/corosync
@@ -16,12 +17,14 @@ skip_list:
   - unnamed-task           # All tasks should be named
   - role-name              # All role names should match "^[a-z_][a-z0-9_]*$"
   - risky-file-permissions # All file creation must specify permissions
+  - fqcn-builtins          # Can't use buildins module without precising the full name with the "ansible.builtin." prefix
 
 warn_list:
   - no-handler             # "when: result.changed" should trigger a handler instead
   - no-changed-when        # Commands should not change things if nothing needs doing
   - no-relative-paths      # Doesn't need a relative path in role
   - load-failure           # Don't search for referenced tasks when linting
+  - meta-no-info           # TEMPORARY
 
 ### Why skip these warnings :
 #

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -14,7 +14,7 @@ filter_plugins = ./ceph-ansible/plugins/filter
 log_path = ./ansible.log
 roles_path = ./roles:ceph-ansible/roles
 forks = 20
-collections_paths = ./collections:~/.ansible/collections:/usr/share/ansible/collections
+collections_path = ./collections:~/.ansible/collections:/usr/share/ansible/collections
 
 # Uncomment this if you want disable the ssh key check. It is useful in
 # developement but must not be set in production.

--- a/playbooks/ci_all_machines_tests.yaml
+++ b/playbooks/ci_all_machines_tests.yaml
@@ -4,7 +4,8 @@
 # Ansible playbook that runs all Cukinia's tests.
 
 ---
-- hosts:
+- name: CI Yocto - run tests
+  hosts:
     - cluster_machines
     - standalone_machine
     - VMs
@@ -12,7 +13,8 @@
   roles:
     - ci_yocto/run_tests
 
-- hosts:
+- name: CI Yocto - get system info
+  hosts:
     - cluster_machines
     - standalone_machine
   gather_facts: false

--- a/playbooks/ci_configure.yaml
+++ b/playbooks/ci_configure.yaml
@@ -18,9 +18,11 @@
     - standalone_machine
   tasks:
   - name: CI configure skip setup_debian reboots
-    set_fact:
+    ansible.builtin.set_fact:
       skip_reboot_setup: true
       skip_reboot_setup_network: true
 
-- import_playbook: ./seapath_setup_main.yaml
-- import_playbook: ./seapath_setup_hardened_debian.yaml
+- name: Import seapath_setup_main playbook
+  import_playbook: ./seapath_setup_main.yaml
+- name: Import seapath_setup_hardened_debian playbook
+  import_playbook: ./seapath_setup_hardened_debian.yaml

--- a/playbooks/ci_latency_tests.yaml
+++ b/playbooks/ci_latency_tests.yaml
@@ -9,46 +9,46 @@
       - yoctoCI-aaeon
   tasks:
       - name: "Create latency_tests directory if it doesn't exist"
-        file:
+        ansible.builtin.file:
           path: "/tmp/latency_tests/"
           state: directory
           mode: '0777'
       - name: "Copy archive"
-        copy:
+        ansible.builtin.copy:
           src: "../ci_latency_tests/build/{{ sv_timestamp_logger_image }}"
           dest: "/tmp/latency_tests/sv_timestamp_logger.tar"
 
 - name: Synchronise machines with PTP
   become: true
   vars:
-      - phc_delay: -37
+    phc_delay: "-37"
   hosts:
       - publisher_machine
   tasks:
     - name: Copy ptp4l.service
-      template:
-          src: ../templates/ptp4l.service.j2
-          dest: /etc/systemd/system/ptp4l.service
+      ansible.builtin.template:
+        src: "{{ (playbook_dir | dirname) }}/templates/ptp4l.service.j2"
+        dest: /etc/systemd/system/ptp4l.service
 
     - name: Copy ptp4l.conf
-      template:
-          src: ../templates/ptp4l.conf.j2
-          dest: /etc/linuxptp/ptp4l.conf
+      ansible.builtin.template:
+        src: "{{ (playbook_dir | dirname) }}/templates/ptp4l.conf.j2"
+        dest: /etc/linuxptp/ptp4l.conf
 
     - name: Enable ptp4l.service
-      systemd:
-          name: ptp4l
-          enabled: true
-          daemon-reload: true
-          state: restarted
+      ansible.builtin.systemd:
+        name: ptp4l
+        enabled: true
+        daemon-reload: true
+        state: restarted
 
     - name: Send phc2sys.service
-      template:
-        src: ../templates/phc2sys.service.j2
+      ansible.builtin.template:
+        src: "{{ (playbook_dir | dirname) }}/templates/phc2sys.service.j2"
         dest: /etc/systemd/system/phc2sys.service
 
     - name: Enable phc2sys.service
-      systemd:
+      ansible.builtin.systemd:
         name: phc2sys
         enabled: true
         daemon-reload: true
@@ -59,10 +59,11 @@
   become: true
   tasks:
     - name: Load Docker archive
-      command: "docker image load -i /tmp/latency_tests/sv_timestamp_logger.tar"
+      ansible.builtin.command: "docker image load -i /tmp/latency_tests/sv_timestamp_logger.tar"
+      changed_when: true
 
     - name: Launch sv timestamp logger
-      command: >-
+      ansible.builtin.command: >-
         docker run
         --rm
         --name sv_timestamp_logger
@@ -76,6 +77,7 @@
         -f "/tmp/latency_tests/ts_{{ inventory_hostname }}.txt"
         -t
         -s svID0000
+      changed_when: true
 
 - name: Launch sv timestamp logger on VMs and docker hosts
   hosts:
@@ -84,10 +86,11 @@
   become: true
   tasks:
     - name: Load Docker archive
-      command: "docker image load -i /tmp/latency_tests/sv_timestamp_logger.tar"
+      ansible.builtin.command: "docker image load -i /tmp/latency_tests/sv_timestamp_logger.tar"
+      changed_when: true
 
     - name: Launch sv timestamp logger
-      command: >-
+      ansible.builtin.command: >-
         docker run
         --name sv_timestamp_logger
         -d
@@ -99,19 +102,21 @@
         -d {{ sv_interface }}
         -f "/tmp/latency_tests/ts_{{ inventory_hostname }}.txt"
         -s svID0000
+      changed_when: true
 
 - name: Launch pcap sending
   hosts: publisher_machine
   become: true
   tasks:
     - name: "Send pcap from publisher"
-      command: >-
+      ansible.builtin.command: >-
         {% if bittwist_cpu is defined %} taskset -c {{ bittwist_cpu }} {% endif %}
           bittwist
             -i {{ sv_interface }}
             -l {{ pcap_loop }}
             /seapath-ci/pcaps/{{ pcap_file }}
       register: cmd
+      changed_when: true
 
 - name: Fetch results
   become: true
@@ -121,10 +126,11 @@
       - yoctoCI-aaeon
   tasks:
     - name: "Stop docker container"
-      command: docker stop sv_timestamp_logger
+      ansible.builtin.command: docker stop sv_timestamp_logger
+      changed_when: true
 
     - name: "Copy results to ansible directory"
-      synchronize:
+      ansible.posix.synchronize:
         src: "/tmp/latency_tests/ts_{{ inventory_hostname }}.txt"
         dest: "../ci_latency_tests/results/"
         mode: pull

--- a/playbooks/ci_prepare_VMs.yaml
+++ b/playbooks/ci_prepare_VMs.yaml
@@ -12,17 +12,18 @@
     - VMs
   become: true
   tasks:
-    - name: remove tuned dynamic tuning
-      lineinfile:
+    - name: Remove tuned dynamic tuning
+      ansible.builtin.lineinfile:
         path: /etc/tuned/tuned-main.conf
         state: present
         regexp: '^#?dynamic_tuning = .*$'
         line: 'dynamic_tuning = 0'
-    - name: enable tuned.service
+    - name: Enable tuned.service
       ansible.builtin.systemd:
         name: tuned.service
         enabled: yes
         state: restarted
-    - name: load realtime-virtual-guest tuned profile
+    - name: Load realtime-virtual-guest tuned profile
       ansible.builtin.command: tuned-adm profile realtime-virtual-guest
       when: "'rt' in vm_features"
+      changed_when: true

--- a/playbooks/ci_standalone_setup.yaml
+++ b/playbooks/ci_standalone_setup.yaml
@@ -21,4 +21,5 @@
       - role: ci_yocto/clean_arm_machines
         when: ansible_facts['architecture'] == "aarch64"
 
-- import_playbook: seapath_setup_main.yaml
+- name: Import seapath_setup_main playbook
+  import_playbook: seapath_setup_main.yaml

--- a/playbooks/ci_test.yaml
+++ b/playbooks/ci_test.yaml
@@ -6,7 +6,7 @@
 
 ---
 
-- name: deploy cukinia
+- name: Deploy cukinia
   hosts:
     - cluster_machines
     - standalone_machine
@@ -15,5 +15,7 @@
   roles:
     - deploy_cukinia
 
-- import_playbook: ./test_deploy_cukinia_tests.yaml
-- import_playbook: ./test_run_cukinia.yaml
+- name: Import test_deploy_cukinia_tests playbook
+  import_playbook: ./test_deploy_cukinia_tests.yaml
+- name: Import test_run_cukinia playbook
+  import_playbook: ./test_run_cukinia.yaml

--- a/playbooks/ci_vms_standalone_ptp.yaml
+++ b/playbooks/ci_vms_standalone_ptp.yaml
@@ -3,7 +3,8 @@
 
 # Ansible playbook that deploy and set-up ptp on vms for a standalone machine
 
-- import_playbook: deploy_vms_standalone.yaml
+- name: Import deploy_vms_standalone
+  import_playbook: deploy_vms_standalone.yaml
 
 - name: Synchronise VMs with PTP
   hosts: VMs

--- a/playbooks/cluster_setup_ceph.yaml
+++ b/playbooks/cluster_setup_ceph.yaml
@@ -29,7 +29,8 @@
   roles:
     - ceph_expansion_lv
 
-- import_playbook: ../ceph-ansible/site.yml
+- name: Import ceph-ansible/site.yml playbook
+  import_playbook: ../ceph-ansible/site.yml
 
 # Ceph mgr module which is enabled by default is not supported by SEAPATH.
 - name: Disable unwanted Ceph mgr module
@@ -37,14 +38,16 @@
       mons
   become: true
   tasks:
-      - name: Disable Ceph mgr restful module
-        command: ceph mgr module disable restful
+      - name: Disable Ceph mgr restful module # noqa: run-once[task]
+        ansible.builtin.command: ceph mgr module disable restful
         run_once: true
+        changed_when: true
 - name: Configure rbd
   hosts:
       osds
   become: true
   tasks:
-      - name: Disable rbd lock
-        command: rbd config global set global rbd_default_features 'layering, deep-flatten'
+      - name: Disable rbd lock # noqa: run-once[task] # noqa command-instead-of-module
+        ansible.builtin.command: rbd config global set global rbd_default_features 'layering, deep-flatten'
         run_once: true
+        changed_when: true

--- a/playbooks/deploy_vms_cluster.yaml
+++ b/playbooks/deploy_vms_cluster.yaml
@@ -11,5 +11,5 @@
   tasks:
   - name: Deploy VMs on Cluster Role
     with_items: "{{ groups['VMs'] }}"
-    include_role:
+    ansible.builtin.include_role:
       name: deploy_vms_cluster

--- a/playbooks/deploy_vms_standalone.yaml
+++ b/playbooks/deploy_vms_standalone.yaml
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-- hosts: hypervisors
-  name: Create and start VMs
+- name: Create and start VMs
+  hosts: hypervisors
   gather_facts: false
   become: true
   vars:
@@ -12,10 +12,10 @@
   roles:
     - deploy_vms_standalone
 
-- hosts: VMs
-  name: Wait for VMs to be online
+- name: Wait for VMs to be online
+  hosts: VMs
   gather_facts: false
   tasks:
     - name: Wait for VM connections
-      wait_for_connection:
+      ansible.builtin.wait_for_connection:
       when: wait_for_connection | default(false)

--- a/playbooks/purge_ceph.yaml
+++ b/playbooks/purge_ceph.yaml
@@ -7,14 +7,15 @@
 # Using it on a fully configured cluster does not allow redeployment of a fresh cluster
 
 ---
-- import_playbook: ../ceph-ansible/infrastructure-playbooks/purge-cluster.yml
+- name: Import purge cluster playbook
+  import_playbook: ../ceph-ansible/infrastructure-playbooks/purge-cluster.yml
 
 - name: Re-create Ceph folders
   hosts: cluster_machines
   become: true
   tasks:
     - name: Re-create Ceph folders
-      file:
+      ansible.builtin.file:
         path: "{{ item }}"
         state: directory
         owner: ceph

--- a/playbooks/replace_machine_find_online_ceph_machine.yaml
+++ b/playbooks/replace_machine_find_online_ceph_machine.yaml
@@ -6,13 +6,13 @@
   gather_facts: false
   tasks:
     - name: Wait for machine to be online
-      wait_for_connection:
+      ansible.builtin.wait_for_connection:
         timeout: 1
       ignore_errors: true
       no_log: true
       register: machine_up_raw
     - name: Register result
-      set_fact:
+      ansible.builtin.set_fact:
         machine_up: "{{ not machine_up_raw.failed }}"
 
 - name: Register the machine to use to control Ceph
@@ -22,14 +22,14 @@
     unvalid_machine_filter: ":!{{ machine_to_remove | default(mon_to_kill | default('fake')) }}"
   tasks:
     - name: Register online machines
-      add_host:
+      ansible.builtin.add_host:
         name: "{{ item }}"
         groups: online_host
       loop: "{{ groups.get(mon_group_name) }}"
       when: hostvars[item].machine_up
       changed_when: false
-    - name: check if a Ceph machine is up
-      fail:
+    - name: Check if a Ceph machine is up
+      ansible.builtin.fail:
         msg: "There is no Ceph machine available"
       when: groups['online_host'] is undefined
     - name: Register offline machines
@@ -40,7 +40,7 @@
       when: not hostvars[item].machine_up
       changed_when: false
     - name: Register a machine to run Ceph commands
-      add_host:
+      ansible.builtin.add_host:
         name: "{{ query('inventory_hostnames', 'online_host' + unvalid_machine_filter)[0] }}"
         groups: mon_host
       changed_when: false

--- a/playbooks/replace_machine_remove_machine_from_cluster.yaml
+++ b/playbooks/replace_machine_remove_machine_from_cluster.yaml
@@ -4,25 +4,26 @@
 - name: Sanity check
   hosts: localhost
   pre_tasks:
-    - name: exit playbook, if no machine was given
+    - name: Exit playbook, if no machine was given
       fail:
         msg: "machine_to_remove must be declared"
       when: machine_to_remove is undefined
 
-- import_playbook: replace_machine_find_online_ceph_machine.yaml
+- name: Import replace_machine_find_online_ceph_machine playbook
+  import_playbook: replace_machine_find_online_ceph_machine.yaml
   when: groups['mon_host'] is undefined
 
 - name: Try to find OSD
   hosts: cluster_machines
   become: true
   tasks:
-    - name: get OSD to shrink
+    - name: Get OSD to shrink
       script: "../scripts/get_osd.py {{ hostvars[machine_to_remove].get('hostname', machine_to_remove) }}"
       register: raw_osd
       delegate_to: "{{ groups['mon_host'][0] }}"
     - debug:
         var: raw_osd
-    - name: register OSD
+    - name: Register OSD
       set_fact:
         osd_to_kill: "{{ raw_osd.stdout_lines[0] }}"
       when: raw_osd.stdout
@@ -30,13 +31,16 @@
     - debug:
         var: osd_to_kill
 
-- import_playbook: replace_machine_shrink_osd.yaml
+- name: Import replace_machine_shrink_osd playbook
+  import_playbook: replace_machine_shrink_osd.yaml
   when: osd_to_kill is defined
 
-- import_playbook: replace_machine_shrink_mon.yaml
+- name: Import replace_machine_shrink_mon playbook
+  import_playbook: replace_machine_shrink_mon.yaml
   vars:
     mon_to_kill: "{{ hostvars[machine_to_remove].get('hostname', machine_to_remove) }}"
 
-- import_playbook: replace_machine_shrink_pacemaker.yaml
+- name: Import replace_machine_shrink_pacemaker playbook
+  import_playbook: replace_machine_shrink_pacemaker.yaml
   vars:
     pacemaker_machine: mon_host

--- a/playbooks/replace_machine_shrink_mgr.yaml
+++ b/playbooks/replace_machine_shrink_mgr.yaml
@@ -17,7 +17,7 @@
 #     automation scripts to avoid interactive prompt.
 
 
-- name: gather facts and check the init system
+- name: Gather facts and check the init system
   hosts:
     - "{{ mon_group_name | default('mons') }}"
     - "{{ mgr_group_name | default('mgrs') }}"
@@ -28,7 +28,7 @@
     - debug:
         msg: gather facts on all Ceph hosts for following reference
 
-- name: confirm if user really meant to remove manager from the ceph cluster
+- name: Confirm if user really meant to remove manager from the ceph cluster
   hosts: "{{ groups[mon_group_name][0] }}"
   become: true
   pre_tasks:
@@ -39,12 +39,12 @@
         name: ceph-facts
         tasks_from: container_binary
 
-    - name: set_fact container_exec_cmd
+    - name: Set_fact container_exec_cmd
       when: containerized_deployment | bool
       set_fact:
         container_exec_cmd: "{{ container_binary }} exec ceph-mon-{{ ansible_facts['hostname'] }}"
 
-    - name: exit playbook, if can not connect to the cluster
+    - name: Exit playbook, if can not connect to the cluster
       command: "{{ container_exec_cmd | default('') }} timeout 5 ceph --cluster {{ cluster }} health"
       register: ceph_health
       changed_when: false
@@ -52,23 +52,24 @@
       retries: 5
       delay: 2
 
-    - name: get total number of mgrs in cluster
+    - name: Get total number of mgrs in cluster
       block:
-        - name: save mgr dump output
+        - name: Save mgr dump output
           command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} mgr dump -f json"
           register: mgr_dump
+          changed_when: true
 
-        - name: get active and standbys mgr list
+        - name: Get active and standbys mgr list
           set_fact:
             active_mgr: "{{ [mgr_dump.stdout | from_json] | map(attribute='active_name') | list }}"
             standbys_mgr: "{{ (mgr_dump.stdout | from_json)['standbys'] | map(attribute='name') | list }}"
 
-    - name: exit playbook, if there's no standby manager
+    - name: Exit playbook, if there's no standby manager
       fail:
         msg: "You are about to shrink the only manager present in the cluster."
       when: standbys_mgr | length | int < 1
 
-    - name: exit playbook, if no manager was given
+    - name: Exit playbook, if no manager was given
       fail:
         msg: "mgr_to_kill must be declared
               Exiting shrink-cluster playbook, no manager was removed.
@@ -77,11 +78,11 @@
               manager each time the playbook runs."
       when: mgr_to_kill is not defined
 
-    - name: set_fact mgr_to_kill_hostname
+    - name: Set_fact mgr_to_kill_hostname
       set_fact:
         mgr_to_kill_hostname: "{{ hostvars[mgr_to_kill]['ansible_facts']['hostname'] }}"
 
-    - name: exit playbook, if the selected manager is not present in the cluster
+    - name: Exit playbook, if the selected manager is not present in the cluster
       fail:
         msg: "It seems that the host given is not present in the cluster."
       when:
@@ -89,9 +90,9 @@
         - mgr_to_kill_hostname not in standbys_mgr
 
   tasks:
-    - name: stop manager services and verify it
+    - name: Stop manager services and verify it
       block:
-        - name: stop manager service
+        - name: Etop manager service
           service:
             name: ceph-mgr@{{ mgr_to_kill_hostname }}
             state: stopped
@@ -99,15 +100,16 @@
           delegate_to: "{{ mgr_to_kill }}"
           failed_when: false
 
-        - name: ensure that the mgr is stopped
-          command: "systemctl is-active ceph-mgr@{{ mgr_to_kill_hostname }}"  # noqa 303
+        - name: Ensure that the mgr is stopped
+          command: "systemctl is-active ceph-mgr@{{ mgr_to_kill_hostname }}"  # noqa command-instead-of-module
           register: mgr_to_kill_status
           failed_when: mgr_to_kill_status.rc == 0
           delegate_to: "{{ mgr_to_kill }}"
           retries: 5
           delay: 2
+          changed_when: true
 
-    - name: fail if the mgr is reported in ceph mgr dump
+    - name: Fail if the mgr is reported in ceph mgr dump
       command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} mgr dump -f json"
       register: mgr_dump
       changed_when: false
@@ -116,13 +118,13 @@
       retries: 12
       delay: 10
 
-    - name: purge manager store
+    - name: Purge manager store
       file:
         path: /var/lib/ceph/mgr/{{ cluster }}-{{ mgr_to_kill_hostname }}
         state: absent
       delegate_to: "{{ mgr_to_kill }}"
 
   post_tasks:
-    - name: show ceph health
+    - name: Show ceph health
       command: "{{ container_exec_cmd | default('') }} ceph --cluster {{ cluster }} -s"
       changed_when: false

--- a/playbooks/replace_machine_shrink_mon.yaml
+++ b/playbooks/replace_machine_shrink_mon.yaml
@@ -21,24 +21,25 @@
 - name: Sanity check
   hosts: localhost
   tasks:
-    - name: exit playbook, if no monitor was given
+    - name: Exit playbook, if no monitor was given
       fail:
         msg: "mon_to_kill must be declared
           Exiting shrink-cluster playbook, no monitor was removed.
            On the command line when invoking the playbook, you can use
            -e mon_to_kill=ceph-mon01 argument. You can only remove a single monitor each time the playbook runs."
-      when: mon_to_kill is not defined
+      when: Mon_to_kill is not defined
 
-- import_playbook: replace_machine_find_online_ceph_machine.yaml
+- name: Import replace_machine_find_online_ceph_machine playbook
+  import_playbook: replace_machine_find_online_ceph_machine.yaml
   when: groups['mon_host'] is undefined
 
-- name: gather facts and check the init system
+- name: Gather facts and check the init system
   hosts: "{{ mon_group_name|default('mons') }}"
   become: true
   tasks:
     - debug:
         var: machine_up
-    - name: "Gather facts"
+    - name: Gather facts
       gather_facts:
       when: machine_up
 
@@ -50,13 +51,13 @@
     offline_host: "{{ groups['offline_host'] is defined }}"
 
   pre_tasks:
-    - name: exit playbook, if only one monitor is present in cluster
+    - name: Exit playbook, if only one monitor is present in cluster
       fail:
         msg: "You are about to shrink the only monitor present in the cluster.
               If you really want to do that, please use the purge-cluster playbook."
       when: groups[mon_group_name] | length | int == 1
 
-    - name: exit playbook, if the monitor is not part of the inventory
+    - name: Exit playbook, if the monitor is not part of the inventory
       fail:
         msg: "It seems that the host given is not part of your inventory, please make sure it is."
       when:
@@ -71,12 +72,12 @@
         tasks_from: container_binary
 
   tasks:
-    - name: "set_fact container_exec_cmd build {{ container_binary }} exec command (containerized)"
+    - name: "Set_fact container_exec_cmd build container_binary  exec command (containerized)"
       set_fact:
         container_exec_cmd: "{{ container_binary }} exec ceph-mon-{{ hostvars[inventory_hostname]['ansible_facts']['hostname'] }}"
       when: containerized_deployment | bool
 
-    - name: exit playbook, if can not connect to the cluster
+    - name: Exit playbook, if can not connect to the cluster
       command: "{{ container_exec_cmd }} timeout 5 ceph --cluster {{ cluster }} health"
       register: ceph_health
       changed_when: false
@@ -84,18 +85,18 @@
       retries: 5
       delay: 2
 
-    - name: set_fact mon_to_kill_hostname
+    - name: Set_fact mon_to_kill_hostname
       set_fact:
         mon_to_kill_hostname: "{{ hostvars[mon_to_kill]['ansible_facts']['hostname'] }}"
       when: offline_host is undefined
 
-    - name: set_fact mon_to_kill_hostname offline
+    - name: Set_fact mon_to_kill_hostname offline
       set_fact:
         mon_to_kill_hostname: "{{ mon_to_kill }}"
       when: offline_host is defined
 
 
-    - name: stop monitor service(s)
+    - name: Stop monitor service(s)
       service:
         name: ceph-mon@{{ mon_to_kill_hostname }}
         state: stopped
@@ -104,20 +105,20 @@
       failed_when: false
       when: offline_host is undefined
 
-    - name: purge monitor store
+    - name: Purge monitor store
       file:
         path: /var/lib/ceph/mon/{{ cluster }}-{{ mon_to_kill_hostname }}
         state: absent
       delegate_to: "{{ mon_to_kill }}"
       when: offline_host is undefined
 
-    - name: remove monitor from the quorum
+    - name: Remove monitor from the quorum
       command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} mon remove {{ mon_to_kill_hostname }}"
       changed_when: false
       failed_when: false
 
   post_tasks:
-    - name: verify the monitor is out of the cluster
+    - name: Verify the monitor is out of the cluster
       command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} quorum_status -f json"
       changed_when: false
       failed_when: false
@@ -126,23 +127,23 @@
       retries: 2
       delay: 10
 
-    - name: please remove the monitor from your ceph configuration file
+    - name: Please remove the monitor from your ceph configuration file # noqa: run-once[task]
       debug:
           msg: "The monitor has been successfully removed from the cluster.
           Please remove the monitor entry from the rest of your ceph configuration files, cluster wide."
       run_once: true
       when: mon_to_kill_hostname not in (result.stdout | from_json)['quorum_names']
 
-    - name: fail if monitor is still part of the cluster
+    - name: Fail if monitor is still part of the cluster # noqa: run-once[task]
       fail:
           msg: "Monitor appears to still be part of the cluster, please check what happened."
       run_once: true
       when: mon_to_kill_hostname in (result.stdout | from_json)['quorum_names']
 
-    - name: show ceph health
+    - name: Show ceph health
       command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} -s"
       changed_when: false
 
-    - name: show ceph mon status
+    - name: Show ceph mon status
       command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} mon stat"
       changed_when: false

--- a/playbooks/replace_machine_shrink_osd.yaml
+++ b/playbooks/replace_machine_shrink_osd.yaml
@@ -21,23 +21,24 @@
 - name: Sanity check
   hosts: localhost
   tasks:
-    - name: exit playbook, if no osd(s) was/were given
+    - name: Exit playbook, if no osd(s) was/were given
       fail:
         msg: "osd_to_kill must be declared
           Exiting shrink-osd playbook, no OSD(s) was/were removed.
            On the command line when invoking the playbook, you can use
            -e osd_to_kill=0,1,2,3 argument."
       when: osd_to_kill is not defined
-    - name: check the osd ids passed have the correct format
+    - name: Check the osd ids passed have the correct format
       fail:
         msg: "The id {{ item }} has wrong format, please pass the number only"
       with_items: "{{ osd_to_kill.split(',') }}"
       when: not item is regex("^\d+$")
 
-- import_playbook: replace_machine_find_online_ceph_machine.yaml
+- name: Import replace_machine_find_online_ceph_machine
+  import_playbook: replace_machine_find_online_ceph_machine.yaml
   when: groups['mon_host'] is undefined
 
-- name: gather facts and check the init system
+- name: Gather facts and check the init system
   hosts:
     - "{{ mon_group_name|default('mons') }}"
     - "{{ osd_group_name|default('osds') }}"
@@ -64,16 +65,16 @@
         tasks_from: container_binary
 
   post_tasks:
-    - name: set_fact container_exec_cmd build docker exec command (containerized)
+    - name: Set_fact container_exec_cmd build docker exec command (containerized)
       set_fact:
         container_exec_cmd: "{{ container_binary }} exec ceph-mon-{{ ansible_facts['hostname'] }}"
       when: containerized_deployment | bool
 
-    - name: set_fact container_run_cmd
+    - name: Set_fact container_run_cmd
       set_fact:
         container_run_cmd: "{{ container_binary + ' run --rm --privileged=true --net=host --pid=host --ipc=host -v /dev:/dev -v /etc/ceph:/etc/ceph -v /var/lib/ceph:/var/lib/ceph -v /var/run:/var/run --entrypoint=' if containerized_deployment else '' }}ceph-volume {{ ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment else '' }}"
 
-    - name: exit playbook, if can not connect to the cluster
+    - name: Exit playbook, if can not connect to the cluster
       command: "{{ container_exec_cmd }} timeout 5 ceph --cluster {{ cluster }} health"
       register: ceph_health
       changed_when: false
@@ -81,20 +82,20 @@
       retries: 5
       delay: 2
 
-    - name: find the host(s) where the osd(s) is/are running on
+    - name: Find the host(s) where the osd(s) is/are running on
       command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} osd find {{ item }}"
       changed_when: false
       with_items: "{{ osd_to_kill.split(',') }}"
       register: find_osd_hosts
       when: offline_host is undefined
 
-    - name: set_fact osd_hosts
+    - name: Set_fact osd_hosts
       set_fact:
-        osd_hosts: "{{ osd_hosts | default([]) + [ [ (item.stdout | from_json).crush_location.host, (item.stdout | from_json).osd_fsid, item.item ] ] }}"
+        osd_hosts: "{{ osd_hosts | default([]) + [[(item.stdout | from_json).crush_location.host, (item.stdout | from_json).osd_fsid, item.item]] }}"
       with_items: "{{ find_osd_hosts.results }}"
       when: offline_host is undefined
 
-    - name: set_fact _osd_hosts
+    - name: Set_fact _osd_hosts
       set_fact:
         _osd_hosts: "{{ _osd_hosts | default([]) + [ [ item.0, item.2, item.3 ] ] }}"
       with_nested:
@@ -104,7 +105,7 @@
         - offline_host is undefined
         - hostvars[item.0]['ansible_facts']['hostname'] == item.1
 
-    - name: get ceph-volume lvm list data
+    - name: Get ceph-volume lvm list data
       command: "{{ container_run_cmd }} lvm list --format json"
       changed_when: false
       register: _lvm_list_data
@@ -112,13 +113,13 @@
       loop: "{{ _osd_hosts }}"
       when: offline_host is undefined
 
-    - name: set_fact _lvm_list
+    - name: Set_fact _lvm_list
       set_fact:
         _lvm_list: "{{ _lvm_list | default({}) | combine(item.stdout | from_json) }}"
       with_items: "{{ _lvm_list_data.results }}"
       when: offline_host is undefined
 
-    - name: find /etc/ceph/osd files
+    - name: Find /etc/ceph/osd files
       find:
         paths: /etc/ceph/osd
         pattern: "{{ item.2 }}-*"
@@ -129,7 +130,7 @@
         - offline_host is undefined
         - item.2 not in _lvm_list.keys()
 
-    - name: slurp ceph osd files content
+    - name: Slurp ceph osd files content
       slurp:
         src: "{{ item['files'][0]['path'] }}"
       delegate_to: "{{ item.item.0 }}"
@@ -140,8 +141,7 @@
         - item.skipped is undefined
         - item.matched > 0
 
-
-    - name: set_fact ceph_osd_files_json
+    - name: Set_fact ceph_osd_files_json
       set_fact:
         ceph_osd_data_json: "{{ ceph_osd_data_json | default({}) | combine({ item.item.item.2: item.content | b64decode | from_json}) }}"
       with_items: "{{ ceph_osd_files_content.results }}"
@@ -149,11 +149,11 @@
         - offline_host is undefined
         - item.skipped is undefined
 
-    - name: mark osd(s) out of the cluster
+    - name: Mark osd(s) out of the cluster
       command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} osd out {{ osd_to_kill.replace(',', ' ') }}"
       changed_when: false
 
-    - name: stop osd(s) service
+    - name: Stop osd(s) service
       service:
         name: ceph-osd@{{ item.2 }}
         state: stopped
@@ -162,8 +162,8 @@
       delegate_to: "{{ item.0 }}"
       when: offline_host is undefined
 
-    - name: umount osd lockbox
-      mount:
+    - name: Umount osd lockbox
+      ansible.posix.mount:
         path: "/var/lib/ceph/osd-lockbox/{{ ceph_osd_data_json[item.2]['data']['uuid'] }}"
         state: absent
       loop: "{{ _osd_hosts }}"
@@ -175,9 +175,8 @@
         - ceph_osd_data_json[item.2]['encrypted'] | default(False) | bool
         - ceph_osd_data_json[item.2]['data']['uuid'] is defined
 
-
-    - name: umount osd data
-      mount:
+    - name: Umount osd data
+      ansible.posix.mount:
         path: "/var/lib/ceph/osd/{{ cluster }}-{{ item.2 }}"
         state: absent
       loop: "{{ _osd_hosts }}"
@@ -186,7 +185,7 @@
         - offline_host is undefined
         - not containerized_deployment | bool
 
-    - name: get parent device for data partition
+    - name: Get parent device for data partition
       command: lsblk --noheadings --output PKNAME --nodeps "{{ ceph_osd_data_json[item.2]['data']['path'] }}"
       register: parent_device_data_part
       loop: "{{ _osd_hosts }}"
@@ -195,17 +194,17 @@
         - offline_host is undefined
         - item.2 not in _lvm_list.keys()
         - ceph_osd_data_json[item.2]['data']['path'] is defined
+      changed_when: true
 
-    - name: add pkname information in ceph_osd_data_json
+    - name: Add pkname information in ceph_osd_data_json
       set_fact:
-        ceph_osd_data_json: "{{ ceph_osd_data_json | default({}) | combine({item.item[2]: {'pkname_data': '/dev/' + item.stdout }}, recursive=True) }}"
+        ceph_osd_data_json: "{{ ceph_osd_data_json | default({}) | combine({ (item.item[2]): { 'pkname_data': '/dev/' + item.stdout } }, recursive=True) }}"
       loop: "{{ parent_device_data_part.results }}"
       when:
         - offline_host is undefined
         - item.skipped is undefined
 
-
-    - name: close dmcrypt close on devices if needed
+    - name: Close dmcrypt close on devices if needed
       command: "cryptsetup close {{ ceph_osd_data_json[item.2][item.3]['uuid'] }}"
       with_nested:
         - "{{ _osd_hosts }}"
@@ -219,8 +218,9 @@
         - item.2 not in _lvm_list.keys()
         - ceph_osd_data_json[item.2]['encrypted'] | default(False) | bool
         - ceph_osd_data_json[item.2][item.3] is defined
+      changed_when: true
 
-    - name: use ceph-volume lvm zap to destroy all partitions
+    - name: Use ceph-volume lvm zap to destroy all partitions
       command: "{{ container_run_cmd }} lvm zap --destroy {{ ceph_osd_data_json[item.2]['pkname_data'] if item.3 == 'data' else ceph_osd_data_json[item.2][item.3]['path'] }}"
       with_nested:
         - "{{ _osd_hosts }}"
@@ -232,8 +232,9 @@
         - offline_host is undefined
         - item.2 not in _lvm_list.keys()
         - ceph_osd_data_json[item.2][item.3] is defined
+      changed_when: true
 
-    - name: zap osd devices
+    - name: Zap osd devices
       ceph_volume:
         action: "zap"
         osd_fsid: "{{ item.1 }}"
@@ -247,16 +248,16 @@
         - offline_host is undefined
         - item.2 in _lvm_list.keys()
 
-    - name: ensure osds are marked down
+    - name: Ensure osds are marked down
       command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} osd down {{ osd_to_kill.replace(',', ' ') }}"
       changed_when: false
 
-    - name: purge osd(s) from the cluster
+    - name: Purge osd(s) from the cluster
       command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} osd purge {{ item }} --yes-i-really-mean-it"
       changed_when: false
       with_items: "{{ osd_to_kill.split(',') }}"
 
-    - name: remove osd data dir
+    - name: Remove osd data dir
       file:
         path: "/var/lib/ceph/osd/{{ cluster }}-{{ item.2 }}"
         state: absent
@@ -264,11 +265,10 @@
       delegate_to: "{{ item.0 }}"
       when: offline_host is undefined
 
-
-    - name: show ceph health
+    - name: Show ceph health
       command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} -s"
       changed_when: false
 
-    - name: show ceph osd tree
+    - name: Show ceph osd tree
       command: "{{ container_exec_cmd }} ceph --cluster {{ cluster }} osd tree"
       changed_when: false

--- a/playbooks/replace_machine_shrink_pacemaker.yaml
+++ b/playbooks/replace_machine_shrink_pacemaker.yaml
@@ -5,11 +5,12 @@
   hosts: "{{ pacemaker_machine | default('cluster_machines') }}"
   become: true
   pre_tasks:
-    - name: exit playbook, if no machine was given
+    - name: Exit playbook, if no machine was given
       fail:
         msg: "machine_to_remove must be declared"
       when: machine_to_remove is undefined
   tasks:
-    - name: Remove pacemaker node
+    - name: Remove pacemaker node # noqa: run-once[task]
       run_once: true
       command: "crm_node -R {{ machine_to_remove }} --force"
+      changed_when: true

--- a/playbooks/seapath_setup_main.yaml
+++ b/playbooks/seapath_setup_main.yaml
@@ -17,25 +17,35 @@
   roles:
     - detect_seapath_distro
 
-- import_playbook: seapath_setup_prerequiscentos.yaml
+- name: Import seapath_setup_prerequiscentos playbook
+  import_playbook: seapath_setup_prerequiscentos.yaml
   when: seapath_distro == "CentOS"
 
-- import_playbook: seapath_setup_prerequisdebian.yaml
+- name: Import seapath_setup_prerequisdebian playbook
+  import_playbook: seapath_setup_prerequisdebian.yaml
   when: seapath_distro == "Debian"
 
-- import_playbook: seapath_setup_prerequisyocto.yaml
+- name: Import seapath_setup_prerequisyocto playbook
+  import_playbook: seapath_setup_prerequisyocto.yaml
   when: seapath_distro == "Yocto"
 
-- import_playbook: seapath_setup_network.yaml
+- name: Import seapath_setup_network playbook
+  import_playbook: seapath_setup_network.yaml
 
-- import_playbook: seapath_setup_timemaster.yaml
+- name: Import seapath_setup_timemaster playbook
+  import_playbook: seapath_setup_timemaster.yaml
 
-- import_playbook: seapath_setup_snmp.yaml
+- name: Import seapath_setup_snmp playbook
+  import_playbook: seapath_setup_snmp.yaml
 
-- import_playbook: cluster_setup_ceph.yaml
-- import_playbook: cluster_setup_libvirt.yaml
-- import_playbook: cluster_setup_users.yaml
-- import_playbook: cluster_setup_ha.yaml
+- name: Import cluster_setup_ceph playbook
+  import_playbook: cluster_setup_ceph.yaml
+- name: Import cluster_setup_libvirt playbook
+  import_playbook: cluster_setup_libvirt.yaml
+- name: Import cluster_setup_users playbook
+  import_playbook: cluster_setup_users.yaml
+- name: Import cluster_setup_ha playbook
+  import_playbook: cluster_setup_ha.yaml
 
 - name: Restart all hosts
   hosts:

--- a/playbooks/seapath_setup_network.yaml
+++ b/playbooks/seapath_setup_network.yaml
@@ -39,7 +39,7 @@
   roles:
     - role: network_configovs
       vars:
-        apply_config: "{{ apply_network_config | default(false) }}"
+        network_configovs_apply_config: "{{ apply_network_config | default(false) }}"
     - network_buildhosts
     - network_resolved
     - network_networkdwait
@@ -49,23 +49,23 @@
     - hypervisors
   become: true
   tasks:
-    - name: calling sriov network pool creation (with a loop)
+    - name: Calling sriov network pool creation (with a loop)
       include_role:
         name: network_sriovpool
       vars:
-        interface: "{{ item.key }}"
-        sriov_network_pool_name: "{{ 'sr-iov-net-' + item.key }}"
+        network_sriovpool_interface: "{{ item.key }}"
+        network_sriovpool_sriov_network_pool_name: "{{ 'sr-iov-net-' + item.key }}"
       loop: "{{ sriov | dict2items }}"
       when: sriov is defined
 
-- name: push iptables rules
+- name: Push iptables rules
   hosts:
     - cluster_machines
     - standalone_machine
   roles:
     - iptables
 
-- name: configure guests br0 interfaces
+- name: Configure guests br0 interfaces
   become: true
   hosts:
     - cluster_machines
@@ -73,7 +73,7 @@
   roles:
     - network_guestsinterfaces
 
-- name: conntrackd
+- name: Conntrackd
   hosts: cluster_machines
   become: true
   roles:
@@ -86,11 +86,11 @@
     - standalone_machine
   become: true
   tasks:
-    - block:
+    - when:
+        - need_reboot is defined and need_reboot
+        - skip_reboot_setup_network is not defined or not skip_reboot_setup_network
+      block:
         - name: Restart to configure network
           reboot:
         - name: Wait for host to be online
           wait_for_connection:
-      when:
-        - need_reboot is defined and need_reboot
-        - skip_reboot_setup_network is not defined or not skip_reboot_setup_network

--- a/playbooks/seapath_setup_prerequiscentos.yaml
+++ b/playbooks/seapath_setup_prerequiscentos.yaml
@@ -41,20 +41,20 @@
     - cluster_machines
   become: true
   tasks:
-    - name: disable libvirt-guests.service
+    - name: Disable libvirt-guests.service
       ansible.builtin.systemd:
         name: libvirt-guests.service
         enabled: no
         state: stopped
 
-- name: upload extra files
+- name: Upload extra files
   hosts:
     - cluster_machines
     - standalone_machine
     - VMs
   become: true
   tasks:
-    - name: upload extra files
+    - name: Upload extra files
       copy:
         src: "{{ item.src }}"
         dest: "{{ item.dest }}"
@@ -66,7 +66,7 @@
       when:
         - upload_files is defined
         - item.extract is not defined or item.extract is false
-    - name: upload extra files and extract them
+    - name: Upload extra files and extract them
       unarchive:
         src: "{{ item.src }}"
         dest: "{{ item.dest }}"

--- a/playbooks/seapath_setup_prerequisdebian.yaml
+++ b/playbooks/seapath_setup_prerequisdebian.yaml
@@ -43,20 +43,20 @@
     - cluster_machines
   become: true
   tasks:
-    - name: disable libvirt-guests.service
+    - name: Disable libvirt-guests.service
       ansible.builtin.systemd:
         name: libvirt-guests.service
         enabled: no
         state: stopped
 
-- name: upload extra files
+- name: Upload extra files
   hosts:
     - cluster_machines
     - standalone_machine
     - VMs
   become: true
   tasks:
-    - name: upload extra files
+    - name: Upload extra files
       copy:
         src: "{{ item.src }}"
         dest: "{{ item.dest }}"
@@ -68,7 +68,7 @@
       when:
         - upload_files is defined
         - item.extract is not defined or item.extract is false
-    - name: upload extra files and extract them
+    - name: Upload extra files and extract them
       unarchive:
         src: "{{ item.src }}"
         dest: "{{ item.dest }}"

--- a/playbooks/seapath_setup_prerequisyocto.yaml
+++ b/playbooks/seapath_setup_prerequisyocto.yaml
@@ -18,14 +18,14 @@
   roles:
     - yocto/hugepages
 
-- name: upload extra files
+- name: Upload extra files
   hosts:
     - cluster_machines
     - standalone_machine
     - VMs
   become: true
   tasks:
-    - name: upload extra files
+    - name: Upload extra files
       copy:
         src: "{{ item.src }}"
         dest: "{{ item.dest }}"
@@ -37,7 +37,7 @@
       when:
         - upload_files is defined
         - item.extract is not defined or item.extract is false
-    - name: upload extra files and extract them
+    - name: Upload extra files and extract them
       unarchive:
         src: "{{ item.src }}"
         dest: "{{ item.dest }}"
@@ -48,7 +48,7 @@
       when:
         - upload_files is defined
         - item.extract is defined and item.extract is true
-    - name: run extra commands after upload
+    - name: Run extra commands after upload
       shell: "{{ item }}"
       tags:
         - skip_ansible_lint

--- a/playbooks/test_run_cukinia-sec.yaml
+++ b/playbooks/test_run_cukinia-sec.yaml
@@ -4,8 +4,8 @@
 # Ansible playbook that runs Cukinia tests and export the result in CSV.
 
 ---
-- hosts: cluster_machines
-  name: Cukinia tests
+- name: Cukinia tests
+  hosts: cluster_machines
   vars:
     tests_format: junitxml
     tests_result_name: cukinia.xml
@@ -16,13 +16,14 @@
       tempfile:
         state: directory
       register: tmp_cukinia_dir
-    - name: Run tests
+    - name: Run tests # noqa: run-once[task]
       shell:
         cmd: >-
           MACHINENAME={{ cukinia_namespace | default(inventory_hostname) }}
           cukinia -f {{ tests_format }}
           -o {{ tmp_cukinia_dir.path }}/{{ tests_result_name }}
           {{ cukinia_configuration }} || true
+      changed_when: true
     - name: Fetch result
       fetch:
         src: "{{ tmp_cukinia_dir.path }}/{{ tests_result_name }}"

--- a/playbooks/test_run_cukinia.yaml
+++ b/playbooks/test_run_cukinia.yaml
@@ -5,7 +5,6 @@
 # CSV.
 
 ---
-
 - name: Get distribution variables
   hosts:
     - cluster_machines
@@ -16,11 +15,11 @@
   tasks:
   - include_vars: "../vars/{{ seapath_distro }}_paths.yml"
 
-- hosts:
+- name: Cukinia tests
+  hosts:
     - cluster_machines
     - standalone_machine
     - VMs
-  name: Cukinia tests
   gather_facts: true
   become: true
   vars:
@@ -38,29 +37,31 @@
           MACHINENAME={{ cukinia_namespace | default(inventory_hostname) }}
           {{ cukinia_command_path }} -f {{ tests_format }}
           -o {{ tmp_cukinia_dir.path }}/{{ tests_result_name }} || true
+      changed_when: true
     - name: Fetch result
       fetch:
         src: "{{ tmp_cukinia_dir.path }}/{{ tests_result_name }}"
         dest: "{{ cukinia_test_prefix }}/{{ tests_result_name }}"
         flat: yes
 
-- hosts:
+- name: Cukinia tests
+  hosts:
     - cluster_machines
-  name: Cukinia tests
   become: true
   vars:
     tests_format: junitxml
     cluster_tests_result_name: "cukinia_cluster_{{ inventory_hostname }}.xml"
     cukinia_test_prefix: ".."
   tasks:
-    - name: Run tests cluster test
+    - name: Run tests cluster test # noqa: run-once[task]
       shell:
         cmd: >-
           {{ cukinia_command_path }} -f {{ tests_format }}
           -o {{ tmp_cukinia_dir.path }}/{{ cluster_tests_result_name }}
           /etc/cukinia/cukinia-cluster.conf || true
       run_once: true
-    - name: Fetch cluster test result
+      changed_when: true
+    - name: Fetch cluster test result # noqa: run-once[task]
       fetch:
         src: "{{ tmp_cukinia_dir.path }}/{{ cluster_tests_result_name }}"
         dest: "{{ cukinia_test_prefix }}/{{ cluster_tests_result_name }}"

--- a/playbooks/test_run_latency_tests.yaml
+++ b/playbooks/test_run_latency_tests.yaml
@@ -7,39 +7,41 @@
 ---
 
 # First, starting hypervisor subscriber
-- hosts: hypervisors
-  name: Hypervisor subscriber tests
+- name: Hypervisor subscriber tests
+  hosts: hypervisors
   become: true
   vars:
-    - svtools_archive_commit_id: "84cc1eb"
-    - poll_timeout: 5
-    - docker_test_image_name: hyp_sub_tests
+    svtools_archive_commit_id: "84cc1eb"
+    poll_timeout: 5
+    docker_test_image_name: hyp_sub_tests
   tasks:
   - name: Copy svtools archive on target
-    copy:
+    ansible.builtin.copy:
       src: ../src/svtools/svtools_{{ svtools_archive_commit_id }}.tar
       dest: /tmp/
   - name: Load svtools as Docker image
-    command:
+    ansible.builtin.command:
       docker load --input /tmp/svtools_{{ svtools_archive_commit_id }}.tar
+    changed_when: true
   - name: Run subscriber tests
     command:
       docker run --name {{ docker_test_image_name }} -d --network host --rm
       -it --cgroup-parent machine-rt.slice --cap-add=sys_nice
       --cpuset-cpus="0-11" -v /data/:/root/ svtools svtools_subscriber_light
       -i eth0 -o /root/svtools_out
+    changed_when: true
 
 # Then starting standalone publisher
-- hosts: ci-tool
-  name: Publisher tests
+- name: Publisher tests
+  hosts: ci-tool
   become: true
   vars:
-    - trafgen_archive_commit_id: a8936ce
-    - poll_timeout: 10
-    - docker_test_image_name: pub_tests
-    - network_interface: dk_8303
-    - network_device: eth0
-    - cpu_set: "2-6"
+    trafgen_archive_commit_id: a8936ce
+    poll_timeout: 10
+    docker_test_image_name: pub_tests
+    network_interface: dk_8303
+    network_device: eth0
+    cpu_set: "2-6"
   tasks:
   - name: Copy trafgen archive on target
     copy:
@@ -48,12 +50,14 @@
   - name: Load trafgen as Docker image
     command:
       docker load --input /tmp/trafgen_{{ trafgen_archive_commit_id }}.tar
+    changed_when: true
   - name: Run publisher tests
     command:
       docker run --cap-add=sys_nice
       --cpuset-cpus={{ cpu_set }} --privileged --network {{ network_interface }} --rm -v
       /tmp/trafgen:/tmp/ trafgen --dev {{ network_device }} --conf /sv_template.cfg -n
       1000000 -t 15us -H
+    changed_when: true
   - name: Get publisher hypervisor tests results
     fetch:
       flat: yes
@@ -61,13 +65,14 @@
       dest: ../tests_results/pub_results_hypervisor_{{ inventory_hostname }}
 
 # Wait and stop subscriber on hypervisor and getting result
-- hosts: hypervisors
-  name: Stop subscriber on hypervisor and getting result
+- name: Stop subscriber on hypervisor and getting result
+  hosts: hypervisors
   become: true
   tasks:
   - name: Stop subscriber hypervisor tests
     command:
       docker stop hyp_sub_tests
+    changed_when: true
   - name: Get hypervisor subscriber tests results
     fetch:
       flat: yes
@@ -75,13 +80,13 @@
       dest: ../tests_results/sub_results_hypervisor_{{ inventory_hostname }}
 
 # Next, we do the same but with with VM as subscriber
-- hosts: guest1
-  name: VM subscriber tests
+- name: VM subscriber tests
+  hosts: guest1
   become: true
   vars:
-    - svtools_archive_commit_id: "84cc1eb"
-    - poll_timeout: 5
-    - docker_test_image_name: vm_sub_tests
+    svtools_archive_commit_id: "84cc1eb"
+    poll_timeout: 5
+    docker_test_image_name: vm_sub_tests
   tasks:
   - name: Copy svtools archive on target
     copy:
@@ -90,24 +95,26 @@
   - name: Load svtools as Docker image
     command:
       docker load --input /tmp/svtools_{{ svtools_archive_commit_id }}.tar
+    changed_when: true
   - name: Run subscriber tests
     command:
       docker run --name {{ docker_test_image_name }} -d --network host --rm
       -it --cgroup-parent machine-rt.slice --cap-add=sys_nice
       --cpuset-cpus="0-11" -v /data/:/root/ svtools svtools_subscriber_light
       -i eth0 -o /root/svtools_out
+    changed_when: true
 
 # Then starting standalone publisher
-- hosts: ci-tool
-  name: Publisher tests
+- name: Publisher tests
+  hosts: ci-tool
   become: true
   vars:
-    - trafgen_archive_commit_id: a8936ce
-    - poll_timeout: 10
-    - docker_test_image_name: pub_tests
-    - network_interface: dk_8303
-    - network_device: eth0
-    - cpu_set: "2-6"
+    trafgen_archive_commit_id: a8936ce
+    poll_timeout: 10
+    docker_test_image_name: pub_tests
+    network_interface: dk_8303
+    network_device: eth0
+    cpu_set: "2-6"
   tasks:
   - name: Copy trafgen archive on target
     copy:
@@ -116,12 +123,14 @@
   - name: Load trafgen as Docker image
     command:
       docker load --input /tmp/trafgen_{{ trafgen_archive_commit_id }}.tar
+    changed_when: true
   - name: Run publisher VM tests
     command:
       docker run --cap-add=sys_nice
       --cpuset-cpus={{ cpu_set }} --privileged --network {{ network_interface }} --rm -v
       /tmp/trafgen:/tmp/ trafgen --dev {{ network_device }} --conf
       /sv_template.cfg -n 1000000 -t 15us -H
+    changed_when: true
 
   - name: Get publisher VM tests results
     fetch:
@@ -130,12 +139,14 @@
       dest: ../tests_results/pub_results_vm_{{ inventory_hostname }}
 
 # Stop subscriber on hypervisor and getting result
-- hosts: guest1
+- name: Stop subscriber on hypervisor and getting result
+  hosts: guest1
   become: true
   tasks:
   - name: Stop subscriber guest1 tests
     command:
       docker stop vm_sub_tests
+    changed_when: true
   - name: Get vm subscriber tests results
     fetch:
       flat: yes

--- a/roles/add_livemigration_user/tasks/main.yml
+++ b/roles/add_livemigration_user/tasks/main.yml
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-- block:
+- when: livemigration_user is defined
+  block:
   - name: Create live migration user
     user:
       name: "{{ livemigration_user }}"
@@ -16,7 +17,7 @@
         path: /etc/shadow
         regexp: '^{{ livemigration_user }}:!:'
         replace: '{{ livemigration_user }}:*:'
-  - name: generate root SSH key
+  - name: Generate root SSH key
     user:
       name: "root"
       generate_ssh_key: yes
@@ -26,28 +27,30 @@
       ssh_key_passphrase: ""
       force: false
   - name: Get root user's home directory
-    shell: getent passwd root | cut -d ':' -f6
+    shell:
+      cmd: set -o pipefail && getent passwd root | cut -d ':' -f6
+      executable: /bin/bash
     register: root_home_dir
+    changed_when: true
   - name: Fetch the root keyfile
     fetch:
       src: "{{ root_home_dir.stdout }}/.ssh/id_rsa.pub"
       dest: "buffer/{{ inventory_hostname }}-id_rsa.pub"
       flat: true
   - name: Copy the key add to authorized_keys using Ansible module
-    authorized_key:
+    ansible.posix.authorized_key:
       user: "{{ livemigration_user }}"
       state: present
-      key: "{{ lookup('file','buffer/' + item + '-id_rsa.pub') }}"
+      key: "{{ lookup('file', 'buffer/' + item + '-id_rsa.pub') }}"
     loop: "{{ groups['hypervisors'] | intersect(groups['cluster_machines']) }}"
   - name: Fetch the ssh keyfile
     fetch:
       src: "/etc/ssh/ssh_host_ed25519_key.pub"
       dest: "buffer/{{ inventory_hostname }}-ssh_host_ed25519_key.pub"
       flat: true
-  - name: populate the known_hosts files
+  - name: Populate the known_hosts files
     known_hosts:
       path: "{{ root_home_dir.stdout }}/.ssh/known_hosts"
       name: "{{ item }}"
-      key: "{{ item }} {{ lookup('file','buffer/' + item + '-ssh_host_ed25519_key.pub') }}"
+      key: "{{ item }} {{ lookup('file', 'buffer/' + item + '-ssh_host_ed25519_key.pub') }}"
     loop: "{{ groups['hypervisors'] | intersect(groups['cluster_machines']) }}"
-  when: livemigration_user is defined

--- a/roles/backup_restore/tasks/main.yml
+++ b/roles/backup_restore/tasks/main.yml
@@ -16,21 +16,21 @@
     mode: '0755'
   with_fileglob:
     - scripts/*.j2
-- name: create /etc/backup-restore.conf file
+- name: Create /etc/backup-restore.conf file
   file:
     path: "/etc/backup-restore.conf"
     state: touch
     mode: 0644
     owner: root
     group: root
-- name: check configuration of backup-restore.sh tool (remote_shell)
+- name: Check configuration of backup-restore.sh tool (remote_shell)
   shell: 'grep -c "^remote_shell=" /etc/backup-restore.conf || true'
   register: check_remote_shell
-- name: add default configuration of backup-restore.sh tool (remote_shell)
+  changed_when: true
+- name: Add default configuration of backup-restore.sh tool (remote_shell)
   lineinfile:
     dest: /etc/backup-restore.conf
     regexp: "^remote_shell="
     line: "remote_shell=\"ssh\""
     state: present
   when: check_remote_shell.stdout == "0"
-

--- a/roles/centos/handlers/main.yml
+++ b/roles/centos/handlers/main.yml
@@ -1,12 +1,20 @@
 # Copyright (C) 2024 Red Hat, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-- name: daemon-reload
+- name: Daemon-reload
   ansible.builtin.service:
     daemon_reload: yes
 
-- name: restart syslog-ng
+- name: Restart syslog-ng
   ansible.builtin.systemd:
     name: syslog-ng
     state: restarted
 
+- name: Restart systemd-journald
+  ansible.builtin.systemd:
+    name: systemd-journald
+    state: restarted
+
+- name: Update Grub
+  command: grub2-mkconfig -o /boot/grub2/grub.cfg
+  changed_when: true

--- a/roles/centos/meta/main.yml
+++ b/roles/centos/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
   min_ansible_version: 2.9.10
   license: Apache-2.0
   platforms:
-  - name: Centos
+  - name: EL
     versions:
     - all
 dependencies: []

--- a/roles/centos/tasks/main.yml
+++ b/roles/centos/tasks/main.yml
@@ -2,24 +2,24 @@
 # Copyright (C) 2024 Red Hat, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-- name: disable vim defaults
+- name: Disable vim defaults
   lineinfile:
     dest: /etc/vimrc
     regexp: '^"? *let g:skip_defaults_vim = 1$'
     line: "let g:skip_defaults_vim = 1"
     state: present
-- name: vim color syntax
+- name: Vim color syntax
   lineinfile:
     dest: /etc/vimrc
     regexp: '^"? *syntax on$'
     line: "syntax on"
     state: present
-- name: remove vimrc.local file
+- name: Remove vimrc.local file
   file:
     path: /etc/vimrc.local
     state: absent
 
-- name: create /var/log/syslog-ng folder on hosts
+- name: Create /var/log/syslog-ng folder on hosts
   file:
     path: /var/log/syslog-ng
     state: directory
@@ -29,8 +29,12 @@
     src: syslog-ng.conf.j2
     dest: /etc/syslog-ng/syslog-ng.conf
     mode: '0644'
-  notify: restart syslog-ng
-- block:
+  notify: Restart syslog-ng
+- when:
+    - syslog_tls_ca is defined
+    - syslog_tls_key is defined
+    - syslog_tls_server_ca is defined
+  block:
   - name: Create /etc/syslog-ng/cert.d
     file:
       path: /etc/syslog-ng/cert.d
@@ -41,56 +45,47 @@
       path: /etc/syslog-ng/ca.d/
       state: directory
       mode: '0755'
-  - name: copy syslog client certificate
+  - name: Copy syslog client certificate
     ansible.builtin.copy:
       src: "{{ syslog_tls_ca }}"
       dest: /etc/syslog-ng/cert.d/clientcert.pem
       mode: '0644'
-  - name: copy syslog key
+  - name: Copy syslog key
     ansible.builtin.copy:
       src: "{{ syslog_tls_key }}"
       dest: /etc/syslog-ng/cert.d/clientkey.pem
       mode: '0400'
-  - name: copy syslog server ca
+  - name: Copy syslog server ca
     ansible.builtin.copy:
       src: "{{ syslog_tls_server_ca }}"
       dest: /etc/syslog-ng/ca.d/serverca.pem
       mode: '0644'
-  when:
-    - syslog_tls_ca is defined
-    - syslog_tls_key is defined
-    - syslog_tls_server_ca is defined
 
-- name: removing or not the virtu user created by the iso
+- name: Removing or not the admin user created by the iso
+  when: admin_user != "admin"
   block:
-    - name: remove 'virtu' from sudoers file
+    - name: Remove 'admin' from sudoers file
       lineinfile:
         dest: /etc/sudoers
         state: absent
-        regexp: '^virtu'
+        regexp: '^admin'
         validate: visudo -cf %s
-    - name: Remove the virtu user 
+    - name: Remove the admin user
       ansible.builtin.user:
-        name: virtu
+        name: admin
         state: absent
         remove: yes
-    - name: Remove the virtu group 
+    - name: Remove the admin group
       ansible.builtin.group:
-        name: virtu
+        name: admin
         state: absent
-  when: admin_user != "virtu"
 
 - name: Copy journald conf file
   ansible.builtin.copy:
     src: journald.conf
     dest: /etc/systemd/journald.conf
     mode: '0644'
-  register: journaldconf
-- name: Restart systemd-journald
-  ansible.builtin.systemd:
-    state: restarted
-    name: systemd-journald
-  when: journaldconf.changed
+  notify: Restart systemd-journald
 
 - name: Ensure admin group exists
   ansible.builtin.group:
@@ -106,7 +101,7 @@
     password: "{{ admin_passwd | default(omit) }}"
     append: no
 - name: Add authorized keys to admin user
-  authorized_key:
+  ansible.posix.authorized_key:
     user: "{{ admin_user }}"
     key: "{{ item }}"
   with_items: "{{ admin_ssh_keys }}"
@@ -134,7 +129,7 @@
   with_items:
     - 00-panicreboot.conf
 
-- name: customize /etc/environment
+- name: Customize /etc/environment
   ansible.builtin.lineinfile:
     dest: "/etc/environment"
     state: present
@@ -161,14 +156,13 @@
     group: "{{ admin_user }}"
     mode: '0644'
 
-
-- name: "remove GRUB_CMDLINE_LINUX_DEFAULT option in grub conf"
+- name: Remove GRUB_CMDLINE_LINUX_DEFAULT option in grub conf
   lineinfile:
     dest: /etc/default/grub
     regexp: "^GRUB_CMDLINE_LINUX_DEFAULT="
     state: absent
 
-- name: "make sure GRUB_CMDLINE_LINUX starts with a space"
+- name: Make sure GRUB_CMDLINE_LINUX starts with a space
   lineinfile:
     dest: /etc/default/grub
     regexp: "^(GRUB_CMDLINE_LINUX=)\"([ ]*)(.*)\""
@@ -176,14 +170,14 @@
     state: present
     backrefs: yes
 
-- name: "grub conf"
+- name: Grub conf
   lineinfile:
     dest: /etc/default/grub
     regexp: "^(GRUB_CMDLINE_LINUX=(?!.* {{ item }})\"[^\"]*)(\".*)"
     line: '\1 {{ item }}\2'
     state: present
     backrefs: yes
-  register: updategrub1
+  notify: Update Grub
   with_items:
     - ipv6.disable=1
     - efi=runtime
@@ -191,16 +185,13 @@
     - fsck.repair=yes
     - "{{ grub_append | default([]) }}"
 
-- name: "grub conf osprober"
+- name: Grub conf osprober
   lineinfile:
     dest: /etc/default/grub
     regexp: '^#?GRUB_DISABLE_OS_PROBER=.*$'
     line: 'GRUB_DISABLE_OS_PROBER=true'
     state: present
-  register: updategrub2
-- name: update-grub
-  command: grub2-mkconfig -o /boot/grub2/grub.cfg
-  when: updategrub1.changed or updategrub2.changed
+  notify: Update Grub
 
 - name: Stop and Disable NetworkManager
   service:
@@ -215,7 +206,6 @@
     state: started
     enabled: yes
   register: sd_start
-
 
 - name: Set need_reboot to true if any change was made
   set_fact:

--- a/roles/centos_hypervisor/handlers/main.yml
+++ b/roles/centos_hypervisor/handlers/main.yml
@@ -1,0 +1,35 @@
+# Copyright (C) 2024 Red Hat, Inc.
+# Copyright (C) 2025 RTE
+# SPDX-License-Identifier: Apache-2.0
+
+- name: Start new slices
+  ansible.builtin.systemd:
+    name: "{{ item }}.slice"
+    state: restarted
+    daemon_reload: yes
+  with_items:
+    - "machine-rt"
+    - "machine-nort"
+    - "ovs"
+
+- name: Start new slices REVERT
+  ansible.builtin.systemd:
+    name: "{{ item }}.slice"
+    state: stopped
+    daemon_reload: yes
+  with_items:
+    - "machine-rt"
+    - "machine-nort"
+    - "ovs"
+
+- name: Restart ovs-vswitchd
+  ansible.builtin.systemd:
+    state: restarted
+    daemon_reload: yes
+    name: ovs-vswitchd
+
+- name: Restart irqbalance
+  ansible.builtin.systemd:
+    name: irqbalance.service
+    enabled: yes
+    state: restarted

--- a/roles/centos_hypervisor/meta/main.yml
+++ b/roles/centos_hypervisor/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9.10
   platforms:
-  - name: CentOS
+  - name: EL
     versions:
     - all
 dependencies: []

--- a/roles/centos_hypervisor/tasks/main.yml
+++ b/roles/centos_hypervisor/tasks/main.yml
@@ -2,18 +2,18 @@
 # Copyright (C) 2024 Red Hat, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-- name: enable docker.service
+- name: Enable docker.service
   ansible.builtin.systemd:
     name: docker.service
     enabled: yes
     state: started
-- name: enable docker.socket
+- name: Enable docker.socket
   ansible.builtin.systemd:
     name: docker.socket
     enabled: yes
     state: started
 
-- name: add vhost_vsock to /etc/modules-load.d
+- name: Add vhost_vsock to /etc/modules-load.d
   ansible.builtin.copy:
     src: modules/vhost_vsock.conf
     dest: /etc/modules-load.d/vhost_vsock.conf
@@ -21,7 +21,7 @@
     group: root
     mode: 0751
 
-- name: add sriov driver to /etc/modules-load.d
+- name: Add sriov driver to /etc/modules-load.d
   ansible.builtin.copy:
     src: modules/sriov_driver.conf
     dest: /etc/modules-load.d/sriov_driver.conf
@@ -29,13 +29,13 @@
     group: root
     mode: 0751
   when: sriov_driver is defined
-- name: load the sriov module
+- name: Load the sriov module
   community.general.modprobe:
     name: "{{ sriov_driver }}"
     state: present
   when: sriov_driver is defined
 
-- name: add sriov sysfs rules
+- name: Add sriov sysfs rules
   template:
     src: sriov.conf.j2
     dest: /etc/tmpfiles.d/sriov.conf
@@ -50,45 +50,43 @@
     mode: '0644'
   register: tmpfiles_cpumask
 
-- name: "irqbalance conf"
+- name: Setup irqbalance conf
   lineinfile:
     path: /etc/sysconfig/irqbalance
     regexp: '^#?IRQBALANCE_BANNED_CPULIST=".*"$'
     line: 'IRQBALANCE_BANNED_CPULIST="{{ isolcpus }}"'
     state: present
-  register: irqbalanceconf1
+  notify: Restart irqbalance
   when: isolcpus is defined
-- name: "irqbalance conf revert"
+- name: Setup irqbalance conf revert
   lineinfile:
     path: /etc/sysconfig/irqbalance
     regexp: '^#?IRQBALANCE_BANNED_CPULIST=(.*)$'
     line: '#IRQBALANCE_BANNED_CPULIST=\1'
     state: present
     backrefs: yes
-  register: irqbalanceconf2
+  notify: Restart irqbalance
   when: isolcpus is not defined
-- name: restart irqbalance
-  ansible.builtin.systemd:
-    name: irqbalance.service
-    enabled: yes
-    state: restarted
-  when: irqbalanceconf1.changed or irqbalanceconf2.changed
 
-- name: "systemd conf RuntimeWatchdogSec"
+- name: Systemd conf RuntimeWatchdogSec
   lineinfile:
     path: /etc/systemd/system.conf
     regexp: '^RuntimeWatchdogSec=.*$'
     line: "RuntimeWatchdogSec=20"
     state: present
-- name: "systemd conf RebootWatchdogSec"
+- name: Systemd conf RebootWatchdogSec
   lineinfile:
     path: /etc/systemd/system.conf
     regexp: '^RebootWatchdogSec=.*$'
     line: "RebootWatchdogSec=5min"
     state: present
 
-- block:
-  - name: "Create systemd slices override (folder)"
+- when:
+    - cpusystem is defined
+    - cpuuser is defined
+    - cpumachines is defined
+  block:
+  - name: Create systemd slices override (folder)
     file:
       path: /etc/systemd/system.control/{{ item }}.slice.d
       state: directory
@@ -99,7 +97,7 @@
       - "system"
       - "user"
       - "machine"
-  - name: create systemd slices override (files)
+  - name: Create systemd slices override (files)
     template:
       src: systemd_slice_override.j2
       dest: /etc/systemd/system.control/{{ item.name }}.slice.d/50-AllowedCPUs.conf
@@ -110,10 +108,7 @@
       - { name: "system", description: "system slice", allowedcpus: "{{ cpusystem }}" }
       - { name: "user", description: "user slice", allowedcpus: "{{ cpuuser }}" }
       - { name: "machine", description: "machine slice", allowedcpus: "{{ cpumachines }}" }
-  when:
-    - cpusystem is defined
-    - cpuuser is defined
-    - cpumachines is defined
+
 - name: Create systemd slices override REVERT
   file:
     path: /etc/systemd/system.control/{{ item }}.slice.d
@@ -124,7 +119,7 @@
     - "machine"
   when: cpusystem is not defined or cpuuser is not defined or cpumachines is not defined
 
-- name: create systemd slices
+- name: Create systemd slices
   template:
     src: systemd_slice.j2
     dest: /etc/systemd/system/{{ item.name }}.slice
@@ -135,12 +130,12 @@
     - { name: "machine-rt", description: "VM rt slice", wants: "machine.slice", allowedcpus: "{{ cpumachinesrt }}" }
     - { name: "machine-nort", description: "VM nonrt slice", wants: "machine.slice", allowedcpus: "{{ cpumachinesnort }}" }
     - { name: "ovs", description: "ovs slice", wants: "", allowedcpus: "{{ cpuovs }}" }
-  register: newslices
+  notify: Start new slices
   when:
     - cpumachinesrt is defined
     - cpumachinesnort is defined
     - cpuovs is defined
-- name: create systemd slices REVERT
+- name: Create systemd slices REVERT
   file:
     path: /etc/systemd/system/{{ item }}.slice
     state: absent
@@ -148,31 +143,10 @@
     - "machine-rt"
     - "machine-nort"
     - "ovs"
-  register: removeslices
+  notify: Start new slices REVERT
   when: cpumachinesrt is not defined and cpumachinesnort is not defined and cpuovs is not defined
 
-- name: start new slices
-  ansible.builtin.systemd:
-    name: "{{ item }}.slice"
-    state: restarted
-    daemon_reload: yes
-  with_items:
-    - "machine-rt"
-    - "machine-nort"
-    - "ovs"
-  when: newslices.changed
-- name: start new slices REVERT
-  ansible.builtin.systemd:
-    name: "{{ item }}.slice"
-    state: stopped
-    daemon_reload: yes
-  with_items:
-    - "machine-rt"
-    - "machine-nort"
-    - "ovs"
-  when: removeslices.changed
-
-- name: make sure tuned package is installed
+- name: Make sure tuned package is installed
   ansible.builtin.dnf:
     name:
      - tuned
@@ -192,13 +166,13 @@
     - /etc/sysctl.d/00-schedrt.conf
     - /etc/default/grub.d/10-isolcpus.cfg
 
-- name: create tuned seapath-rt profile folder
+- name: Create tuned seapath-rt profile folder
   file:
     path: /etc/tuned/seapath-rt-host
     state: directory
     mode: '0755'
 
-- name: copy seapath-rt-host tuned profile conf
+- name: Copy seapath-rt-host tuned profile conf
   template:
     src: tuned.conf.j2
     dest: /etc/tuned/seapath-rt-host/tuned.conf
@@ -206,27 +180,28 @@
     owner: root
     mode: '0644'
 
-- name: remove tuned dynamic tuning
+- name: Remove tuned dynamic tuning
   lineinfile:
     path: /etc/tuned/tuned-main.conf
     state: present
     regexp: '^#?dynamic_tuning = .*$'
     line: 'dynamic_tuning = 0'
 
-- name: enable tuned.service
+- name: Enable tuned.service
   ansible.builtin.systemd:
     name: tuned.service
     enabled: yes
     state: restarted
 
-- name: load seapath-rt-host tuned profile
+- name: Load seapath-rt-host tuned profile
   ansible.builtin.command: tuned-adm profile seapath-rt-host
   when: isolcpus is defined
+  changed_when: true
 
-- name: unload tuned profile
+- name: Unload tuned profile
   ansible.builtin.command: tuned-adm off
   when: isolcpus is not defined
-
+  changed_when: true
 
 - name: Create ovs-vswitchd.service.d directory
   file:
@@ -242,22 +217,16 @@
     owner: root
     group: root
     mode: 0644
-  register: ovsvswitchd
-- name: Restart ovs-vswitchd
-  ansible.builtin.systemd:
-    state: restarted
-    daemon_reload: yes
-    name: ovs-vswitchd
-  when: ovsvswitchd.changed
+  notify: Restart ovs-vswitchd
 
-- name: enable libvirtd.service
+- name: Enable libvirtd.service
   ansible.builtin.systemd:
     name: libvirtd.service
     enabled: yes
     state: started
 
 - name: Create system alternative for a debian kvm path
-  alternatives:
+  community.general.alternatives:
     name: "debian kvm"
     path: "/usr/libexec/qemu-kvm"
     link: "/usr/bin/qemu-system-x86_64"

--- a/roles/centos_physical_machine/handlers/main.yml
+++ b/roles/centos_physical_machine/handlers/main.yml
@@ -1,7 +1,16 @@
 # Copyright (C) 2024 Red Hat, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-- name: daemon-reload
+- name: Trigger daemon-reload
   ansible.builtin.service:
     daemon_reload: yes
 
+- name: Restart systemd-sysctl if needed
+  ansible.builtin.systemd:
+    name: systemd-sysctl.service
+    state: restarted
+
+- name: Rebuild initramfs if necessary
+  command:
+    cmd: /usr/bin/dracut --regenerate-all --force
+  changed_when: true

--- a/roles/centos_physical_machine/meta/main.yml
+++ b/roles/centos_physical_machine/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9.10
   platforms:
-  - name: CentOS
+  - name: EL
     versions:
     - all
 dependencies: []

--- a/roles/centos_physical_machine/tasks/main.yml
+++ b/roles/centos_physical_machine/tasks/main.yml
@@ -9,7 +9,7 @@
     mode: '0644'
   with_items:
     - 00-bridge_nf_call.conf
-  register: sysctl1
+  notify: Restart systemd-sysctl
 
 - name: Add sysctl conf from inventory (extra_sysctl_physical_machines)
   ansible.builtin.copy:
@@ -17,29 +17,23 @@
     mode: '0644'
     content: "{{ extra_sysctl_physical_machines }}"
   when: extra_sysctl_physical_machines is defined
-  register: sysctl2
+  notify: Restart systemd-sysctl
 
-- name: restart systemd-sysctl if needed
-  ansible.builtin.systemd:
-    name: systemd-sysctl.service
-    state: restarted
-  when: sysctl1.changed or sysctl2.changed
-
-- name: create src folder on hosts
+- name: Create src folder on hosts
   file:
     path: /tmp/src
     state: directory
     mode: '0755'
 
-- name: temp fix for synchronize to force evaluate variables
+- name: Temp fix for synchronize to force evaluate variables
   set_fact:
     ansible_host: "{{ ansible_host }}"
 
-- name: deploy vm_manager
+- name: Deploy vm_manager
   include_role:
     name: deploy_vm_manager
 
-- name: deploy python3-setup-ovs
+- name: Deploy python3-setup-ovs
   include_role:
     name: deploy_python3_setup_ovs
 
@@ -49,7 +43,7 @@
     dest: /usr/local/bin/consolevm
     mode: '0755'
 
-- name: create /usr/lib/ocf/resource.d/seapath on hosts
+- name: Create /usr/lib/ocf/resource.d/seapath on hosts
   file:
     path: /usr/lib/ocf/resource.d/seapath
     state: directory
@@ -71,11 +65,8 @@
     group: root
     mode: '0644'
   register: chronywait
-- name: daemon-reload chrony-wait.service
-  ansible.builtin.service:
-    daemon_reload: yes
-  when: chronywait.changed
-- name: enable chrony-wait.service
+  notify: Trigger daemon-reload
+- name: Enable chrony-wait.service
   ansible.builtin.systemd:
     name: chrony-wait.service
     enabled: yes
@@ -94,18 +85,18 @@
     owner: root
     group: root
     mode: 0644
-  notify: daemon-reload
+  notify: Trigger daemon-reload
   register: pacemaker_corosync
 - name: Get Pacemaker service Status
   ansible.builtin.systemd:
     name: "pacemaker.service"
   register: pacemaker_service_status
-- name: disable pacemaker (reinstall step 1/2)
+- name: Disable pacemaker (reinstall step 1/2)
   ansible.builtin.systemd:
     name: pacemaker.service
     enabled: no
   when: pacemaker_corosync.changed and pacemaker_service_status.status.UnitFileState == "enabled"
-- name: enable pacemaker (reinstall step 2/2)
+- name: Enable pacemaker (reinstall step 2/2)
   ansible.builtin.systemd:
     name: pacemaker.service
     enabled: yes
@@ -113,14 +104,14 @@
 
 - name: Add extra modules to the kernel
   block:
-    - name: create extra modules conf file
+    - name: Create extra modules conf file
       ansible.builtin.file:
         path: /etc/modules-load.d/extra_modules.conf
         owner: root
         group: root
         mode: 0751
         state: touch
-    - name: add extra modules to conf file
+    - name: Add extra modules to conf file
       lineinfile:
         dest: /etc/modules-load.d/extra_modules.conf
         state: present
@@ -134,13 +125,13 @@
     groups: libvirt
     append: yes
 
-
 - name: Creating libvirt user with libvirtd permissions
-  user: name=libvirt
-    group=libvirt
-    shell=/bin/false
+  user:
+    name: libvirt
+    group: libvirt
+    shell: /bin/false
 
-- name: add br_netfilter to /etc/modules-load.d
+- name: Add br_netfilter to /etc/modules-load.d
   ansible.builtin.copy:
     src: modules/netfilter.conf
     dest: /etc/modules-load.d/netfilter.conf
@@ -148,7 +139,7 @@
     group: root
     mode: 0751
 
-- name: lineinfile in hosts file for logstash-seapath
+- name: Lineinfile in hosts file for logstash-seapath
   lineinfile:
     dest: /etc/hosts
     regexp: '.* logstash-seapath$'
@@ -162,69 +153,66 @@
     regexp: "^#?host_uuid_source ="
     line: "host_uuid_source = \"machine-id\""
     state: present
-- name: restart libvirtd
+- name: Restart libvirtd
   ansible.builtin.systemd:
     name: libvirtd.service
     state: restarted
 
-- name: enable virtsecretd
+- name: Enable virtsecretd
   ansible.builtin.systemd:
     name: virtsecretd.service
     enabled: yes
     state: started
 
-- name: enable docker.service
+- name: Enable docker.service
   ansible.builtin.systemd:
     name: docker.service
-- name: "add initramfs-tools scripts: script file (LVM rebooter and log handling)"
+- name: "Add initramfs-tools scripts: script file (LVM rebooter and log handling)"
   ansible.builtin.copy:
     src: initramfs-tools/scripts/
     dest: /etc/initramfs-tools/scripts/
     mode: '0755'
-  register: initramfs_tools_scripts
+  notify: Rebuild initramfs if necessary
 
-- name: "get the /var/log/ device"
+- name: Get the /var/log/ device
   command: "findmnt -n -o SOURCE --target /var/log"
   register: varlog_dev
+  changed_when: false
 
-- name: "set_fact /var/log/ device"
+- name: Set_fact /var/log/ device
   set_fact:
     lvm_rebooter_log_device: "{{ varlog_dev.stdout }}"
 
-- name: "get the /var/log/ relative path"
+- name: Get the /var/log/ relative path
   shell: "realpath --relative-to=$(findmnt -n -o TARGET --target /var/log/) /var/log"
   register: varlog_path
+  changed_when: false
 
-- name: "set_fact /var/log/ relative path"
+- name: Set_fact /var/log/ relative path
   set_fact:
     lvm_rebooter_log_path: "{{ varlog_path.stdout }}"
 
-- name: "Copy rebooter.conf"
+- name: Copy rebooter.conf
   template:
     src: initramfs-tools/conf.d/rebooter.conf.j2
     dest: /etc/dracut.conf.d/rebooter.conf
 
-- name: "configure initramfs-tools to use busybox"
+- name: Configure initramfs-tools to use busybox
   lineinfile:
     dest: /etc/dracut.conf
     regexp: "^#?BUSYBOX="
     line: "BUSYBOX=y"
     state: present
-  register: initramfs_busybox
+  notify: Rebuild initramfs if necessary
 
-- name: "rebuild initramfs if necessary"
-  command:
-    cmd: /usr/bin/dracut --regenerate-all --force
-  when: initramfs_tools_scripts.changed or initramfs_busybox.changed
-
-- name: "add rbd type to lvm.conf"
+- name: Add rbd type to lvm.conf
   ansible.builtin.lineinfile:
     path: /etc/lvm/lvm.conf
     insertafter: 'devices {'
     line: "        types = [ \"rbd\", 1024 ]"
     state: present
 
-- name: "Configure firewalld for ceph"
+- name: Configure firewalld for ceph
   block:
     - name: "Configure firewalld for ceph monitor"
       ansible.posix.firewalld:
@@ -242,7 +230,7 @@
         permanent: true
         state: enabled
 
-- name: "Configure firewalld for high-availability services"
+- name: Configure firewalld for high-availability services
   ansible.posix.firewalld:
     service: high-availability
     permanent: true

--- a/roles/ceph_expansion_lv/meta/main.yml
+++ b/roles/ceph_expansion_lv/meta/main.yml
@@ -10,10 +10,7 @@ galaxy_info:
   - name: Debian
     versions:
     - all
-  - name: CentOS
-    versions:
-    - all
-  - name: Yocto
+  - name: EL
     versions:
     - all
 dependencies: []

--- a/roles/ceph_expansion_lv/tasks/main.yml
+++ b/roles/ceph_expansion_lv/tasks/main.yml
@@ -7,6 +7,7 @@
     expand_lv: "{{ (lvm_volumes[0].data_size | regex_replace('[A-Za-z]*', '') | int) > ansible_lvm['lvs'][lvm_volumes[0].data]['size_g'] | int }}"
   when: ansible_lvm is defined and lvm_volumes is defined
 - name: Increase ceph LV and OSD
+  when: expand_lv is defined and expand_lv
   block:
     - name: Increase lv size
       community.general.lvol:
@@ -14,37 +15,39 @@
         lv: "{{ lvm_volumes[0].data }}"
         size: "{{ lvm_volumes[0].data_size }}"
       register: lv_resized
-    - name: find the osd number
+    - name: Find the osd number
       find:
         paths: /var/lib/ceph/osd/
         file_type: directory
         patterns: "ceph-[0-9]"
         use_regex: yes
       register: ceph_osd_number
-    - name: resize OSDS
+    - name: Resize OSDS
+      when:
+        - lv_resized.changed
+        - ceph_osd_number.files | length > 0
       block:
-        - name: stop ceph-osd
+        - name: Stop ceph-osd
           ansible.builtin.systemd:
             name: ceph-osd.target
             state: stopped
-        - name: pause 3s
+        - name: Pause 3s
           command: "sleep 3"
+          changed_when: false
         - name: Resize ceph-osd
           command: "{{ item }}"
           with_items:
             - "/usr/bin/ceph-bluestore-tool bluefs-bdev-expand --path {{ ceph_osd_number.files[0].path }}"
             - "/usr/bin/ceph-bluestore-tool bluefs-bdev-expand --path {{ ceph_osd_number.files[0].path }}"
-        - name: start ceph-osd
+          changed_when: true
+        - name: Start ceph-osd
           ansible.builtin.systemd:
             name: ceph-osd.target
             state: started
-        - name: wait for cluster to be HEALTH_OK
+        - name: Wait for cluster to be HEALTH_OK
           command: '/usr/bin/ceph status --format=json'
           register: osdsdown
           until: osdsdown.stdout | from_json | community.general.json_query('health.status') == "HEALTH_OK"
           retries: 20
           delay: 2
-      when:
-        - lv_resized.changed
-        - ceph_osd_number.files | length > 0
-  when: expand_lv is defined and expand_lv
+          changed_when: false

--- a/roles/ceph_expansion_vg/meta/main.yml
+++ b/roles/ceph_expansion_vg/meta/main.yml
@@ -10,10 +10,7 @@ galaxy_info:
   - name: Debian
     versions:
     - all
-  - name: CentOS
-    versions:
-    - all
-  - name: Yocto
+  - name: EL
     versions:
     - all
 dependencies: []

--- a/roles/ceph_expansion_vg/tasks/main.yml
+++ b/roles/ceph_expansion_vg/tasks/main.yml
@@ -2,22 +2,25 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-- name: ceph pv ang vg expansion
+- name: Ceph pv ang vg expansion
+  when: ansible_lvm is defined and lvm_volumes is defined
   block:
-    - set_fact:
+    - name: Set fact unit, new_pv_size, list_pvs
+      set_fact:
         unit: "{{ lvm_volumes[0].device_size | regex_replace('[0-9.]*', '') }}"
         new_pv_size: "{{ (lvm_volumes[0].device_size | regex_replace('[A-Za-z]*', '') | int) }}"
         list_pvs: "{{ ansible_lvm['pvs'] | dict2items | community.general.json_query(query) }}"
       vars:
         query: "[?value.vg=='{{ lvm_volumes[0].data_vg }}'].key"
-    - name: get parted info for SD devices
+    - name: Get parted info for SD devices
       community.general.parted:
         # Get the name of the device by escaping the partition number
         device: "{{ item | regex_replace('(p?\\d+)$', '') }}"
         unit: "{{ unit }}"
       loop: "{{ list_pvs }}"
       register: parted_info
-    - set_fact:
+    - name: Set fact part_info
+      set_fact:
         part_info: "{{ parted_info.results | community.general.json_query(query) | first | first }}"
       vars:
         # The regex gets the number of the partition (Ex: /dev/nvme0n1p3 -> 3)
@@ -29,7 +32,8 @@
         cmd: "/usr/sbin/parted -s {{ item.item | regex_replace('(p?\\d+)$', '') }} resizepart  {{ item.item | regex_search('[0-9.]*$') }} {{ item.ansible_facts.part_info.end + (item.ansible_facts.part_info.newsize | int) - (item.ansible_facts.part_info.oldsize | int) }}{{ unit }}"
       loop: "{{ parts.results }}"
       when: (item.ansible_facts.part_info.newsize|int) > (item.ansible_facts.part_info.oldsize|int)
+      changed_when: true
     - name: Resize PVs
       command: "pvresize {{ item }}"
       loop: "{{ list_pvs }}"
-  when: ansible_lvm is defined and lvm_volumes is defined
+      changed_when: true

--- a/roles/ceph_prepare_installation/meta/main.yml
+++ b/roles/ceph_prepare_installation/meta/main.yml
@@ -10,10 +10,7 @@ galaxy_info:
   - name: Debian
     versions:
     - all
-  - name: CentOS
-    versions:
-    - all
-  - name: Yocto
+  - name: EL
     versions:
     - all
 dependencies: []

--- a/roles/ceph_prepare_installation/tasks/main.yml
+++ b/roles/ceph_prepare_installation/tasks/main.yml
@@ -18,30 +18,41 @@
       state: directory
   register: new_ceph_installation
 
-- name: Prepare OSD disk
+- name: Prepare OSD disk # noqa: no-handler
+  when:
+    - new_ceph_installation.changed
   block:
     - name: Refresh LVM VG
       command:
         cmd:  vgchange --refresh
+      changed_when: true
     - name: Cleanup LV if we are in existing LV situation
-      block:
-        - name: Cleanup Ceph LV with ceph-volume
-          command: "ceph-volume lvm zap /dev/{{ lvm_volumes[0].data_vg }}/{{ lvm_volumes[0].data }}"
       when:
         - lvm_volumes is defined
         - ansible_lvm['lvs'][lvm_volumes[0].data] is defined
+      block:
+        - name: Cleanup Ceph LV with ceph-volume
+          command: "ceph-volume lvm zap /dev/{{ lvm_volumes[0].data_vg }}/{{ lvm_volumes[0].data }}"
+          changed_when: true
     - name: Create VG/LV if they don't exist
+      when:
+        - lvm_volumes is not defined or ansible_lvm['lvs'][lvm_volumes[0].data] is not defined
       block:
         - name: Get real path for OSD disk
           command: "realpath {{ ceph_osd_disk }}" # Get the resolved path of the disk given initialy by the "/dev/disk/by-path/" for ceph purposes
           register: ceph_osd_realdisk
+          changed_when: false
         - name: Cleanup Ceph OSD disks with ceph-volume
           command: "ceph-volume lvm zap {{ ceph_osd_realdisk.stdout }} --destroy" # Zapping the disk and destroying any vgs or lvs present
           when: lvm_volumes is not defined or lvm_volumes[0].device_number == 1 # The disk must not be zapped in the case of a single disk for linux and ceph
+          changed_when: true
         - name: Cleanup Ceph lvm's partition with ceph-volume
           command: "ceph-volume lvm zap /dev/{{ lvm_volumes[0].data_vg }}" # In the case of a single-disk installation, only the Ceph partition is zapped
           when: lvm_volumes is defined and ansible_lvm['lvs'][lvm_volumes[0].data] is defined
+          changed_when: true
         - name: Create volumes for OSD disk
+          when:
+            - lvm_volumes is defined
           block:
             - name: Create partition on OSD disks with parted
               community.general.parted:
@@ -55,6 +66,7 @@
             - name: Get disk/by-path of OSD disk
               command: "/usr/bin/find -L /dev/disk/by-path -samefile {{ ceph_osd_result.disk.dev }} -print -quit"
               register: ceph_osd_finddisk
+              changed_when: false
             - name: Create volume group on the partition
               community.general.lvg:
                 vg: "{{ lvm_volumes[0].data_vg }}"
@@ -64,9 +76,3 @@
                 vg: "{{ lvm_volumes[0].data_vg }}"
                 lv: "{{ lvm_volumes[0].data }}"
                 size: "{{ lvm_volumes[0].data_size }}"
-          when:
-            - lvm_volumes is defined
-      when:
-        - lvm_volumes is not defined or ansible_lvm['lvs'][lvm_volumes[0].data] is not defined
-  when:
-    - new_ceph_installation.changed

--- a/roles/ci_restore_snapshot/tasks/main.yml
+++ b/roles/ci_restore_snapshot/tasks/main.yml
@@ -4,7 +4,7 @@
 ---
 - include_vars: "{{ seapath_distro }}.yml"
 
-- name: "grub conf"
+- name: Grub conf
   lineinfile:
     dest: /etc/default/grub
     regexp: "^(GRUB_CMDLINE_LINUX=(?!.* {{ item }})\"[^\"]*)(\".*)"
@@ -16,25 +16,29 @@
     - efi=runtime
     - "{{ grub_append | default([]) }}"
 - name: Update grub
-  command: "{{ grub_update_command }}"
+  command: "{{ ci_restore_snapshot_grub_update_command }}"
+  changed_when: true
 - name: Merge lvm snapshot
   command:
     cmd: lvconvert --merge vg1/root-snap
+  changed_when: true
 - name: Restart for snapshot rollback
   reboot:
 - name: Refresh LVM
   command:
     cmd:  lvchange --refresh vg1
+  changed_when: true
 
-- name: wait until snapshot is cleared
+- name: Wait until snapshot is cleared
   command: lvs -a
   register: result
   until: result.stdout | regex_search('root-snap', ignorecase=True) is none
   retries: 6
   delay: 10
+  changed_when: false
 
 - name: Recreate the snapshot
-  lvol:
+  community.general.lvol:
     vg: vg1
     lv: root
     snapshot: root-snap

--- a/roles/ci_restore_snapshot/vars/CentOS.yml
+++ b/roles/ci_restore_snapshot/vars/CentOS.yml
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-grub_update_command: "grub2-mkconfig -o /boot/grub2/grub.cfg"
+ci_restore_snapshot_grub_update_command: "grub2-mkconfig -o /boot/grub2/grub.cfg"

--- a/roles/ci_restore_snapshot/vars/Debian.yml
+++ b/roles/ci_restore_snapshot/vars/Debian.yml
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-grub_update_command: "update-grub"
+ci_restore_snapshot_grub_update_command: "update-grub"

--- a/roles/ci_restore_snapshot/vars/Yocto.yml
+++ b/roles/ci_restore_snapshot/vars/Yocto.yml
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-grub_update_command: "update-grub"
+ci_restore_snapshot_grub_update_command: "update-grub"

--- a/roles/ci_yocto/clean_arm_machines/tasks/main.yaml
+++ b/roles/ci_yocto/clean_arm_machines/tasks/main.yaml
@@ -11,23 +11,26 @@
     state: directory
     mode: '0755'
 - name: Mount the USB key
-  mount:
+  ansible.posix.mount:
     src: "{{ usb_device }}"
     path: /tmp/update
     fstype: vfat
     state: mounted
 - name: Execute Swupdate
   command: /usr/bin/swupdate -i /tmp/update/{{ swupdate_image }}
+  changed_when: true
 - name: Unmount the USB key
-  mount:
+  ansible.posix.mount:
     path: /tmp/update
     state: unmounted
 - name: Get overlay mounts
   command: awk '$3 == "overlay" {print $2}' /proc/mounts
   register: overlay_mounts
+  changed_when: false
 - name: Unmount overlays
   command: umount -l {{ item }}
   with_items: "{{ overlay_mounts.stdout_lines }}"
+  changed_when: true
 - name: Remove persistent data
   file:
     path: '{{ item }}'

--- a/roles/ci_yocto/meta/main.yml
+++ b/roles/ci_yocto/meta/main.yml
@@ -6,9 +6,4 @@ galaxy_info:
   description: contains the CI code for yocto
   min_ansible_version: 2.9.10
   license: Apache-2.0
-  platforms:
-  - name: Yocto
-    versions:
-    - all
 dependencies: []
-

--- a/roles/ci_yocto/run_tests/tasks/main.yaml
+++ b/roles/ci_yocto/run_tests/tasks/main.yaml
@@ -15,6 +15,7 @@
       MACHINENAME={{ cukinia_namespace | default(inventory_hostname) }}
       cukinia -f junitxml -o {{ tmp_test_dir.path }}/cukinia.xml
       /etc/cukinia/cukinia.conf || true
+  changed_when: true
 - name: Fetch result
   fetch:
     src: '{{ tmp_test_dir.path }}/cukinia.xml'
@@ -24,6 +25,7 @@
     flat: yes
 
 - name: Cyclictest
+  when: skip_cyclictest is not defined or not skip_cyclictest
   block:
     - name: Execute cyclitect script
       script: run_cyclictest.py '{{ tmp_test_dir.path }}/cyclictest.txt'
@@ -32,5 +34,4 @@
         src: '{{ tmp_test_dir.path }}/cyclictest.txt'
         dest: "{{ cukinia_test_prefix | default('..') }}/cyclictest_{{ inventory_hostname }}.txt"
         flat: yes
-  when: skip_cyclictest is not defined or not skip_cyclictest
 ...

--- a/roles/configure_admin_user/meta/main.yml
+++ b/roles/configure_admin_user/meta/main.yml
@@ -10,7 +10,6 @@ galaxy_info:
   - name: Debian
     versions:
     - all
-  platforms:
-  - name: CentOS
+  - name: EL
     versions:
     - all

--- a/roles/configure_admin_user/tasks/main.yml
+++ b/roles/configure_admin_user/tasks/main.yml
@@ -2,19 +2,22 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-- block:
+- when: seapath_distro in [ "CentOS", "Debian" ]
+  block:
     - name: Get root user's home directory
-      shell: getent passwd root | cut -d ':' -f6
+      shell:
+        cmd: set -o pipefail && getent passwd root | cut -d ':' -f6
+        executable: /usr/bin/bash
       register: root_home_dir
+      changed_when: false
     - name: Fetch the root keyfile
       fetch:
         src: "{{ root_home_dir.stdout }}/.ssh/id_rsa.pub"
         dest: "buffer/{{ inventory_hostname }}-id_rsa.pub"
         flat: true
     - name: Copy the key to admin user's authorized_keys using Ansible module
-      authorized_key:
+      ansible.posix.authorized_key:
         user: "{{ admin_user }}"
         state: present
-        key: "{{ lookup('file','buffer/' + item + '-id_rsa.pub') }}"
+        key: "{{ lookup('file', 'buffer/' + item + '-id_rsa.pub') }}"
       loop: "{{ groups['hypervisors'] | intersect(groups['cluster_machines']) }}"
-  when: seapath_distro in [ "CentOS", "Debian" ]

--- a/roles/configure_ha/README.md
+++ b/roles/configure_ha/README.md
@@ -8,14 +8,14 @@ No requirement.
 
 ## Role Variables
 
-| Variable                | Required | Type        | Default | Comments                                                                       |
-|-------------------------|----------|-------------|---------|--------------------------------------------------------------------------------|
-| seapath_distro          | yes      | String      |         | SEAPATH variant. *CentOS*, *Debian* or *Yocto*. The variable can be set automatically using the *detect_seapath_distro role* |
-| corosync_node_list      | yes      | String list |         | List of all corosync nodes. Usually `{{ groups['cluster_machines'] \| list }}` |
-| tmpdir                  | no       | String      | /tmp    | Temporary directory path to use                                                |
-| enable_vmmgr_http_api   | no       | Bool        | false   | Set to true to enable SEAPATH vm-manager REST API                              |
-| admin_cluster_ip        | no       | String      |         | IP of the REST API. If not set the m-manager REST API will be disabled even if `enable_vmmgr_http_api is set to true` |
-| extra_crm_cmd_to_run    | no       | String      |         | List of `crm configure` commands to run separate by a new line.                |
+| Variable                             | Required | Type        | Default | Comments                                                                       |
+|--------------------------------------|----------|-------------|---------|--------------------------------------------------------------------------------|
+| seapath_distro                       | yes      | String      |         | SEAPATH variant. *CentOS*, *Debian* or *Yocto*. The variable can be set automatically using the *detect_seapath_distro role* |
+| corosync_node_list                   | yes      | String list |         | List of all corosync nodes. Usually `{{ groups['cluster_machines'] \| list }}` |
+| configure_ha_tmpdir                  | no       | String      | /tmp    | Temporary directory path to use                                                |
+| configure_ha_enable_vmmgr_http_api   | no       | Bool        | false   | Set to true to enable SEAPATH vm-manager REST API                              |
+| admin_cluster_ip                     | no       | String      |         | IP of the REST API. If not set the m-manager REST API will be disabled even if `configure_ha_enable_vmmgr_http_api is set to true` |
+| extra_crm_cmd_to_run                 | no       | String      |         | List of `crm configure` commands to run separate by a new line.                |
 
 ## Example Playbook
 

--- a/roles/configure_ha/defaults/main.yml
+++ b/roles/configure_ha/defaults/main.yml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-tmpdir: "/tmp"
-enable_vmmgr_http_api: false
+configure_ha_tmpdir: "/tmp"
+configure_ha_enable_vmmgr_http_api: false

--- a/roles/configure_ha/meta/main.yml
+++ b/roles/configure_ha/meta/main.yml
@@ -8,9 +8,6 @@ galaxy_info:
   - name: Debian
     versions:
     - all
-  - name: CentOS
-    versions:
-    - all
-  - name: Yocto
+  - name: EL
     versions:
     - all

--- a/roles/configure_ha/tasks/main.yml
+++ b/roles/configure_ha/tasks/main.yml
@@ -10,13 +10,13 @@
     dest: /etc/cluster.conf
 
 # Check if corosync is already setup
-- name: check corosync service status
+- name: Check corosync service status
   systemd:
     name: corosync
     state: started
   check_mode: true
   register: corosync_service_status
-- name: Create a group with unconfigured_machines
+- name: Create a group with unconfigured_machines # noqa: no-handler
   add_host:
     name: "{{ item }}"
     groups: unconfigured_machine_group
@@ -24,7 +24,7 @@
   loop: "{{ groups['cluster_machines'] }}"
   changed_when: false
   when: hostvars[item].corosync_service_status.changed
-- name: Create a group with valid_machines
+- name: Create a group with valid_machines # noqa: no-handler
   add_host:
     name: "{{ item }}"
     groups: valid_machine
@@ -35,12 +35,14 @@
 
 # Setup Corosync from scratch
 - name: Setup Corosync from scratch
+  when: groups['valid_machine'] is undefined
   block:
 
     - name: Generating /etc/corosync/authkey file
       command:
         /usr/sbin/corosync-keygen
       run_once: true
+      changed_when: true
     - name: Waiting for /etc/corosync/authkey file
       wait_for:
         path: '/etc/corosync/authkey'
@@ -53,53 +55,55 @@
       when: inventory_hostname == play_hosts[0]
     - name: Synchronizing /etc/corosync/authkey everywhere
       copy:
-        content: "{{ hostvars[play_hosts[0]].tmp_authkey['content'] | b64decode  }}"
+        content: "{{ hostvars[play_hosts[0]].tmp_authkey['content'] | b64decode }}"
         dest: /etc/corosync/authkey
         mode: 0400
       when: inventory_hostname != play_hosts[0]
 
-    - name: templating corosync.conf
+    - name: Templating corosync.conf
       template:
         src: corosync.conf.j2
         dest: /etc/corosync/corosync.conf
       register: corosync_conf
-    - name: Restart Corosync
+    - name: Restart Corosync # noqa: no-handler
       ansible.builtin.systemd:
         name: corosync
         state: restarted
         enabled: yes
       when: corosync_conf.changed
-  when: groups['valid_machine'] is undefined
 
-- block:
+- when:
+    - groups['valid_machine'] is defined
+    - groups['unconfigured_machine_group'] is defined
+  run_once: true
+  delegate_to: "{{ groups['valid_machine'][0] }}"
+  block:
     - name: Fetch corosync configuration
       fetch:
         src: "/etc/corosync/corosync.conf"
-        dest: "{{ tmpdir }}/corosync.conf"
+        dest: "{{ configure_ha_tmpdir }}/corosync.conf"
         flat: true
     - name: Fetch corosync key
       fetch:
         src: "/etc/corosync/authkey"
-        dest: "{{ tmpdir }}/authkey"
+        dest: "{{ configure_ha_tmpdir }}/authkey"
         flat: true
-  run_once: true
-  delegate_to: "{{ groups['valid_machine'][0] }}"
-  when:
-    - groups['valid_machine'] is defined
-    - groups['unconfigured_machine_group'] is defined
 
 - name: Setup Corosync using existing configuration
+  when:
+    - groups['valid_machine'] is defined
+    - "'unconfigured_machine_group' in group_names"
   block:
     - name: Install corosync configuration
       copy:
-        src: "{{ tmpdir }}/corosync.conf"
+        src: "{{ configure_ha_tmpdir }}/corosync.conf"
         dest: /etc/corosync/corosync.conf
         owner: root
         group: root
         mode: '0644'
     - name: Install corosync key
       copy:
-        src: "{{ tmpdir }}/authkey"
+        src: "{{ configure_ha_tmpdir }}/authkey"
         dest: /etc/corosync/authkey
         owner: root
         group: root
@@ -109,29 +113,28 @@
           name: corosync
           state: started
           enabled: true
-  when:
-    - groups['valid_machine'] is defined
-    - "'unconfigured_machine_group' in group_names"
 
 - name: Setup Pacemaker on unconfigured_machine_group
+  when:
+    - "'unconfigured_machine_group' in group_names"
   block:
     - name: Start Pacemaker
       ansible.builtin.systemd:
           name: pacemaker
           state: started
           enabled: true
-    - name: wait for pacemaker
-      command: "{{ crm_command_path }} status"
+    - name: Wait for pacemaker
+      command: "{{ configure_ha_crm_command_path }} status"
       register: result
       until: result.rc == 0
       retries: 3
       delay: 1
+      changed_when: false
     - name: Disable stonith
-      command: "{{ crm_command_path }} configure property stonith-enabled=false"
+      command: "{{ configure_ha_crm_command_path }} configure property stonith-enabled=false"
       run_once: true
       when: groups['valid_machine'] is undefined
-  when:
-    - "'unconfigured_machine_group' in group_names"
+      changed_when: true
 
 - name: Making sure that Corosync service is started
   ansible.builtin.systemd:
@@ -140,12 +143,12 @@
     enabled: yes
 
 # run extra CRM commands
-- name: run extra CRM configuration commands for vm-mgr http api
+- name: Run extra CRM configuration commands for vm-mgr http api
   command:
     cmd: crm -d config load update -
     stdin: "{{ vmmgrapi_cmd_list }}"
   when:
-    - enable_vmmgr_http_api is true
+    - configure_ha_enable_vmmgr_http_api is true
     - admin_cluster_ip is defined
   run_once: true
   register: vmmgrapi_cmd_list_task
@@ -156,7 +159,7 @@
       primitive vmmgrapi systemd:nginx.service  op monitor interval=30s
       colocation vmmgrapi_colocation inf: ClusterIP vmmgrapi
       order order_ClusterIP_vmmgrapi ClusterIP vmmgrapi
-- name: run extra CRM configuration commands
+- name: Run extra CRM configuration commands
   command:
     cmd: crm -d config load update -
     stdin: "{{ extra_crm_cmd_to_run }}"

--- a/roles/configure_ha/vars/CentOS.yml
+++ b/roles/configure_ha/vars/CentOS.yml
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-crm_command_path: "/usr/local/bin/crm"
+configure_ha_crm_command_path: "/usr/local/bin/crm"

--- a/roles/configure_ha/vars/Debian.yml
+++ b/roles/configure_ha/vars/Debian.yml
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-crm_command_path: "crm"
+configure_ha_crm_command_path: "crm"

--- a/roles/configure_ha/vars/Yocto.yml
+++ b/roles/configure_ha/vars/Yocto.yml
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-crm_command_path: "/usr/bin/crm"
+configure_ha_crm_command_path: "/usr/bin/crm"

--- a/roles/configure_libvirt/README.md
+++ b/roles/configure_libvirt/README.md
@@ -8,10 +8,10 @@ No requirement.
 
 ## Role Variables
 
-| Variable                | Required | Type   | Default | Comments                                       |
-|-------------------------|----------|--------|---------|------------------------------------------------|
-| libvirt_rbd_pool        | no       | String | rbd     | The Ceph RBD pool use by libvirts              |
-| libvirt_pool_name       | no       | String | ceph    | The name of the libvirt storage pool to create |
+| Variable                           | Required | Type   | Default | Comments                                       |
+|------------------------------------|----------|--------|---------|------------------------------------------------|
+| configure_libvirt_libvirt_rbd_pool | no       | String | rbd     | The Ceph RBD pool use by libvirts              |
+| configure_libvirt_libvirt_pool_name| no       | String | ceph    | The name of the libvirt storage pool to create |
 
 ## Example Playbook
 

--- a/roles/configure_libvirt/defaults/main.yml
+++ b/roles/configure_libvirt/defaults/main.yml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-libvirt_rbd_pool: "rbd"
-libvirt_pool_name: "ceph"
+configure_libvirt_libvirt_rbd_pool: "rbd"
+configure_libvirt_libvirt_pool_name: "ceph"

--- a/roles/configure_libvirt/handlers/main.yml
+++ b/roles/configure_libvirt/handlers/main.yml
@@ -1,7 +1,7 @@
 # Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-- name: restart libvirtd
+- name: Restart libvirtd
   ansible.builtin.systemd:
     name: libvirtd
     state: restarted

--- a/roles/configure_libvirt/meta/main.yml
+++ b/roles/configure_libvirt/meta/main.yml
@@ -10,10 +10,7 @@ galaxy_info:
   - name: Debian
     versions:
     - all
-  - name: CentOS
-    versions:
-    - all
-  - name: Yocto
+  - name: EL
     versions:
     - all
 dependencies: []

--- a/roles/configure_libvirt/tasks/main.yml
+++ b/roles/configure_libvirt/tasks/main.yml
@@ -5,7 +5,8 @@
 ---
 - name: Try to get already defined secret
   shell:
-    cmd: virsh secret-list |grep "ceph" |grep -oE '[a-f0-9]+-[a-f0-9]+-[a-f0-9]+-[a-f0-9]+-[a-f0-9]+'
+    cmd: set -o pipefail && virsh secret-list |grep "ceph" |grep -oE '[a-f0-9]+-[a-f0-9]+-[a-f0-9]+-[a-f0-9]+-[a-f0-9]+'
+    executable: /bin/bash
   register: secret_defined
   failed_when: secret_defined.rc > 1
   changed_when: false
@@ -54,6 +55,7 @@
   - name: Create libvirt rbd secret
     command: virsh secret-define /tmp/secret.xml
     when: not secret_defined.failed
+    changed_when: true
   - name: Remove temporary file
     file:
         path: /tmp/secret.xml
@@ -64,33 +66,35 @@
 
 - name: Get secret UUID
   shell:
-    cmd: virsh secret-list |grep "ceph" |grep -oE '[a-f0-9]+-[a-f0-9]+-[a-f0-9]+-[a-f0-9]+-[a-f0-9]+'
+    cmd: set -o pipefail && virsh secret-list |grep "ceph" |grep -oE '[a-f0-9]+-[a-f0-9]+-[a-f0-9]+-[a-f0-9]+-[a-f0-9]+'
+    executable: /bin/bash
   register: secret_uuid_raw
+  changed_when: false
 - name: Register secret UUID
   set_fact:
     libvirt_uuid_rbd: "{{ secret_uuid_raw.stdout }}"
 - name: Create libvirt pool link with rbd pool
   community.libvirt.virt_pool:
-      command: define
-      xml: '{{ lookup("template", "libvirt_pool.xml.j2") }}'
-      name: "{{ libvirt_pool_name }}"
+    command: define
+    xml: '{{ lookup("template", "libvirt_pool.xml.j2") }}'
+    name: "{{ configure_libvirt_libvirt_pool_name }}"
 - name: Start libvirt pool
   community.libvirt.virt_pool:
-      state: active
-      name: "{{ libvirt_pool_name }}"
+    state: active
+    name: "{{ configure_libvirt_libvirt_pool_name }}"
 - name: Autostart pool
   community.libvirt.virt_pool:
-      autostart: yes
-      name: "{{ libvirt_pool_name }}"
+    autostart: yes
+    name: "{{ configure_libvirt_libvirt_pool_name }}"
 - name: Refresh pool
   command: virsh pool-refresh --pool ceph
   changed_when: false
 
 - name: Copy libvirtd.conf
   template:
-      src: libvirtd.conf.j2
-      dest: /etc/libvirt/libvirtd.conf
-      owner: root
-      group: root
-      mode: 0644
-  notify: restart libvirtd
+    src: libvirtd.conf.j2
+    dest: /etc/libvirt/libvirtd.conf
+    owner: root
+    group: root
+    mode: 0644
+  notify: Restart libvirtd

--- a/roles/configure_libvirt/templates/libvirt_pool.xml.j2
+++ b/roles/configure_libvirt/templates/libvirt_pool.xml.j2
@@ -1,7 +1,7 @@
 <pool type="rbd">
-  <name>{{ libvirt_pool_name }}</name>
+  <name>{{ configure_libvirt_libvirt_pool_name }}</name>
   <source>
-    <name>{{ libvirt_rbd_pool }}</name>
+    <name>{{ configure_libvirt_libvirt_rbd_pool }}</name>
     <host name='rbd' port='6789' />
     <auth username='libvirt' type='ceph'>
       <secret uuid='{{ libvirt_uuid_rbd }}'/>

--- a/roles/configure_nic_irq_affinity/meta/main.yml
+++ b/roles/configure_nic_irq_affinity/meta/main.yml
@@ -10,10 +10,7 @@ galaxy_info:
   - name: Debian
     versions:
     - all
-  - name: Yocto
-    versions:
-    - all
-  - name: CentOS
+  - name: EL
     versions:
     - all
 dependencies: []

--- a/roles/configure_nic_irq_affinity/tasks/main.yml
+++ b/roles/configure_nic_irq_affinity/tasks/main.yml
@@ -4,6 +4,7 @@
 
 ---
 - name: Run the NICs IRQs affinity configuration tasks
+  when: nics_affinity is defined
   block:
     - name: Copy NIC irq affinity script
       copy:
@@ -25,5 +26,3 @@
         dest: /etc/default/setup_nic_irq_affinity
         mode: 0644
       notify: Enable and start NIC irq affinity service
-
-  when: nics_affinity is defined

--- a/roles/conntrackd/meta/main.yml
+++ b/roles/conntrackd/meta/main.yml
@@ -10,7 +10,7 @@ galaxy_info:
   - name: Debian
     versions:
     - all
-  - name: CentOS
+  - name: EL
     versions:
     - all
 dependencies: []

--- a/roles/conntrackd/tasks/main.yml
+++ b/roles/conntrackd/tasks/main.yml
@@ -23,8 +23,9 @@
     daemon_reload: yes
     name: conntrackd
   when: conntrackd.changed and conntrackd_ignore_ip_list is defined
-- block:
-    - name: copy conntrackd.conf file
+- when: conntrackd_ignore_ip_list is defined
+  block:
+    - name: Copy conntrackd.conf file
       template:
         src: conntrackd.conf.j2
         dest: /etc/conntrackd/conntrackd.conf
@@ -32,23 +33,21 @@
         owner: root
         mode: '0644'
       register: conntrackdconf
-    - name: enable conntrackd.service
+    - name: Enable conntrackd.service
       ansible.builtin.systemd:
         name: conntrackd.service
         enabled: yes
         state: started
-    - name: enable conntrackd.service
+    - name: Enable conntrackd.service # noqa: no-handler
       ansible.builtin.systemd:
         name: conntrackd.service
         enabled: yes
         state: restarted
       when: conntrackdconf.changed
-  when: conntrackd_ignore_ip_list is defined
-- block:
-    - name: stop and disable conntrackd.service
+- when: conntrackd_ignore_ip_list is not defined
+  block:
+    - name: Stop and disable conntrackd.service
       ansible.builtin.systemd:
         name: conntrackd.service
         enabled: no
         state: stopped
-  when: conntrackd_ignore_ip_list is not defined
-

--- a/roles/debian/handlers/main.yml
+++ b/roles/debian/handlers/main.yml
@@ -1,8 +1,18 @@
-- name: daemon-reload
-  ansible.builtin.service:
-    daemon_reload: yes
+# Copyright (C) 2025 RTE
+# SPDX-License-Identifier: Apache-2.0
 
-- name: restart syslog-ng
+---
+- name: Restart systemd-journald
+  ansible.builtin.systemd:
+    name: systemd-journald
+    state: restarted
+
+- name: Restart syslog-ng
   ansible.builtin.systemd:
     name: syslog-ng
     state: restarted
+    enabled: yes
+
+- name: Update-grub
+  command: update-grub
+  changed_when: true

--- a/roles/debian/tasks/main.yml
+++ b/roles/debian/tasks/main.yml
@@ -2,24 +2,24 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-- name: disable vim defaults
+- name: Disable vim defaults
   lineinfile:
     dest: /etc/vim/vimrc
     regexp: '^"? *let g:skip_defaults_vim = 1$'
     line: "let g:skip_defaults_vim = 1"
     state: present
-- name: vim color syntax
+- name: Vim color syntax
   lineinfile:
     dest: /etc/vim/vimrc
     regexp: '^"? *syntax on$'
     line: "syntax on"
     state: present
-- name: remove vimrc.local file
+- name: Remove vimrc.local file
   file:
     path: /etc/vim/vimrc.local
     state: absent
 
-- name: create /var/log/syslog-ng folder on hosts
+- name: Create /var/log/syslog-ng folder on hosts
   file:
     path: /var/log/syslog-ng
     state: directory
@@ -29,37 +29,42 @@
     src: syslog-ng.conf.j2
     dest: /etc/syslog-ng/syslog-ng.conf
     mode: '0644'
-  notify: restart syslog-ng
-- block:
+  notify: Restart syslog-ng
+- when:
+    - syslog_tls_ca is defined
+    - syslog_tls_key is defined
+    - syslog_tls_server_ca is defined
+  block:
   - name: Create /etc/syslog-ng/cert.d
     file:
       path: /etc/syslog-ng/cert.d
       state: directory
       mode: '0755'
+    notify: Restart syslog-ng
   - name: Create /etc/syslog-ng/ca.d
     file:
       path: /etc/syslog-ng/ca.d/
       state: directory
       mode: '0755'
-  - name: copy syslog client certificate
+    notify: Restart syslog-ng
+  - name: Copy syslog client certificate
     ansible.builtin.copy:
       src: "{{ syslog_tls_ca }}"
       dest: /etc/syslog-ng/cert.d/clientcert.pem
       mode: '0644'
-  - name: copy syslog key
+    notify: Restart syslog-ng
+  - name: Copy syslog key
     ansible.builtin.copy:
       src: "{{ syslog_tls_key }}"
       dest: /etc/syslog-ng/cert.d/clientkey.pem
       mode: '0400'
-  - name: copy syslog server ca
+    notify: Restart syslog-ng
+  - name: Copy syslog server ca
     ansible.builtin.copy:
       src: "{{ syslog_tls_server_ca }}"
       dest: /etc/syslog-ng/ca.d/serverca.pem
       mode: '0644'
-  when:
-    - syslog_tls_ca is defined
-    - syslog_tls_key is defined
-    - syslog_tls_server_ca is defined
+    notify: Restart syslog-ng
 
 - name: Retrieve user information for UID 1000
   ansible.builtin.command: getent passwd 1000
@@ -69,10 +74,10 @@
   ansible.builtin.set_fact:
     old_admin_user: "{{ user_info.stdout.split(':')[0] }}"
 
-- name: removing or not the old admin user created by the iso
+- name: Removing or not the old admin user created by the iso
   when: admin_user != old_admin_user
   block:
-    - name: remove old admin user from sudoers file
+    - name: Remove old admin user from sudoers file
       lineinfile:
         dest: /etc/sudoers
         state: absent
@@ -93,12 +98,7 @@
     src: journald.conf
     dest: /etc/systemd/journald.conf
     mode: '0644'
-  register: journaldconf
-- name: Restart systemd-journald
-  ansible.builtin.systemd:
-    state: restarted
-    name: systemd-journald
-  when: journaldconf.changed
+  notify: Restart systemd-journald
 
 - name: Ensure admin group exists
   ansible.builtin.group:
@@ -114,7 +114,7 @@
     password: "{{ admin_passwd | default(omit) }}"
     append: no
 - name: Add authorized keys to admin user
-  authorized_key:
+  ansible.posix.authorized_key:
     user: "{{ admin_user }}"
     key: "{{ item }}"
   with_items: "{{ admin_ssh_keys }}"
@@ -142,7 +142,7 @@
   with_items:
     - 00-panicreboot.conf
 
-- name: customize /etc/environment
+- name: Customize /etc/environment
   ansible.builtin.lineinfile:
     dest: "/etc/environment"
     state: present
@@ -158,7 +158,7 @@
       SYSTEMD_EDITOR: 'vim'
   with_items: "{{ env_list | dict2items }}"
 
-- name: "PATH for admin user"
+- name: PATH for admin user
   lineinfile:
     dest: "/home/{{ admin_user }}/.bash_profile"
     regexp: '^export PATH'
@@ -169,7 +169,8 @@
     group: "{{ admin_user }}"
     mode: '0644'
 
-- block:
+- when: apt_repo is defined
+  block:
     - name: Remove all file in /etc/apt/sources.list.d
       file:
         path: /etc/apt/sources.list.d
@@ -178,9 +179,8 @@
       template:
         src: sources.list.j2
         dest: /etc/apt/sources.list
-  when: apt_repo is defined
 
-- name: "remove /etc/default/grub.d/*.cfg (FAI)"
+- name: Remove /etc/default/grub.d/*.cfg (FAI)
   file:
     path: "/etc/default/grub.d/{{ item }}"
     state: absent
@@ -188,15 +188,15 @@
     - 20_efi_ipv6.cfg
     - 30_console.cfg
 
-- name: "remove quiet from GRUB_CMDLINE_LINUX_DEFAULT option in grub conf"
+- name: Remove quiet from GRUB_CMDLINE_LINUX_DEFAULT option in grub conf
   lineinfile:
     dest: /etc/default/grub
     regexp: "^(GRUB_CMDLINE_LINUX_DEFAULT=\")(.*?[ ])?quiet([ ].*)?(\")$"
     line: '\1\2\3\4'
     backrefs: yes
-  register: updategrub0
+  notify: Update-grub
 
-- name: "make sure GRUB_CMDLINE_LINUX_DEFAULT has no double space"
+- name: Make sure GRUB_CMDLINE_LINUX_DEFAULT has no double space
   lineinfile:
     dest: /etc/default/grub
     regexp: "^(GRUB_CMDLINE_LINUX_DEFAULT=\".*)[ ][ ](.*\")"
@@ -205,10 +205,10 @@
     backrefs: yes
   register: doublespace
   until: not doublespace.changed
-  delay: 0.1
+  delay: 1
   retries: 10
 
-- name: "make sure GRUB_CMDLINE_LINUX exists 1/2"
+- name: Make sure GRUB_CMDLINE_LINUX exists 1/2
   lineinfile:
     path: /etc/default/grub
     regexp: "^GRUB_CMDLINE_LINUX=\".*\""
@@ -217,14 +217,14 @@
   changed_when: false
   register: check_grub_cmdline_linux
 
-- name: "make sure GRUB_CMDLINE_LINUX exists 2/2"
+- name: Make sure GRUB_CMDLINE_LINUX exists 2/2
   lineinfile:
     path: /etc/default/grub
     state: present
     line: "GRUB_CMDLINE_LINUX=\" \""
   when: check_grub_cmdline_linux.found == 0
 
-- name: "make sure GRUB_CMDLINE_LINUX starts with a space"
+- name: Make sure GRUB_CMDLINE_LINUX starts with a space
   lineinfile:
     dest: /etc/default/grub
     regexp: "^(GRUB_CMDLINE_LINUX=)\"([ ]*)(.*)\""
@@ -232,14 +232,14 @@
     state: present
     backrefs: yes
 
-- name: "grub conf"
+- name: Make grub conf
   lineinfile:
     dest: /etc/default/grub
     regexp: "^(GRUB_CMDLINE_LINUX=(?!.* {{ item }})\"[^\"]*)(\".*)"
     line: '\1 {{ item }}\2'
     state: present
     backrefs: yes
-  register: updategrub1
+  notify: Update-grub
   with_items:
     - ipv6.disable=1
     - efi=runtime
@@ -247,13 +247,10 @@
     - fsck.repair=yes
     - "{{ grub_append | default([]) }}"
 
-- name: "grub conf osprober"
+- name: Grub conf osprober
   lineinfile:
     dest: /etc/default/grub
     regexp: '^#?GRUB_DISABLE_OS_PROBER=.*$'
     line: 'GRUB_DISABLE_OS_PROBER=true'
     state: present
-  register: updategrub2
-- name: update-grub
-  command: update-grub
-  when: updategrub0.changed or updategrub1.changed or updategrub2.changed
+  notify: Update-grub

--- a/roles/debian_hardening/handlers/main.yml
+++ b/roles/debian_hardening/handlers/main.yml
@@ -2,5 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 
-- name: update sysfs values using sysctl
+- name: Update sysfs values using sysctl
   command: sysctl --system
+  changed_when: true

--- a/roles/debian_hardening/tasks/main.yml
+++ b/roles/debian_hardening/tasks/main.yml
@@ -19,7 +19,7 @@
     state: present
     backrefs: yes
   register: updategrub
-  with_items: "{{ kernel_params }}"
+  with_items: "{{ debian_hardening_kernel_params }}"
   when: not revert
 
 - name: "Revert kernel parameters added in grub"
@@ -30,7 +30,7 @@
     state: present
     backrefs: yes
   register: updategrub
-  with_items: "{{ kernel_params }}"
+  with_items: "{{ debian_hardening_kernel_params }}"
   when: revert
 
 - name: "Disable coredumps"
@@ -40,14 +40,14 @@
     line: "kernel.core_pattern=/dev/null"
     create: yes
     state: present
-  notify: update sysfs values using sysctl
+  notify: Update sysfs values using sysctl
   when: not revert
 - name: "Revert coredump disabling"
   lineinfile:
     dest: /etc/sysctl.d/50-coredump.conf
     regexp: "^kernel.core_pattern=/dev/null$"
     state: absent
-  notify: update sysfs values using sysctl
+  notify: Update sysfs values using sysctl
   when: revert
 
 - name: "Disable kexec"
@@ -57,14 +57,14 @@
     line: "kernel.kexec_load_disabled=1"
     create: yes
     state: present
-  notify: update sysfs values using sysctl
+  notify: Update sysfs values using sysctl
   when: not revert
 - name: "Revert kexec disabling"
   lineinfile:
     dest: /etc/sysctl.d/50-kexec.conf
     regexp: "^kernel.kexec_load_disabled=1$"
     state: absent
-  notify: update sysfs values using sysctl
+  notify: Update sysfs values using sysctl
   when: revert
 
 - name: "Disable binfmt_misc"
@@ -74,40 +74,40 @@
     line: "fs.binfmt_misc.status=0"
     create: yes
     state: present
-  notify: update sysfs values using sysctl
+  notify: Update sysfs values using sysctl
   when: not revert
 - name: "Revert binfmt_misc disabling"
   lineinfile:
     dest: /etc/sysctl.d/50-binfmt_misc.conf
     regexp: "^fs.binfmt_misc.status=0$"
     state: absent
-  notify: update sysfs values using sysctl
+  notify: Update sysfs values using sysctl
   when: revert
 
 - name: "Install hardened sysfs rules"
   copy:
     src: sysctl/90-sysctl-hardening.conf
     dest: /etc/sysctl.d/zz-sysctl-hardening.conf
-  notify: update sysfs values using sysctl
+  notify: Update sysfs values using sysctl
   when: not revert
 - name: "Uninstall hardened sysfs rules"
   file:
     path: /etc/sysctl.d/zz-sysctl-hardening.conf
     state: absent
-  notify: update sysfs values using sysctl
+  notify: Update sysfs values using sysctl
   when: revert
 
 - name: "Install network hardened sysfs rules"
   copy:
     src: sysctl/99-sysctl-network.conf
     dest: /etc/sysctl.d/99-sysctl-network.conf
-  notify: update sysfs values using sysctl
+  notify: Update sysfs values using sysctl
   when: not revert
 - name: "Uninstall network hardened sysfs rules"
   file:
     path: /etc/sysctl.d/sysctl/99-sysctl-network.conf
     state: absent
-  notify: update sysfs values using sysctl
+  notify: Update sysfs values using sysctl
   when: revert
 
 - name: "Install random-root-passwd.service"
@@ -116,7 +116,7 @@
     dest: /etc/systemd/system/random-root-passwd.service
   when: not revert
   register: random_root
-- name: "enable random-root-passwd.service"
+- name: "Enable random-root-passwd.service"
   ansible.builtin.systemd:
     name: random-root-passwd.service
     enabled: yes
@@ -204,7 +204,7 @@
   with_items: "{{ sudoers_files.files }}"
   when: not revert
 
-- name: adding sudo users to group privileged
+- name: Adding sudo users to group privileged
   user:
     name: "{{ item }}"
     groups: privileged
@@ -224,6 +224,7 @@
     which cockpit-bridge
   register: cockpit_status
   ignore_errors: true
+  changed_when: false
 
 - name: Disable require tty for cockpit
   copy:
@@ -332,20 +333,20 @@
     owner: root
     group: root
     mode: 0755
-  with_items: "{{ hardened_services }}"
+  with_items: "{{ debian_hardening_hardened_services }}"
 
 - name: Add systemd service hardening rules
   copy:
     src: "{{ item }}_hardening.conf"
     dest: "/etc/systemd/system/{{ item }}.service.d/hardening.conf"
-  with_items: "{{ hardened_services }}"
+  with_items: "{{ debian_hardening_hardened_services }}"
   when: not revert
 
 - name: Remove systemd service hardening rules
   file:
     path: "/etc/systemd/system/{{ item }}.service.d/hardening.conf"
     state: absent
-  with_items: "{{ hardened_services }}"
+  with_items: "{{ debian_hardening_hardened_services }}"
   when: revert
 
 - name: Set grub password
@@ -362,14 +363,14 @@
     path: /etc/grub.d/01_password
   when: revert
 
-- name: add unrestricted in grub.cfg
+- name: Add unrestricted in grub.cfg
   lineinfile:
     #CLASS="--class gnu-linux --class gnu --class os --unrestricted"
     path: /etc/grub.d/10_linux
     regexp: '^CLASS='
     line: 'CLASS="--class gnu-linux --class gnu --class os --unrestricted"'
   when: not revert
-- name: remove unrestricted in grub.cfg
+- name: Remove unrestricted in grub.cfg
   lineinfile:
     #CLASS="--class gnu-linux --class gnu --class os"
     path: /etc/grub.d/10_linux
@@ -377,15 +378,16 @@
     line: 'CLASS="--class gnu-linux --class gnu --class os"'
   when: revert
 
-- name: copy syslog.conf
+- name: Copy syslog.conf
   copy:
     src: auditd/syslog.conf
     dest: /etc/audit/plugins.d/syslog.conf
 
-- name: copy audit.rules
+- name: Copy audit.rules
   copy:
     src: auditd/audit.rules
     dest: /etc/audit/rules.d/audit.rules
 
 - name: Update grub
   command: update-grub
+  changed_when: true

--- a/roles/debian_hardening/vars/main.yml
+++ b/roles/debian_hardening/vars/main.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 
-kernel_params:
+debian_hardening_kernel_params:
  - init_on_alloc=1
  - init_on_free=1
  - slab_nomerge
@@ -16,5 +16,5 @@ kernel_params:
  - rng_core.default_quality=500
  - lsm=apparmor,lockdown,capability,landlock,yama,bpf,integrity
 
-hardened_services:
+debian_hardening_hardened_services:
   - syslog-ng

--- a/roles/debian_hardening_physical_machine/tasks/main.yml
+++ b/roles/debian_hardening_physical_machine/tasks/main.yml
@@ -30,14 +30,14 @@
     mode: '0440'
   when: not revert
 
-- name: adding ceph user to group privileged
+- name: Adding ceph user to group privileged
   user:
     name: "ceph"
     groups: privileged
     append: yes
   when: not revert
 
-- name: adding Debian-snmp user to group privileged
+- name: Adding Debian-snmp user to group privileged
   user:
     name: "Debian-snmp"
     groups: privileged
@@ -51,18 +51,18 @@
     owner: root
     group: root
     mode: 0755
-  with_items: "{{ hardened_services }}"
+  with_items: "{{ debian_hardening_physical_machine_hardened_services }}"
 
 - name: Add systemd service hardening rules for physical machines
   copy:
     src: "{{ item }}_hardening.conf"
     dest: "/etc/systemd/system/{{ item }}.service.d/hardening.conf"
-  with_items: "{{ hardened_services }}"
+  with_items: "{{ debian_hardening_physical_machine_hardened_services }}"
   when: not revert
 
 - name: Remove systemd service hardening rules for physical machines
   file:
     path: "/etc/systemd/system/{{ item }}.service.d/hardening.conf"
     state: absent
-  with_items: "{{ hardened_services }}"
+  with_items: "{{ debian_hardening_physical_machine_hardened_services }}"
   when: revert

--- a/roles/debian_hardening_physical_machine/vars/main.yml
+++ b/roles/debian_hardening_physical_machine/vars/main.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 
-hardened_services:
+debian_hardening_physical_machine_hardened_services:
   - ovs-vswitchd
   - ovsdb-server
   - corosync

--- a/roles/debian_hypervisor/handlers/main.yml
+++ b/roles/debian_hypervisor/handlers/main.yml
@@ -1,0 +1,34 @@
+# Copyright (C) 2025 RTE
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Restart sysfsutils
+  ansible.builtin.systemd:
+    name: sysfsutils.service
+    state: restarted
+
+- name: Start new slices
+  ansible.builtin.systemd:
+    name: "{{ item }}.slice"
+    state: restarted
+    daemon_reload: yes
+  with_items:
+    - "machine-rt"
+    - "machine-nort"
+    - "ovs"
+
+- name: Start new slices REVERT
+  ansible.builtin.systemd:
+    name: "{{ item }}.slice"
+    state: stopped
+    daemon_reload: yes
+  with_items:
+    - "machine-rt"
+    - "machine-nort"
+    - "ovs"
+
+- name: Restart ovs-vswitchd
+  ansible.builtin.systemd:
+    state: restarted
+    daemon_reload: yes
+    name: ovs-vswitchd

--- a/roles/debian_hypervisor/tasks/main.yml
+++ b/roles/debian_hypervisor/tasks/main.yml
@@ -2,32 +2,32 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-- name: enable docker.service
+- name: Enable docker.service
   ansible.builtin.systemd:
     name: docker.service
     enabled: yes
     state: started
-- name: enable docker.socket
+- name: Enable docker.socket
   ansible.builtin.systemd:
     name: docker.socket
     enabled: yes
     state: started
 
-- name: add vhost_vsock to /etc/modules
+- name: Add vhost_vsock to /etc/modules
   lineinfile:
     path: /etc/modules
     state: present
     regexp: '^vhost_vsock$'
     line: 'vhost_vsock'
 
-- name: add sriov driver to /etc/modules
+- name: Add sriov driver to /etc/modules
   lineinfile:
     path: /etc/modules
     state: present
     regexp: "^{{ sriov_driver }}$"
     line: "{{ sriov_driver }}"
   when: sriov_driver is defined
-- name: add sriov apparmor permission for libvirt
+- name: Add sriov apparmor permission for libvirt
   lineinfile:
     path: /etc/apparmor.d/local/abstractions/libvirt-qemu
     state: present
@@ -35,13 +35,13 @@
     create: yes
     mode: 0644
   when: sriov_driver is defined
-- name: load the sriov module
+- name: Load the sriov module
   community.general.modprobe:
     name: "{{ sriov_driver }}"
     state: present
   when: sriov_driver is defined
 
-- name: add sriov sysfs rules
+- name: Add sriov sysfs rules
   ansible.builtin.lineinfile:
     path: "/etc/sysfs.d/sriov.conf"
     state: present
@@ -51,28 +51,27 @@
     mode: 0644
   with_items: "{{ sriov | dict2items }}"
   when: sriov is defined
-  register: sriov_sysfs
-- name: restart sysfsutils
-  ansible.builtin.systemd:
-    name: sysfsutils.service
-    state: restarted
-  when: sriov_sysfs.changed
+  notify: Restart sysfsutils
 
-- name: "systemd conf RuntimeWatchdogSec"
+- name: Systemd conf RuntimeWatchdogSec
   lineinfile:
     path: /etc/systemd/system.conf
     regexp: '^RuntimeWatchdogSec=.*$'
     line: "RuntimeWatchdogSec=20"
     state: present
-- name: "systemd conf RebootWatchdogSec"
+- name: Systemd conf RebootWatchdogSec
   lineinfile:
     path: /etc/systemd/system.conf
     regexp: '^RebootWatchdogSec=.*$'
     line: "RebootWatchdogSec=5min"
     state: present
 
-- block:
-  - name: "Create systemd slices override (folder)"
+- when:
+    - cpusystem is defined
+    - cpuuser is defined
+    - cpumachines is defined
+  block:
+  - name: Create systemd slices override (folder)
     file:
       path: /etc/systemd/system.control/{{ item }}.slice.d
       state: directory
@@ -83,7 +82,7 @@
       - "system"
       - "user"
       - "machine"
-  - name: create systemd slices override (files)
+  - name: Create systemd slices override (files)
     template:
       src: systemd_slice_override.j2
       dest: /etc/systemd/system.control/{{ item.name }}.slice.d/50-AllowedCPUs.conf
@@ -94,10 +93,6 @@
       - { name: "system", description: "system slice", allowedcpus: "{{ cpusystem }}" }
       - { name: "user", description: "user slice", allowedcpus: "{{ cpuuser }}" }
       - { name: "machine", description: "machine slice", allowedcpus: "{{ cpumachines }}" }
-  when:
-    - cpusystem is defined
-    - cpuuser is defined
-    - cpumachines is defined
 - name: Create systemd slices override REVERT
   file:
     path: /etc/systemd/system.control/{{ item }}.slice.d
@@ -108,7 +103,7 @@
     - "machine"
   when: cpusystem is not defined or cpuuser is not defined or cpumachines is not defined
 
-- name: create systemd slices
+- name: Create systemd slices
   template:
     src: systemd_slice.j2
     dest: /etc/systemd/system/{{ item.name }}.slice
@@ -119,12 +114,12 @@
     - { name: "machine-rt", description: "VM rt slice", wants: "machine.slice", allowedcpus: "{{ cpumachinesrt }}" }
     - { name: "machine-nort", description: "VM nonrt slice", wants: "machine.slice", allowedcpus: "{{ cpumachinesnort }}" }
     - { name: "ovs", description: "ovs slice", wants: "", allowedcpus: "{{ cpuovs }}" }
-  register: newslices
+  notify: Start new slices
   when:
     - cpumachinesrt is defined
     - cpumachinesnort is defined
     - cpuovs is defined
-- name: create systemd slices REVERT
+- name: Create systemd slices REVERT
   file:
     path: /etc/systemd/system/{{ item }}.slice
     state: absent
@@ -132,41 +127,20 @@
     - "machine-rt"
     - "machine-nort"
     - "ovs"
-  register: removeslices
+  notify: Start new slices REVERT
   when: cpumachinesrt is not defined and cpumachinesnort is not defined and cpuovs is not defined
 
-- name: start new slices
-  ansible.builtin.systemd:
-    name: "{{ item }}.slice"
-    state: restarted
-    daemon_reload: yes
-  with_items:
-    - "machine-rt"
-    - "machine-nort"
-    - "ovs"
-  when: newslices.changed
-- name: start new slices REVERT
-  ansible.builtin.systemd:
-    name: "{{ item }}.slice"
-    state: stopped
-    daemon_reload: yes
-  with_items:
-    - "machine-rt"
-    - "machine-nort"
-    - "ovs"
-  when: removeslices.changed
-
-- name: create tuned seapath-rt profile folder
+- name: Create tuned seapath-rt profile folder
   file:
     path: /etc/tuned/seapath-rt-host
     state: directory
     mode: '0755'
 
-- name: tuned path
+- name: Tuned path
   set_fact:
     tuned_path: "{{ custom_tuned_profile_path if custom_tuned_profile_path is defined else 'tuned.conf.j2' }}"
 
-- name: copy seapath-rt-host tuned profile conf
+- name: Copy seapath-rt-host tuned profile conf
   template:
     src: "{{ tuned_path }}"
     dest: /etc/tuned/seapath-rt-host/tuned.conf
@@ -174,26 +148,28 @@
     owner: root
     mode: '0644'
 
-- name: remove tuned dynamic tuning
+- name: Remove tuned dynamic tuning
   lineinfile:
     path: /etc/tuned/tuned-main.conf
     state: present
     regexp: '^#?dynamic_tuning = .*$'
     line: 'dynamic_tuning = 0'
 
-- name: enable tuned.service
+- name: Enable tuned.service
   ansible.builtin.systemd:
     name: tuned.service
     enabled: yes
     state: restarted
 
-- name: load seapath-rt-host tuned profile
+- name: Load seapath-rt-host tuned profile
   ansible.builtin.command: tuned-adm profile seapath-rt-host
   when: isolcpus is defined
+  changed_when: true
 
-- name: unload tuned profile
+- name: Unload tuned profile
   ansible.builtin.command: tuned-adm off
   when: isolcpus is not defined
+  changed_when: true
 
 - name: Create ovs-vswitchd.service.d directory
   file:
@@ -202,6 +178,7 @@
     owner: root
     group: root
     mode: 0755
+  notify: Restart ovs-vswitchd
 - name: Create ovs-vswitchd.service drop-in
   template:
     src: ovs-vswitchd_override.conf.j2
@@ -209,8 +186,8 @@
     owner: root
     group: root
     mode: 0644
-  register: ovsvswitchd
   when: team0_0 is defined and team0_1 is defined
+  notify: Restart ovs-vswitchd
 - name: Copy team0_x@.service file
   ansible.builtin.copy:
     src: team0_x@.service
@@ -218,11 +195,5 @@
     owner: root
     group: root
     mode: 0644
-  register: team0_x_service
   when: team0_0 is defined and team0_1 is defined
-- name: Restart ovs-vswitchd
-  ansible.builtin.systemd:
-    state: restarted
-    daemon_reload: yes
-    name: ovs-vswitchd
-  when: ovsvswitchd.changed or team0_x_service.changed
+  notify: Restart ovs-vswitchd

--- a/roles/debian_physical_machine/handlers/main.yml
+++ b/roles/debian_physical_machine/handlers/main.yml
@@ -1,3 +1,16 @@
-- name: daemon-reload
+# Copyright (C) 2025 RTE
+# SPDX-License-Identifier: Apache-2.0
+
+- name: Trigger daemon-reload
   ansible.builtin.service:
     daemon_reload: yes
+
+- name: Restart systemd-sysctl
+  ansible.builtin.systemd:
+    name: systemd-sysctl.service
+    state: restarted
+
+- name: Rebuild initramfs if necessary
+  command:
+    cmd: /usr/bin/dracut --regenerate-all --force
+  changed_when: true

--- a/roles/debian_physical_machine/tasks/main.yml
+++ b/roles/debian_physical_machine/tasks/main.yml
@@ -12,7 +12,7 @@
     mode: '0644'
   with_items:
     - 00-bridge_nf_call.conf
-  register: sysctl1
+  notify: Restart systemd-sysctl
 
 - name: Add sysctl conf from inventory (extra_sysctl_physical_machines)
   ansible.builtin.copy:
@@ -20,29 +20,23 @@
     mode: '0644'
     content: "{{ extra_sysctl_physical_machines }}"
   when: extra_sysctl_physical_machines is defined
-  register: sysctl2
+  notify: Restart systemd-sysctl
 
-- name: restart systemd-sysctl if needed
-  ansible.builtin.systemd:
-    name: systemd-sysctl.service
-    state: restarted
-  when: sysctl1.changed or sysctl2.changed
-
-- name: create src folder on hosts
+- name: Create src folder on hosts
   file:
     path: /tmp/src
     state: directory
     mode: '0755'
 
-- name: temp fix for synchronize to force evaluate variables
+- name: Temp fix for synchronize to force evaluate variables
   set_fact:
     ansible_host: "{{ ansible_host }}"
 
-- name: deploy vm_manager
+- name: Deploy vm_manager
   include_role:
     name: deploy_vm_manager
 
-- name: deploy python3-setup-ovs
+- name: Deploy python3-setup-ovs
   include_role:
     name: deploy_python3_setup_ovs
 
@@ -52,7 +46,7 @@
     dest: /usr/local/bin/consolevm
     mode: '0755'
 
-- name: create /usr/lib/ocf/resource.d/seapath on hosts
+- name: Create /usr/lib/ocf/resource.d/seapath on hosts
   file:
     path: /usr/lib/ocf/resource.d/seapath
     state: directory
@@ -76,16 +70,15 @@
     group: root
     mode: '0644'
   register: chronywait
-- name: daemon-reload chrony-wait.service
-  ansible.builtin.service:
-    daemon_reload: yes
-  when: chronywait.changed
-- name: enable chrony-wait.service
+  notify: Trigger daemon-reload
+- name: Enable chrony-wait.service
   ansible.builtin.systemd:
     name: chrony-wait.service
     enabled: yes
 
-- block:
+- when:
+    - services['pacemaker.service'] is defined
+  block:
     - name: Create pacemaker.service.d directory
       file:
         path: /etc/systemd/system/pacemaker.service.d/
@@ -100,24 +93,22 @@
         owner: root
         group: root
         mode: 0644
-      notify: daemon-reload
+      notify: Trigger daemon-reload
       register: pacemaker_corosync
     - name: Get Pacemaker service Status
       ansible.builtin.systemd:
         name: "pacemaker.service"
       register: pacemaker_service_status
-    - name: disable pacemaker (reinstall step 1/2)
+    - name: Disable pacemaker (reinstall step 1/2)
       ansible.builtin.systemd:
         name: pacemaker.service
         enabled: no
       when: pacemaker_corosync.changed and pacemaker_service_status.status.UnitFileState == "enabled"
-    - name: enable pacemaker (reinstall step 2/2)
+    - name: Enable pacemaker (reinstall step 2/2)
       ansible.builtin.systemd:
         name: pacemaker.service
         enabled: yes
       when: pacemaker_corosync.changed and pacemaker_service_status.status.UnitFileState == "enabled"
-  when:
-    - services['pacemaker.service'] is defined
 
 - name: Add extra modules to the kernel
   lineinfile:
@@ -134,17 +125,18 @@
     append: yes
 
 - name: Creating libvirt user with libvirtd permissions
-  user: name=libvirt
-    group=libvirt
-    shell=/bin/false
+  user:
+    name: libvirt
+    group: libvirt
+    shell: /bin/false
 
-- name: add br_netfilter to /etc/modules
+- name: Add br_netfilter to /etc/modules
   lineinfile:
     dest: /etc/modules
     state: present
     regexp: '^br_netfilter$'
     line: 'br_netfilter'
-- name: add raid6_pq to /etc/modules
+- name: Add raid6_pq to /etc/modules
   lineinfile:
     dest: /etc/modules
     state: present
@@ -157,7 +149,7 @@
     dest: /etc/apparmor.d/abstractions/libvirt-qemu
     mode: '0644'
 
-- name: lineinfile in hosts file for logstash-seapath
+- name: Lineinfile in hosts file for logstash-seapath
   lineinfile:
     dest: /etc/hosts
     regexp: '.* logstash-seapath$'
@@ -171,51 +163,53 @@
     regexp: "^#?host_uuid_source ="
     line: "host_uuid_source = \"machine-id\""
     state: present
-- name: restart libvirtd
+- name: Restart libvirtd
   ansible.builtin.systemd:
     name: libvirtd.service
     state: restarted
 
-- name: enable docker.service
+- name: Enable docker.service
   ansible.builtin.systemd:
     name: docker.service
-- name: "add initramfs-tools scripts: script file (LVM rebooter and log handling)"
+- name: "Add initramfs-tools scripts: script file (LVM rebooter and log handling)"
   ansible.builtin.copy:
     src: initramfs-tools/scripts/
     dest: /etc/initramfs-tools/scripts/
     mode: '0755'
-  register: initramfs_tools_scripts
+  notify: Rebuild initramfs if necessary
 
-- name: "get the /var/log/ device"
+- name: Get the /var/log/ device
   command: "findmnt -n -o SOURCE --target /var/log"
   register: varlog_dev
+  changed_when: false
 
-- name: "set_fact /var/log/ device"
+- name: Set fact /var/log/ device
   set_fact:
     lvm_rebooter_log_device: "{{ varlog_dev.stdout }}"
 
-- name: "get the /var/log/ relative path"
+- name: Get the /var/log/ relative path
   shell: "realpath --relative-to=$(findmnt -n -o TARGET --target /var/log/) /var/log"
   register: varlog_path
+  changed_when: false
 
-- name: "set_fact /var/log/ relative path"
+- name: Set fact /var/log/ relative path
   set_fact:
     lvm_rebooter_log_path: "{{ varlog_path.stdout }}"
 
-- name: "Copy rebooter.conf"
+- name: Copy rebooter.conf
   template:
     src: initramfs-tools/conf.d/rebooter.conf.j2
     dest: /etc/initramfs-tools/conf.d/rebooter.conf
 
-- name: "configure initramfs-tools to use busybox"
+- name: Configure initramfs-tools to use busybox
   lineinfile:
     dest: /etc/initramfs-tools/initramfs.conf
     regexp: "^#?BUSYBOX="
     line: "BUSYBOX=y"
     state: present
-  register: initramfs_busybox
+  notify: Rebuild initramfs if necessary
 
-- name: "add udev rules for lvm2 limitation"
+- name: Add udev rules for lvm2 limitation
   ansible.builtin.copy:
     src: 69-lvm.rules
     dest: /etc/udev/rules.d/69-lvm.rules
@@ -223,12 +217,7 @@
   when: ansible_distribution == 'Debian' and ansible_distribution_version | int >= 12
   register: udevlvm
 
-- name: "rebuild initramfs if necessary"
-  command:
-    cmd: /usr/sbin/update-initramfs -u
-  when: udevlvm.changed or initramfs_tools_scripts.changed or initramfs_busybox.changed
-
-- name: "add rbd type to lvm.conf"
+- name: Add rbd type to lvm.conf
   ansible.builtin.lineinfile:
     path: /etc/lvm/lvm.conf
     insertafter: 'devices {'

--- a/roles/deploy_cukinia_tests/tasks/main.yml
+++ b/roles/deploy_cukinia_tests/tasks/main.yml
@@ -3,7 +3,7 @@
 
 ---
 - name: Copy Cukinia's tests
-  synchronize:
+  ansible.posix.synchronize:
     src: cukinia-tests/cukinia
     dest: /etc/
     delete: true
@@ -44,7 +44,8 @@
     group: root
     mode: 0755
 
-- name: tasks only on hosts
+- name: Tasks only on hosts
+  when: "'hypervisors' in group_names"
   block:
     - name: Copy vm.xml
       copy:
@@ -59,22 +60,21 @@
         src: /etc/cukinia/cukinia-hypervisor.conf
         dest: /etc/cukinia/cukinia.conf
         state: link
-  when: "'hypervisors' in group_names"
 
 - name: Create /etc/cukinia.conf for observers
+  when: "'observers' in group_names"
   block:
     - name: Create a symlink cukinia.conf to cukinia-observer.conf
       file:
         src: /etc/cukinia/cukinia-observer.conf
         dest: /etc/cukinia/cukinia.conf
         state: link
-  when: "'observers' in group_names"
 
 - name: Create /etc/cukinia.conf for VMs
+  when: "'VMs' in group_names"
   block:
     - name: Create a symlink cukinia.conf to cukinia-observer.conf
       file:
         src: /etc/cukinia/cukinia-observer.conf
         dest: /etc/cukinia/cukinia.conf
         state: link
-  when: "'VMs' in group_names"

--- a/roles/deploy_python3_setup_ovs/handlers/main.yml
+++ b/roles/deploy_python3_setup_ovs/handlers/main.yml
@@ -1,0 +1,7 @@
+# Copyright (C) 2024 RTE
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Trigger daemon-reload
+  ansible.builtin.service:
+    daemon_reload: yes

--- a/roles/deploy_python3_setup_ovs/meta/main.yml
+++ b/roles/deploy_python3_setup_ovs/meta/main.yml
@@ -10,7 +10,7 @@ galaxy_info:
   - name: Debian
     versions:
     - all
-  - name: CentOS
+  - name: EL
     versions:
     - all
 dependencies: []

--- a/roles/deploy_python3_setup_ovs/tasks/main.yml
+++ b/roles/deploy_python3_setup_ovs/tasks/main.yml
@@ -12,17 +12,14 @@
   command:
     cmd: /usr/bin/pip install --root-user-action=ignore --prefix=/usr/ .
     chdir: /tmp/src/python3-setup-ovs
+  changed_when: true
 - name: Copy seapath-config_ovs.service
   ansible.builtin.copy:
     src: seapath-config_ovs.service
     dest: /etc/systemd/system/seapath-config_ovs.service
     mode: '0644'
-  register: seapathconfigovs
-- name: daemon-reload seapath-config_ovs
-  ansible.builtin.service:
-    daemon_reload: yes
-  when: seapathconfigovs.changed
-- name: enable seapath-config_ovs.service
+  notify: Trigger daemon-reload
+- name: Enable seapath-config_ovs.service
   ansible.builtin.systemd:
     name: seapath-config_ovs.service
     enabled: yes

--- a/roles/deploy_vm_manager/meta/main.yml
+++ b/roles/deploy_vm_manager/meta/main.yml
@@ -10,7 +10,7 @@ galaxy_info:
   - name: Debian
     versions:
     - all
-  - name: CentOS
+  - name: EL
     versions:
     - all
 dependencies: []

--- a/roles/deploy_vm_manager/tasks/main.yml
+++ b/roles/deploy_vm_manager/tasks/main.yml
@@ -12,6 +12,7 @@
   command:
     cmd: /usr/bin/python3 setup.py install
     chdir: /tmp/src/vm_manager
+  changed_when: true
 - name: Create a symbolic link
   ansible.builtin.file:
     src: /usr/local/bin/vm_manager_cmd.py

--- a/roles/deploy_vms_cluster/defaults/main.yml
+++ b/roles/deploy_vms_cluster/defaults/main.yml
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-
-disk_copy: true
-qcow2tmpuploadfolder: "/tmp"
-vms_disks_directory: ""
+deploy_vms_cluster_disk_copy: true
+deploy_vms_cluster_qcow2tmpuploadfolder: "/tmp"
+deploy_vms_cluster_vms_disks_directory: ""

--- a/roles/deploy_vms_cluster/meta/main.yml
+++ b/roles/deploy_vms_cluster/meta/main.yml
@@ -6,8 +6,4 @@ galaxy_info:
   description: deploys Guests in cluster mode
   license: Apache-2.0
   min_ansible_version: 2.9.10
-  platforms:
-  - name: Linux
-    versions:
-    - all
 dependencies: []

--- a/roles/deploy_vms_cluster/tasks/main.yml
+++ b/roles/deploy_vms_cluster/tasks/main.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-- name: "check presence of vm before copy"
+- name: Check presence of vm before copy
   cluster_vm:
     command: status
     name: "{{ item }}"
@@ -13,60 +13,59 @@
 
 - name: Check tmp folder permission
   file:
-    path: "{{ qcow2tmpuploadfolder }}"
+    path: "{{ deploy_vms_cluster_qcow2tmpuploadfolder }}"
     state: directory
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
     mode: '0755'
   when:
-    - qcow2tmpuploadfolder is defined
-    - qcow2tmpuploadfolder != "/tmp"
+    - deploy_vms_cluster_qcow2tmpuploadfolder is defined
+    - deploy_vms_cluster_qcow2tmpuploadfolder != "/tmp"
 
-- block:
-      - name: "Copy {{ item }} system disk on target"
-        copy:
-          src: "{{ vm_file }}"
-          dest: "{{ vm_file_dest }}"
-        vars:
-          ansible_remote_tmp: "{{ qcow2tmpuploadfolder | default(omit) }}"
-        when: disk_copy | bool
-      - name: "Create {{ item }}"
-        cluster_vm:
-          name: "{{ item }}"
-          command: create
-          system_image: "{{ vm_file_dest }}"
-          force: true
-          live_migration: "{{ hostvars[item].live_migration | default(false) }}"
-          migration_user: "{{ livemigration_user | default(omit) }}"
-          migrate_to_timeout: "{{ hostvars[item].migrate_to_timeout | default(omit) }}"
-          migration_downtime: "{{ hostvars[item].migration_downtime | default(omit) }}"
-          priority: "{{ hostvars[item].priority | default(omit) }}"
-          enable: "{{ hostvars[item].enable | default(true) }}"
-          pinned_host: "{{ hostvars[item].pinned_host | default(omit) }}"
-          preferred_host: "{{ hostvars[item].preferred_host | default(omit) }}"
-          crm_config_cmd: "{{ hostvars[item].crm_config_cmd | default(omit) }}"
-          xml: >-
-            {{ lookup('file', hostvars[item].xml_path)
-                 if hostvars[item].xml_path is defined
-               else lookup('template',hostvars[item].vm_template,template_vars=dict(vm=hostvars[item]))
-                 if hostvars[item].vm_template is defined
-               else lookup('file',vms_disks_directory + '/' + item + '.xml')
-               | replace('\n', '') }}
-      - name: Remove temporary file
-        file:
-          path: "{{ vm_file_dest }}"
-          state: absent
-      - name: Wait for VM connections
-        wait_for_connection:
-        delegate_to: "{{ item }}"
-        when:
-          - hostvars[item].wait_for_connection is defined
-          - hostvars[item].wait_for_connection
+- when: presencevm.status == "Undefined" or (hostvars[item].force is defined and hostvars[item].force)
   vars:
-    vm_file: "{{ hostvars[item].vm_disk | default( vms_disks_directory ~ '/' ~ item ~ '.qcow2') }}"
-    vm_file_dest: "{{ qcow2tmpuploadfolder + '/os.qcow2' }}"
-
-  when: presencevm.status == "Undefined" or (hostvars[item].force is defined and hostvars[item].force)
+    vm_file: "{{ hostvars[item].vm_disk | default( deploy_vms_cluster_vms_disks_directory ~ '/' ~ item ~ '.qcow2') }}"
+    vm_file_dest: "{{ deploy_vms_cluster_qcow2tmpuploadfolder + '/os.qcow2' }}"
+  block:
+    - name: "Copy system disk on target for {{ item }}"
+      copy:
+        src: "{{ vm_file }}"
+        dest: "{{ vm_file_dest }}"
+      vars:
+        ansible_remote_tmp: "{{ deploy_vms_cluster_qcow2tmpuploadfolder | default(omit) }}"
+      when: deploy_vms_cluster_disk_copy | bool
+    - name: "Create {{ item }}"
+      cluster_vm:
+        name: "{{ item }}"
+        command: create
+        system_image: "{{ vm_file_dest }}"
+        force: true
+        live_migration: "{{ hostvars[item].live_migration | default(false) }}"
+        migration_user: "{{ livemigration_user | default(omit) }}"
+        migrate_to_timeout: "{{ hostvars[item].migrate_to_timeout | default(omit) }}"
+        migration_downtime: "{{ hostvars[item].migration_downtime | default(omit) }}"
+        priority: "{{ hostvars[item].priority | default(omit) }}"
+        enable: "{{ hostvars[item].enable | default(true) }}"
+        pinned_host: "{{ hostvars[item].pinned_host | default(omit) }}"
+        preferred_host: "{{ hostvars[item].preferred_host | default(omit) }}"
+        crm_config_cmd: "{{ hostvars[item].crm_config_cmd | default(omit) }}"
+        xml: >-
+          {{ lookup('file', hostvars[item].xml_path)
+               if hostvars[item].xml_path is defined
+             else lookup('template',hostvars[item].vm_template,template_vars=dict(vm=hostvars[item]))
+               if hostvars[item].vm_template is defined
+             else lookup('file',deploy_vms_cluster_vms_disks_directory + '/' + item + '.xml')
+             | replace('\n', '') }}
+    - name: Remove temporary file
+      file:
+        path: "{{ vm_file_dest }}"
+        state: absent
+    - name: Wait for VM connections
+      wait_for_connection:
+      delegate_to: "{{ item }}"
+      when:
+        - hostvars[item].wait_for_connection is defined
+        - hostvars[item].wait_for_connection
 
 - name: "Define colocation constraints for {{ item }}"
   cluster_vm:

--- a/roles/deploy_vms_standalone/defaults/main.yml
+++ b/roles/deploy_vms_standalone/defaults/main.yml
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-
-disk_copy: true
-qcow2tmpuploadfolder: "/tmp"
-disk_pool: "/var/lib/libvirt/images"
+deploy_vms_standalone_disk_copy: true
+deploy_vms_standalone_qcow2tmpuploadfolder: "/tmp"
+deploy_vms_standalone_disk_pool: "/var/lib/libvirt/images"

--- a/roles/deploy_vms_standalone/meta/main.yml
+++ b/roles/deploy_vms_standalone/meta/main.yml
@@ -10,10 +10,7 @@ galaxy_info:
   - name: Debian
     versions:
     - all
-  - name: CentOS
-    versions:
-    - all
-  - name: Yocto
+  - name: EL
     versions:
     - all
 dependencies: []

--- a/roles/deploy_vms_standalone/tasks/main.yml
+++ b/roles/deploy_vms_standalone/tasks/main.yml
@@ -3,12 +3,12 @@
 
 ---
 - name: List all VMs
-  virt:
+  community.libvirt.virt:
     command: list_vms
   register: all_vms
 
 - name: Stop VM
-  virt:
+  community.libvirt.virt:
     state: destroyed
     name: "{{ item }}"
   when:
@@ -24,6 +24,7 @@
     - hostvars[item].force is defined
     - hostvars[item].force
   loop: "{{ groups['VMs'] }}"
+  changed_when: true
 
 - name: Print info
   debug:
@@ -33,23 +34,23 @@
 
 - name: Check tmp folder permission
   file:
-    path: "{{ qcow2tmpuploadfolder }}"
+    path: "{{ deploy_vms_standalone_qcow2tmpuploadfolder }}"
     state: directory
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
     mode: '0755'
   when:
-    - qcow2tmpuploadfolder is defined
-    - qcow2tmpuploadfolder != "/tmp"
+    - deploy_vms_standalone_qcow2tmpuploadfolder is defined
+    - deploy_vms_standalone_qcow2tmpuploadfolder != "/tmp"
 
 - name: Copy the disk on target
   copy:
     src: "{{ hostvars[item].vm_disk }}"
-    dest: "{{ disk_pool }}/{{ hostvars[item].inventory_hostname }}.qcow2"
+    dest: "{{ deploy_vms_standalone_disk_pool }}/{{ hostvars[item].inventory_hostname }}.qcow2"
   vars:
-    ansible_remote_tmp: "{{ qcow2tmpuploadfolder | default(omit) }}"
+    ansible_remote_tmp: "{{ deploy_vms_standalone_qcow2tmpuploadfolder | default(omit) }}"
   when:
-    - disk_copy | bool
+    - deploy_vms_standalone_disk_copy | bool
     - hostvars[item].disk_extract is not defined or not hostvars[item].disk_extract | bool
     - item not in all_vms.list_vms or (item in all_vms.list_vms and hostvars[item].force is defined and hostvars[item].force)
   loop: "{{ groups['VMs'] }}"
@@ -57,9 +58,9 @@
 - name: Copy the gzipped disk on target
   copy:
     src: "{{ hostvars[item].vm_disk }}"
-    dest: "{{ disk_pool }}/{{ hostvars[item].inventory_hostname }}.img.gz"
+    dest: "{{ deploy_vms_standalone_disk_pool }}/{{ hostvars[item].inventory_hostname }}.img.gz"
   when:
-    - disk_copy | default(true) | bool
+    - deploy_vms_standalone_disk_copy | default(true) | bool
     - hostvars[item].disk_extract is defined
     - hostvars[item].disk_extract | bool
     - item not in all_vms.list_vms or (item in all_vms.list_vms and hostvars[item].force is defined and hostvars[item].force)
@@ -67,10 +68,10 @@
 
 - name: Extract the gzipped disk on target
   command:
-    cmd: "gzip -d -f {{ disk_pool }}/{{ hostvars[item].inventory_hostname }}.img.gz"
+    cmd: "gzip -d -f {{ deploy_vms_standalone_disk_pool }}/{{ hostvars[item].inventory_hostname }}.img.gz"
     creates: "{{ hostvars[item].inventory_hostname }}.img"
   when:
-    - disk_copy | default(true) | bool
+    - deploy_vms_standalone_disk_copy | default(true) | bool
     - hostvars[item].disk_extract is defined
     - hostvars[item].disk_extract | bool
     - item not in all_vms.list_vms or (item in all_vms.list_vms and hostvars[item].force is defined and hostvars[item].force)
@@ -95,7 +96,7 @@
   loop: "{{ groups['VMs'] }}"
 
 - name: Create VMs
-  virt:
+  community.libvirt.virt:
     command: define
     xml: >-
       {{ lookup('template',
@@ -105,7 +106,7 @@
   when: item not in all_vms.list_vms or (item in all_vms.list_vms and hostvars[item].force is defined and hostvars[item].force)
 
 - name: Start VMs
-  virt:
+  community.libvirt.virt:
     name: "{{ item }}"
     state: running
   loop: "{{ groups['VMs'] }}"

--- a/roles/detect_seapath_distro/meta/main.yml
+++ b/roles/detect_seapath_distro/meta/main.yml
@@ -7,13 +7,10 @@ galaxy_info:
   license: Apache-2.0
   min_ansible_version: 2.9.10
   platforms:
-    - name: Yocto
-      versions:
-      - all
     - name: Debian
       versions:
       - all
-    - name: CentOS
+    - name: EL
       versions:
       - all
 dependencies: []

--- a/roles/detect_seapath_distro/tasks/main.yaml
+++ b/roles/detect_seapath_distro/tasks/main.yaml
@@ -17,16 +17,17 @@
   when: ansible_distribution | regex_search("CentOS|RedHat")
 
 - name: Detect Yocto distribution
+  when: seapath_distro is not defined
   block:
     - name: Search CPE_NAME field of {{ ansible_distribution_file_path }}
       command: grep 'CPE_NAME.*cpe:/o:openembedded' {{ ansible_distribution_file_path }}
       register: ret
       failed_when: ret.rc != 0 and ret.rc != 1
+      changed_when: false
     - name: Set seapath_distro for Yocto distro
       set_fact:
         seapath_distro: Yocto
       when: ret.rc == 0
-  when: seapath_distro is not defined
 
 - name: Check distro detection
   fail:

--- a/roles/iptables/handlers/main.yml
+++ b/roles/iptables/handlers/main.yml
@@ -1,0 +1,9 @@
+# Copyright (C) 2025 RTE
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Reload iptables rules if needed
+  become: true
+  ansible.builtin.shell:
+    cmd: "/usr/sbin/iptables-restore < /etc/iptables/rules.v4"
+  changed_when: true

--- a/roles/iptables/meta/main.yml
+++ b/roles/iptables/meta/main.yml
@@ -8,10 +8,7 @@ galaxy_info:
   - name: Debian
     versions:
     - all
-  - name: CentOS
-    versions:
-    - all
-  - name: Yocto
+  - name: EL
     versions:
     - all
 dependencies: []

--- a/roles/iptables/tasks/main.yml
+++ b/roles/iptables/tasks/main.yml
@@ -2,36 +2,31 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-- name: check presence of iptables_rules_path file
+- name: Check presence of iptables_rules_path file
   delegate_to: localhost
   stat:
     path: "{{ iptables_rules_path }}"
   when: iptables_rules_path is defined
   register: iptables_rules_path_present
-- name: copy iptables rules file
+- name: Copy iptables rules file
   become: true
   ansible.builtin.copy:
     src: "{{ iptables_rules_path }}"
     dest: /etc/iptables/rules.v4
     mode: "0644"
   when: iptables_rules_path is defined and iptables_rules_path_present.stat.exists
-  register: iptables_rules
-- name: check presence of iptables_rules_template_path file
+  notify: Reload iptables rules if needed
+- name: Check presence of iptables_rules_template_path file
   delegate_to: localhost
   stat:
     path: "{{ iptables_rules_template_path }}"
   when: iptables_rules_template_path is defined
   register: iptables_rules_template_path_present
-- name: copy iptables rules template file
+- name: Copy iptables rules template file
   become: true
   template:
     src: "{{ iptables_rules_template_path }}"
     dest: /etc/iptables/rules.v4
     mode: "0644"
   when: iptables_rules_template_path is defined and iptables_rules_template_path_present.stat.exists
-  register: iptables_rules_template
-- name: reload iptables rules if needed
-  become: true
-  ansible.builtin.shell:
-    cmd: "/usr/sbin/iptables-restore < /etc/iptables/rules.v4"
-  when: iptables_rules.changed or iptables_rules_template.changed
+  notify: Reload iptables rules if needed

--- a/roles/network_basics/meta/main.yml
+++ b/roles/network_basics/meta/main.yml
@@ -10,10 +10,7 @@ galaxy_info:
   - name: Debian
     versions:
     - all
-  - name: CentOS
-    versions:
-    - all
-  - name: Yocto
+  - name: EL
     versions:
     - all
 dependencies: []

--- a/roles/network_basics/tasks/main.yml
+++ b/roles/network_basics/tasks/main.yml
@@ -2,18 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-- block:
-  - name: wipe the network directory content 1/2, list files
+- when: Remove_all_network_config is defined and remove_all_network_config is true
+  block:
+  - name: Wipe the network directory content 1/2, list files
     find:
       paths: ["/etc/systemd/network/", "/etc/netplan"]
       patterns: "*"
     register: network_files_to_delete
-  - name: wipe the network directory content 2/2, remove files
+  - name: Wipe the network directory content 2/2, remove files
     file:
       path: "{{ item.path }}"
       state: absent
     with_items: "{{ network_files_to_delete.files }}"
-  when: remove_all_network_config is defined and remove_all_network_config is true
 - name: Remove FAI network configuration
   file:
     path: "/etc/systemd/network/{{ item }}.network"

--- a/roles/network_buildhosts/meta/main.yml
+++ b/roles/network_buildhosts/meta/main.yml
@@ -10,10 +10,7 @@ galaxy_info:
   - name: Debian
     versions:
     - all
-  - name: CentOS
-    versions:
-    - all
-  - name: Yocto
+  - name: EL
     versions:
     - all
 dependencies: []

--- a/roles/network_buildhosts/tasks/main.yml
+++ b/roles/network_buildhosts/tasks/main.yml
@@ -27,10 +27,10 @@
 - name: Build hosts file for Standalone machines
   lineinfile:
     dest: /etc/hosts
-    line: "{{ ip_addr | default( ansible_host ) }} {{ inventory_hostname }} {{ hostname | default('') }}"
+    line: "{{ ip_addr | default(ansible_host) }} {{ inventory_hostname }} {{ hostname | default('') }}"
     state: present
   when: inventory_hostname in groups['standalone_machine']|default([])
-- name: remove 'debian' from hosts file
+- name: Remove 'debian' from hosts file
   lineinfile:
     dest: /etc/hosts
     state: absent

--- a/roles/network_clusternetwork/handlers/main.yml
+++ b/roles/network_clusternetwork/handlers/main.yml
@@ -1,0 +1,12 @@
+# Copyright (C) 2025 RTE
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Trigger daemon-reload
+  ansible.builtin.service:
+    daemon_reload: yes
+
+- name: Restart hsr
+  ansible.builtin.systemd:
+    name: hsr
+    state: restarted

--- a/roles/network_clusternetwork/meta/main.yml
+++ b/roles/network_clusternetwork/meta/main.yml
@@ -10,10 +10,7 @@ galaxy_info:
   - name: Debian
     versions:
     - all
-  - name: CentOS
-    versions:
-    - all
-  - name: Yocto
+  - name: EL
     versions:
     - all
 dependencies: []

--- a/roles/network_clusternetwork/tasks/main.yml
+++ b/roles/network_clusternetwork/tasks/main.yml
@@ -4,8 +4,11 @@
 ---
 - name: Populate service facts
   service_facts:
-- block:
-  - name: stop and disable hsr service if it exists
+- when:
+    - cluster_protocol is not defined or cluster_protocol != "HSR" or hsr_mac_address is not defined
+    - skip_recreate_team0_config is not defined or skip_recreate_team0_config is not true
+  block:
+  - name: Stop and disable hsr service if it exists
     service:
       name: "hsr"
       state: stopped
@@ -13,60 +16,60 @@
     when: "'hsr.service' in services"
   - name: Remove team0 bridge in OVS
     command: "/usr/bin/ovs-vsctl --if-exists del-br team0"
+    changed_when: true
   - name: Create team0 bridge in OVS
     command: "/usr/bin/ovs-vsctl add-br team0"
+    changed_when: true
   - name: Add interface team0_0 to team0 bridge
     command: "/usr/bin/ovs-vsctl -- --if-exists del-port {{ team0_0 }} -- add-port team0 {{ team0_0 }}"
+    changed_when: true
   - name: Add interface team0_1 to team0 bridge
     command: "/usr/bin/ovs-vsctl -- --if-exists del-port {{ team0_1 }} -- add-port team0 {{ team0_1 }}"
+    changed_when: true
   - name: Enable RSTP on team0 bridge
     command: "/usr/bin/ovs-vsctl set Bridge team0 rstp_enable=true"
+    changed_when: true
   - name: Set RSTP priority on team0 bridge
     command: "/usr/bin/ovs-vsctl set Bridge team0 other_config=rstp-priority={{ br_rstp_priority | default(16384) }}"
+    changed_when: true
   - name: Restart conntrackd
     ansible.builtin.systemd:
       name: conntrackd
       state: restarted
     when: conntrackd_ignore_ip_list is defined
     failed_when: false
-  when:
-    - cluster_protocol is not defined or cluster_protocol != "HSR" or hsr_mac_address is not defined
-    - skip_recreate_team0_config is not defined or skip_recreate_team0_config is not true
-- block:
-  - name: copy hsr.sh script
+- when: cluster_protocol is defined and cluster_protocol == "HSR" and hsr_mac_address is defined
+  block:
+  - name: Copy hsr.sh script
     template:
       src: hsr.sh.j2
       dest: /usr/local/sbin/hsr.sh
       mode: 0755
       owner: root
       group: root
-    register: hsr1
-  - name: copy hsrstop.sh script
+    notify:
+      - Trigger daemon-reload
+      - Restart hsr
+  - name: Copy hsrstop.sh script
     template:
       src: hsrstop.sh.j2
       dest: /usr/local/sbin/hsrstop.sh
       mode: 0755
       owner: root
       group: root
-    register: hsr2
-  - name: copy hsr systemd service file
+    notify:
+      - Trigger daemon-reload
+      - Restart hsr
+  - name: Copy hsr systemd service file
     ansible.builtin.copy:
       src: hsr.service
       dest: /etc/systemd/system/hsr.service
       mode: '0644'
-    register: hsr3
-  - name: daemon-reload hsr
-    ansible.builtin.service:
-      daemon_reload: yes
-    when: hsr1.changed or hsr2.changed or hsr3.changed
-  - name: enable hsr.service
+    notify:
+     - Trigger daemon-reload
+     - Restart hsr
+  - name: Enable hsr.service
     ansible.builtin.systemd:
       name: hsr.service
       enabled: yes
-    register: hsrservice
-  - name: Restart hsr
-    ansible.builtin.systemd:
-      name: hsr
-      state: restarted
-    when: hsr1.changed or hsr2.changed or hsr3.changed or hsrservice.changed
-  when: cluster_protocol is defined and cluster_protocol == "HSR" and hsr_mac_address is defined
+    notify: Restart hsr

--- a/roles/network_configovs/meta/main.yml
+++ b/roles/network_configovs/meta/main.yml
@@ -10,9 +10,6 @@ galaxy_info:
   - name: Debian
     versions:
     - all
-  - name: CentOS
-    versions:
-    - all
-  - name: Yocto
+  - name: EL
     versions:
     - all

--- a/roles/network_configovs/tasks/main.yml
+++ b/roles/network_configovs/tasks/main.yml
@@ -8,24 +8,25 @@
   template:
     src: ovs_configuration.json.j2
     dest: /etc/ovs_configuration.json
-    validate: "{{ setup_ovs_command_path }} -v -c -f %s"
+    validate: "{{ network_configovs_setup_ovs_command_path }} -v -c -f %s"
   register: ovs_conf
 - name: Restart seapath-config_ovs
   ansible.builtin.systemd:
     name: seapath-config_ovs
     state: restarted
   when:
-    - apply_config
+    - network_configovs_apply_config
     - ovs_conf.changed
 - name: Register reboot
   set_fact:
     need_reboot: true
   when:
-    - not apply_config
+    - not network_configovs_apply_config
     - ovs_conf.changed
 
-- name: run extra ovs-vsctl configuration commands
+- name: Run extra ovs-vsctl configuration commands
   command: "/usr/bin/ovs-vsctl {{ item }}"
   when:
     - ovs_vsctl_cmds is defined
   loop: "{{ ovs_vsctl_cmds }}"
+  changed_when: true

--- a/roles/network_configovs/vars/CentOS.yml
+++ b/roles/network_configovs/vars/CentOS.yml
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-setup_ovs_command_path: "/usr/local/bin/setup_ovs"
+network_configovs_setup_ovs_command_path: "/usr/local/bin/setup_ovs"

--- a/roles/network_configovs/vars/Debian.yml
+++ b/roles/network_configovs/vars/Debian.yml
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-setup_ovs_command_path: "setup_ovs"
+network_configovs_setup_ovs_command_path: "setup_ovs"

--- a/roles/network_configovs/vars/Yocto.yml
+++ b/roles/network_configovs/vars/Yocto.yml
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-setup_ovs_command_path: "/usr/bin/setup_ovs"
+network_configovs_setup_ovs_command_path: "/usr/bin/setup_ovs"

--- a/roles/network_guestsinterfaces/handlers/main.yml
+++ b/roles/network_guestsinterfaces/handlers/main.yml
@@ -1,0 +1,8 @@
+# Copyright (C) 2025 RTE
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Reload systemd-networkd configuration
+  ansible.builtin.service:
+    name: systemd-networkd
+    state: reloaded

--- a/roles/network_guestsinterfaces/meta/main.yml
+++ b/roles/network_guestsinterfaces/meta/main.yml
@@ -10,10 +10,7 @@ galaxy_info:
   - name: Debian
     versions:
     - all
-  - name: CentOS
-    versions:
-    - all
-  - name: Yocto
+  - name: EL
     versions:
     - all
 dependencies: []

--- a/roles/network_guestsinterfaces/tasks/main.yml
+++ b/roles/network_guestsinterfaces/tasks/main.yml
@@ -6,7 +6,7 @@
     var: item.value
   with_items: "{{ interfaces_on_br0 | dict2items }}"
   when: interfaces_on_br0 is defined
-- name: create 00-INTERFACEX.netdev
+- name: Create 00-INTERFACEX.netdev
   template:
     src: 00-INTERFACEX.netdev.j2
     dest: /etc/systemd/network/00-{{ item.key }}.netdev
@@ -15,8 +15,8 @@
     mode: '0644'
   with_items: "{{ interfaces_on_br0 | dict2items }}"
   when: interfaces_on_br0 is defined
-  register: interfaces_br0_netdev
-- name: create 00-INTERFACEX.network
+  notify: Reload systemd-networkd configuration
+- name: Create 00-INTERFACEX.network
   template:
     src: 00-INTERFACEX.network.j2
     dest: /etc/systemd/network/00-{{ item.key }}.network
@@ -25,10 +25,4 @@
     mode: '0644'
   with_items: "{{ interfaces_on_br0 | dict2items }}"
   when: interfaces_on_br0 is defined
-  register: interfaces_br0_network
-- name: Reload systemd-networkd configuration
-  ansible.builtin.service:
-    name: systemd-networkd
-    state: reloaded
-  when: interfaces_br0_netdev.changed or interfaces_br0_netdev.changed
-
+  notify: Reload systemd-networkd configuration

--- a/roles/network_netplan/handlers/main.yml
+++ b/roles/network_netplan/handlers/main.yml
@@ -1,2 +1,3 @@
 - name: Apply Netplan configuration
   command: netplan apply
+  changed_when: true

--- a/roles/network_netplan/meta/main.yml
+++ b/roles/network_netplan/meta/main.yml
@@ -10,10 +10,7 @@ galaxy_info:
   - name: Debian
     versions:
     - all
-  - name: CentOS
-    versions:
-    - all
-  - name: Yocto
+  - name: EL
     versions:
     - all
 dependencies: []

--- a/roles/network_netplan/tasks/main.yml
+++ b/roles/network_netplan/tasks/main.yml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-- block:
+- when: netplan_configurations is defined
+  block:
     - name: Create /etc/netplan directory
       file:
         path: /etc/netplan
@@ -19,7 +20,6 @@
         mode: '0600'
       with_items: "{{ netplan_configurations }}"
       notify: Apply Netplan configuration
-    - name: avoid reboot for netplan
+    - name: Avoid reboot for netplan
       set_fact:
         need_reboot: false
-  when: netplan_configurations is defined

--- a/roles/network_networkdwait/meta/main.yml
+++ b/roles/network_networkdwait/meta/main.yml
@@ -10,10 +10,7 @@ galaxy_info:
   - name: Debian
     versions:
     - all
-  - name: CentOS
-    versions:
-    - all
-  - name: Yocto
+  - name: EL
     versions:
     - all
 dependencies: []

--- a/roles/network_networkdwait/tasks/main.yml
+++ b/roles/network_networkdwait/tasks/main.yml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-- block:
+- when: netplan_configurations is not defined
+  block:
     - name: Create systemd-networkd-wait-online.service.d directory
       file:
         path: /etc/systemd/system/systemd-networkd-wait-online.service.d/
@@ -14,9 +15,7 @@
       template:
         src: systemd-networkd-wait-online.service.j2
         dest: /etc/systemd/system/systemd-networkd-wait-online.service.d/override.conf
-    - name: enable systemd-networkd-wait-online.service
+    - name: Enable systemd-networkd-wait-online.service
       ansible.builtin.systemd:
         name: systemd-networkd-wait-online.service
         enabled: yes
-  when: netplan_configurations is not defined
-

--- a/roles/network_resolved/handlers/main.yml
+++ b/roles/network_resolved/handlers/main.yml
@@ -1,0 +1,9 @@
+# Copyright (C) 2024 RTE
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Restart systemd-resolved
+  ansible.builtin.systemd:
+    name: systemd-resolved
+    state: restarted
+    enabled: true

--- a/roles/network_resolved/meta/main.yml
+++ b/roles/network_resolved/meta/main.yml
@@ -10,10 +10,7 @@ galaxy_info:
   - name: Debian
     versions:
     - all
-  - name: CentOS
-    versions:
-    - all
-  - name: Yocto
+  - name: EL
     versions:
     - all
 dependencies: []

--- a/roles/network_resolved/tasks/main.yml
+++ b/roles/network_resolved/tasks/main.yml
@@ -2,47 +2,40 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-- block:
-  - name: configure LLMNR /etc/systemd/resolved.conf
+- when:
+  - dns_servers is defined
+  - netplan_configurations is not defined
+  block:
+  - name: Configure LLMNR /etc/systemd/resolved.conf
     lineinfile:
       dest: /etc/systemd/resolved.conf
       regexp: "^#?LLMNR="
       line: "LLMNR=no"
       state: present
-    register: resolved_conf1
-  - name: configure DNS /etc/systemd/resolved.conf
+    notify: Restart systemd-resolved
+  - name: Configure DNS /etc/systemd/resolved.conf
     lineinfile:
       dest: /etc/systemd/resolved.conf
       regexp: "^#?DNS="
       line: "DNS={{ dns_servers | join(' ') if dns_servers is not string else dns_servers }}"
       state: present
-    register: resolved_conf2
+    notify: Restart systemd-resolved
   - name: Create resolv.conf stub link
     ansible.builtin.file:
       src: /run/systemd/resolve/resolv.conf
       dest: /etc/resolv.conf
       state: link
       force: true
-    register: resolved_conf3
+    notify: Restart systemd-resolved
   - name: Enable systemd-resolved
     ansible.builtin.systemd:
       name: systemd-resolved
       state: started
       enabled: true
-  - name: Restart systemd-resolved
-    ansible.builtin.systemd:
-      name: systemd-resolved
-      state: restarted
-      enabled: true
-    when: resolved_conf1.changed or resolved_conf2.changed or resolved_conf3.changed
-  when:
-  - dns_servers is defined
-  - netplan_configurations is not defined
 
-- name: disable resolved if no dns server is defined
+- name: Disable resolved if no dns server is defined
   ansible.builtin.systemd:
     name: systemd-resolved
     state: stopped
     enabled: false
   when: dns_servers is not defined
-

--- a/roles/network_sriovpool/meta/main.yml
+++ b/roles/network_sriovpool/meta/main.yml
@@ -10,10 +10,7 @@ galaxy_info:
   - name: Debian
     versions:
     - all
-  - name: CentOS
-    versions:
-    - all
-  - name: Yocto
+  - name: EL
     versions:
     - all
 dependencies: []

--- a/roles/network_sriovpool/tasks/main.yml
+++ b/roles/network_sriovpool/tasks/main.yml
@@ -6,23 +6,27 @@
     msg: "the network pool name is {{ sriov_network_pool_name }}"
 - name: Try to get sriov network pool
   shell:
-    cmd: virsh -q net-list --all | awk '{ print $1 }' | grep -q "{{ sriov_network_pool_name }}"
+    cmd: set -o pipefail && virsh -q net-list --all | awk '{ print $1 }' | grep -q "{{ sriov_network_pool_name }}"
+    executable: /bin/bash
   register: pool_defined
   failed_when: pool_defined.rc > 1
   changed_when: false
-- block:
+- when: pool_defined.rc != 0
+  block:
     - name: Copy libvirt xml SRIOV network pool file
       template:
           src: sriov_network_pool.xml.j2
           dest: /tmp/sriov_network_pool.xml
     - name: Create libvirt SRIOV network pool
       command: "virsh net-define /tmp/sriov_network_pool.xml"
+      changed_when: true
     - name: AutoStart libvirt SRIOV network pool
       command: "virsh net-autostart {{ sriov_network_pool_name }}"
+      changed_when: true
     - name: Start libvirt SRIOV network pool
       command: "virsh net-start {{ sriov_network_pool_name }}"
+      changed_when: true
     - name: Remove temporary file
       file:
           path: /tmp/sriov_network_pool.xml
           state: absent
-  when: pool_defined.rc != 0

--- a/roles/network_sriovpool/templates/sriov_network_pool.xml.j2
+++ b/roles/network_sriovpool/templates/sriov_network_pool.xml.j2
@@ -1,6 +1,6 @@
 <network>
-<name>{{ sriov_network_pool_name }}</name>
+<name>{{ network_sriovpool_sriov_network_pool_name }}</name>
 <forward mode='hostdev' managed='yes'>
-<pf dev='{{ interface }}'/>
+<pf dev='{{ network_sriovpool_interface }}'/>
 </forward>
 </network>

--- a/roles/ptp_status_vsock/tasks/main.yml
+++ b/roles/ptp_status_vsock/tasks/main.yml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-- name: ptp/vsock when ptp_interface is enabled
+- name: Ptp/vsock when ptp_interface is enabled
+  when: ptp_interface is defined
   block:
     - name: Create ptp directory
       ansible.builtin.file:
@@ -32,18 +33,17 @@
         dest: /etc/systemd/system/ptp_vsock.service
         mode: '0644'
       register: ptpvsock
-    - name: daemon-reload ptp status
+    - name: Daemon-reload ptp status
       ansible.builtin.service:
         daemon_reload: yes
       when: ptpstatus.changed or ptpvsock.changed
-    - name: enable ptpstatus.service
+    - name: Enable ptpstatus.service
       ansible.builtin.systemd:
         name: ptpstatus.service
         enabled: yes
         state: started
-    - name: enable ptp_vsock.service
+    - name: Enable ptp_vsock.service
       ansible.builtin.systemd:
         name: ptp_vsock.service
         enabled: yes
         state: started
-  when: ptp_interface is defined

--- a/roles/snmp/meta/main.yml
+++ b/roles/snmp/meta/main.yml
@@ -10,6 +10,6 @@ galaxy_info:
   - name: Debian
     versions:
     - all
-  - name: Centos
+  - name: EL
     versions:
     - all

--- a/roles/snmp/tasks/main.yml
+++ b/roles/snmp/tasks/main.yml
@@ -4,13 +4,14 @@
 ---
 - include_vars: "{{ seapath_distro }}.yml"
 
-- name: configure snmp
+- name: Configure snmp
+  when: snmp_admin_ip_addr is defined
   block:
-  - name: get {{ snmp_user_name }} uid
+  - name: Get uid for {{ snmp_user_name }}
     getent:
       database: passwd
       key: "{{ snmp_user_name }}"
-  - name: get {{ snmp_user_name }} gid
+  - name: Get gid for {{ snmp_user_name }}
     getent:
       database: group
       key: "{{ snmp_user_name }}"
@@ -19,25 +20,25 @@
         - "user id {{ getent_passwd[snmp_user_name][1] }}"
         - "group id {{ getent_group[snmp_user_name][1] }}"
 
-  - name: Set {{ snmp_user_name }} correct uid/gid
+  - name: Set correct uid/gid for {{ snmp_user_name }}
+    when: getent_passwd[snmp_user_name][1] != '902' or getent_group[snmp_user_name][1] != '902'
     block:
-      - name: stop snmpd if needed
+      - name: Stop snmpd if needed
         ansible.builtin.systemd:
           name: snmpd.service
           state: stopped
-      - name: Ensure group "{{ snmp_user_name }}" exists with correct gid
+      - name: Ensure group exists with correct gid for "{{ snmp_user_name }}"
         ansible.builtin.group:
           name: "{{ snmp_user_name }}"
           state: present
           gid: 902
-      - name: Ensure user {{ snmp_user_name }} has correct uid and gid
+      - name: Ensure user has correct uid and gid for {{ snmp_user_name }}
         user:
           name: "{{ snmp_user_name }}"
           uid: 902
           group: "{{ snmp_user_name }}"
-    when: getent_passwd[snmp_user_name][1] != '902' or getent_group[snmp_user_name][1] != '902'
 
-  - name: temp fix for synchronize to force evaluate variables
+  - name: Temp fix for synchronize to force evaluate variables
     set_fact:
       ansible_host: "{{ ansible_host }}"
 
@@ -62,12 +63,12 @@
       src: exposeseapathsnmp.pl
       dest: "/usr/local/bin/exposeseapathsnmp.pl"
       mode: '0755'
-  - name: script run by cron job to generate snmp data
+  - name: Script run by cron job to generate snmp data
     copy:
       src: snmp_getdata.py
       dest: "/usr/local/sbin/snmp_getdata.py"
       mode: '0755'
-  - name: cron job to generate snmp data
+  - name: Cron job to generate snmp data
     copy:
       src: seapathsnmp.cron
       dest: "/etc/cron.d/seapathsnmp"
@@ -80,9 +81,10 @@
       state: present
 
   - name: SNMP V3
+    when: snmp_accounts is defined and snmp_accounts | length > 0
     block:
       # restart is needed for /var/lib/snmp/snmpd.conf to exist
-      - name: restart snmpd
+      - name: Restart snmpd
         ansible.builtin.systemd:
           name: snmpd.service
           state: restarted
@@ -103,22 +105,20 @@
           create: yes
           insertbefore: BOF
         loop: "{{ snmp_accounts }}"
-    when: snmp_accounts is defined and snmp_accounts | length > 0
 
-  - name: restart snmpd
+  - name: Restart snmpd
     ansible.builtin.systemd:
       name: snmpd.service
       state: restarted
       enabled: yes
 
-  - name: Install sudo {{ snmp_user_name }} user rules
+  - name: Install sudo user rules for {{ snmp_user_name }}
     template:
       src: sudoers_snmp.j2
       dest: "/etc/sudoers.d/{{ snmp_user_name }}"
       owner: root
       group: root
       mode: '0440'
-  when: snmp_admin_ip_addr is defined
 
 - name: Disable snmp if it is not needed
   systemd:

--- a/roles/timemaster/README.md
+++ b/roles/timemaster/README.md
@@ -8,14 +8,14 @@ No requirement.
 
 ## Role Variables
 
-| Variable              | Required | Type    | Default | Comments                                                                                                                               |
-|-----------------------|----------|---------|---------|----------------------------------------------------------------------------------------------------------------------------------------|
-| seapath_distro        | yes      | String  |         | SEAPATH variant. CentOS, Debian or Yocto. The variable can be set automatically using the detect_seapath_distro role                   |
-| ptp_interface         | no       | String  |         | Network interface to use for PTP. The interface must support PTP hardware reception. If not set the PTP configuration will be skipped. |
-| ptp_vlanid            | no       | Integer |         | Optional VLAN ID to use with PTP                                                                                                       |
-| ntp_servers           | no       | String  |         | List of NTP/SNTP servers separated by a new line. If not set NTP configuration will be skipped                                         |
-| ptp_network_transport | no       | String  | "L2"    | PTP transport configuration. "L2" or "UDP"                                                                                             |
-| ptp_delay_mechanism   | no       | String  | "P2P"   | PTP delay mechanism. "P2P" or "E2E"                                                                                                    |
+| Variable                         | Required | Type    | Default | Comments                                                                                                                               |
+|----------------------------------|----------|---------|---------|----------------------------------------------------------------------------------------------------------------------------------------|
+| seapath_distro                   | yes      | String  |         | SEAPATH variant. CentOS, Debian or Yocto. The variable can be set automatically using the detect_seapath_distro role                   |
+| ptp_interface                    | no       | String  |         | Network interface to use for PTP. The interface must support PTP hardware reception. If not set the PTP configuration will be skipped. |
+| ptp_vlanid                       | no       | Integer |         | Optional VLAN ID to use with PTP                                                                                                       |
+| ntp_servers                      | no       | String  |         | List of NTP/SNTP servers separated by a new line. If not set NTP configuration will be skipped                                         |
+| timemaster_ptp_network_transport | no       | String  | "L2"    | PTP transport configuration. "L2" or "UDP"                                                                                             |
+| timemaster_ptp_delay_mechanism   | no       | String  | "P2P"   | PTP delay mechanism. "P2P" or "E2E"                                                                                                    |
 
 
 ## Example Playbook

--- a/roles/timemaster/defaults/main.yml
+++ b/roles/timemaster/defaults/main.yml
@@ -1,6 +1,0 @@
-# Copyright (C) 2024 Savoir-faire Linux, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
----
-ptp_network_transport: "L2"
-ptp_delay_mechanism: "P2P"

--- a/roles/timemaster/handlers/main.yml
+++ b/roles/timemaster/handlers/main.yml
@@ -1,0 +1,10 @@
+# Copyright (C) 2025 RTE
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Restart timemaster
+  service:
+    name: "timemaster"
+    state: restarted
+    enabled: true
+    daemon_reload: true

--- a/roles/timemaster/meta/main.yml
+++ b/roles/timemaster/meta/main.yml
@@ -10,9 +10,6 @@ galaxy_info:
   - name: Debian
     versions:
     - all
-  - name: CentOS
-    versions:
-    - all
-  - name: Yocto
+  - name: EL
     versions:
     - all

--- a/roles/timemaster/tasks/main.yml
+++ b/roles/timemaster/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: Populate service facts
   service_facts:
-- name: stop and disable systemd-timesyncd if it exists
+- name: Stop and disable systemd-timesyncd if it exists
   service:
     name: "systemd-timesyncd"
     state: stopped
@@ -15,14 +15,14 @@
 - name: Create timemaster configuration
   template:
     src: timemaster.conf.j2
-    dest: "{{ path_timemaster_conf }}"
-  register: timemasterconf1
-- name: comment pool configuration in chrony.conf
+    dest: "{{ timemaster_path_timemaster_conf }}"
+  notify: Restart timemaster
+- name: Comment pool configuration in chrony.conf
   replace:
-    path: "{{ path_chrony_conf }}"
+    path: "{{ timemaster_path_chrony_conf }}"
     regexp: '^(pool .*)'
     replace: '#\1'
-  register: timemasterconf2
+  notify: Restart timemaster
 - name: Create timemaster.service.d directory
   file:
     path: /etc/systemd/system/timemaster.service.d/
@@ -30,25 +30,18 @@
     owner: root
     group: root
     mode: 0755
+  notify: Restart timemaster
 - name: Copy timemaster.service overide
   template:
     src: timemaster.service.j2
     dest: /etc/systemd/system/timemaster.service.d/override.conf
-  register: timemasterconf3
+  notify: Restart timemaster
 - name: Enable timemaster
   service:
     name: "timemaster"
     enabled: true
-- name: restart timemaster if necessary
+- name: Stop and disable chrony
   service:
-    name: "timemaster"
-    state: restarted
-    enabled: true
-    daemon_reload: true
-  when:
-    - timemasterconf1.changed or timemasterconf2.changed or timemasterconf3.changed
-- name: stop and disable chrony
-  service:
-    name: "{{ service_name_chrony }}"
+    name: "{{ timemaster_service_name_chrony }}"
     state: stopped
     enabled: false

--- a/roles/timemaster/templates/timemaster.conf.j2
+++ b/roles/timemaster/templates/timemaster.conf.j2
@@ -22,7 +22,7 @@ delay 1e-9
 ntp_program chronyd
 
 [chrony.conf]
-include {{ path_chrony_conf }}
+include {{ timemaster_path_chrony_conf }}
 {% if ntp_servers is defined %}
 {%- for line in ntp_servers %}{% if ptp_interface is not defined and loop.index==1 %}server {{ line }} trust iburst maxsamples 10 minsamples 10 maxpoll 6 minpoll 6
 {% else %}server {{ line }} iburst maxsamples 10 minsamples 10 maxpoll 6 minpoll 6
@@ -37,8 +37,8 @@ slaveOnly             1
 
 # IEC 61850-9-3 Profile
 # (from : https://en.wikipedia.org/wiki/IEC/IEEE_61850-9-3)
-network_transport     {{ ptp_network_transport }}
-delay_mechanism       {{ ptp_delay_mechanism }}
+network_transport     {{ ptp_network_transport | default ('L2') }}
+delay_mechanism       {{ ptp_delay_mechanism | default ('P2P') }}
 domainNumber             0
 
 # Announce interval: 1s

--- a/roles/timemaster/vars/CentOS.yml
+++ b/roles/timemaster/vars/CentOS.yml
@@ -2,6 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-path_timemaster_conf: "/etc/timemaster.conf"
-path_chrony_conf: "/etc/chrony.conf"
-service_name_chrony: "chronyd"
+timemaster_path_timemaster_conf: "/etc/timemaster.conf"
+timemaster_path_chrony_conf: "/etc/chrony.conf"
+timemaster_service_name_chrony: "chronyd"

--- a/roles/timemaster/vars/Debian.yml
+++ b/roles/timemaster/vars/Debian.yml
@@ -2,6 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-path_timemaster_conf: "/etc/linuxptp/timemaster.conf"
-path_chrony_conf: "/etc/chrony/chrony.conf"
-service_name_chrony: "chrony"
+timemaster_path_timemaster_conf: "/etc/linuxptp/timemaster.conf"
+timemaster_path_chrony_conf: "/etc/chrony/chrony.conf"
+timemaster_service_name_chrony: "chrony"

--- a/roles/timemaster/vars/Yocto.yml
+++ b/roles/timemaster/vars/Yocto.yml
@@ -2,6 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-path_timemaster_conf: "/etc/linuxptp/timemaster.conf"
-path_chrony_conf: "/etc/chrony.conf"
-service_name_chrony: "chronyd"
+timemaster_path_timemaster_conf: "/etc/linuxptp/timemaster.conf"
+timemaster_path_chrony_conf: "/etc/chrony.conf"
+timemaster_service_name_chrony: "chronyd"

--- a/roles/update/README.md
+++ b/roles/update/README.md
@@ -12,7 +12,7 @@ No requirement.
 
 | Variable                | Required | Type   | Default   | Comments                                         |
 |-------------------------|----------|--------|-----------|--------------------------------------------------|
-| swu_image               | yes      | String | swu_image | Path of the swupdate file on the Ansible machine |
+| update_swu_image        | yes      | String | swu_image | Path of the swupdate file on the Ansible machine |
 
 ## Dependencies
 

--- a/roles/update/defaults/main.yaml
+++ b/roles/update/defaults/main.yaml
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-swu_image: update.swu
+update_swu_image: update.swu

--- a/roles/update/meta/main.yml
+++ b/roles/update/meta/main.yml
@@ -6,9 +6,4 @@ galaxy_info:
   description: Update a SEAPATH machine
   min_ansible_version: 2.9.10
   license: Apache-2.0
-  platforms:
-  - name: Yocto
-    versions:
-    - all
-
 dependencies: []

--- a/roles/update/tasks/main.yaml
+++ b/roles/update/tasks/main.yaml
@@ -7,6 +7,7 @@
   command: swupdate -v
   register: swupdate_version
   ignore_errors: yes
+  changed_when: false
 - fail:
     msg: "Only Swupdate update is supported"
   when: swupdate_version.rc != 0
@@ -17,23 +18,27 @@
     path: /etc/corosync/corosync.conf
   register: corosync_conf
 
-- block:
+- when: corosync_conf.stat.exists
+  block:
     - name: Set hypervisor in maintenance mode
       command: crm node standby "{{ inventory_hostname }}"
+      changed_when: true
     - name: Wait for all ressources to be migrated
       shell:
-        cmd: crm status|grep "Migrating"|wc -l
+        cmd: set -o pipefail && crm status|grep "Migrating"|wc -l
+        executable: /bin/bash
+      changed_when: false
       register: check_migration
       until: check_migration.stdout == '0'
       retries: 10
-  when: corosync_conf.stat.exists
 
 - name: Copy SWU file on machine
   copy:
-    src: "{{ swu_image_path }}"
+    src: "{{ update_swu_image_path }}"
     dest: "/tmp/update.swu"
 - name: Apply update
   command: swupdate -i /tmp/update.swu
+  changed_when: true
 - name: Reboot host
   reboot:
     msg: "Reboot initiated by Ansible"
@@ -45,17 +50,21 @@
 - name: Wait systemd has finished to boot
   command: systemctl is-system-running --wait
   register: system_status
+  changed_when: false
   failed_when: system_status.rc != 0 and system_status.rc != 1
   tags:
     - skip_ansible_lint
 
 
-- name: unset maintenance mode for hypervisor
+- name: Unset maintenance mode for hypervisor
   command: crm node online "{{ inventory_hostname }}"
   when: corosync_conf.stat.exists
+  changed_when: true
 
 - name: Check if update has succeed
   shell:
-    cmd: journalctl -u swupdate_check.service -b |grep "Update have failed"|wc -l
+    cmd: set -o pipefail && journalctl -u swupdate_check.service -b |grep "Update have failed"|wc -l
+    executable: /bin/bash
   register: update_status
   failed_when: update_status.stdout != '0'
+  changed_when: false

--- a/roles/vmmgrapi/tasks/main.yml
+++ b/roles/vmmgrapi/tasks/main.yml
@@ -8,17 +8,18 @@
 #- name: Print service facts
 #  ansible.builtin.debug:
 #    var: ansible_facts.services
-- name: install vm-mgr http interface
+- name: Install vm-mgr http interface
   vars:
     vmmgrapi_certs_dir: "/var/local/vmmgrapi/certs"
+  when: Enable_vmmgr_http_api is defined and enable_vmmgr_http_api is true
   block:
-    - name: create vm-mgr api certs folder
+    - name: Create vm-mgr api certs folder
       file:
         path: "{{ vmmgrapi_certs_dir }}"
         state: directory
         mode: 0755
 
-    - name: upload cert/key if provided
+    - name: Upload cert/key if provided
       copy:
         src: "{{ item }}"
         dest: "{{ vmmgrapi_certs_dir }}/{{ item }}"
@@ -30,7 +31,7 @@
         - vmmgr_http_tls_crt_path is defined
         - vmmgr_http_tls_key_path is defined
 
-    - name: create certificat / key if not provided
+    - name: Create certificat / key if not provided
       command: openssl req -x509 -nodes -days 9125 -newkey rsa:4096 -subj "/C=FR/ST=seapath/L=seapath/O=seapath/OU=seapath/CN=seapath" -keyout "{{ vmmgrapi_certs_dir }}/seapath.key" -out "{{ vmmgrapi_certs_dir }}/seapath.crt"
       args:
         creates: "{{ item }}"
@@ -68,7 +69,7 @@
         mode: '0600'
       register: nginx_conf
 
-    - name: restart nginx if needed
+    - name: Restart nginx if needed
       ansible.builtin.systemd:
         name: nginx.service
         enabled: no
@@ -95,27 +96,25 @@
         - gunicorn.service
       register: vmmgrapi_systemd
 
-    - name: daemon-reload vmmgrapi
+    - name: Daemon-reload vmmgrapi # noqa: no-handler
       ansible.builtin.service:
         daemon_reload: yes
       when: vmmgrapi_systemd.changed
 
-    - name: restart gunicorn.socket if needed
+    - name: Restart gunicorn.socket if needed # noqa: no-handler
       ansible.builtin.systemd:
         name: gunicorn.socket
         enabled: yes
         state: restarted
       when: vmmgrapi_systemd.changed
 
-    - name: start and enable gunicorn.socket
+    - name: Start and enable gunicorn.socket
       ansible.builtin.systemd:
         name: gunicorn.socket
         enabled: yes
         state: started
 
-  when: enable_vmmgr_http_api is defined and enable_vmmgr_http_api is true
-
-- name: disable gunicorn.socket if http flask api is not enabled
+- name: Disable gunicorn.socket if http flask api is not enabled
   ansible.builtin.systemd:
     name: gunicorn.socket
     enabled: no
@@ -124,14 +123,14 @@
     - enable_vmmgr_http_api is not defined or enable_vmmgr_http_api is false
     - services['gunicorn.socket'] is defined
 
-- name: disable nginx.service all the time, if it exists
+- name: Disable nginx.service all the time, if it exists
   ansible.builtin.systemd:
     name: nginx.service
     enabled: no
   when:
     - services['nginx.service'] is defined
 
-- name: disable gunicorn.service all the time, if it exists
+- name: Disable gunicorn.service all the time, if it exists
   ansible.builtin.systemd:
     name: gunicorn.service
     enabled: no

--- a/roles/yocto/README.md
+++ b/roles/yocto/README.md
@@ -12,7 +12,7 @@ No requirement.
 |---------------------------|---------------------------|----------|---------|---------|-------------------------------------------|
 | extra_kernel_parameters   | extra_kernel_parameters   | No       | String  |         | Extra kernel parameter to set             |
 | kernel_parameters_restart | kernel_parameters_restart | No       | Bool    | false   | Restart after the kernel parameter update |
-| hugepages                 | hugepages                 | No       | Integer | 0       | One GB hugepages to allocate              |
+| yocto_hugepages           | hugepages                 | No       | Integer | 0       | One GB hugepages to allocate              |
 
 ## Example Playbook
 

--- a/roles/yocto/hugepages/defaults/main.yaml
+++ b/roles/yocto/hugepages/defaults/main.yaml
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-hugepages: 0
+yocto_hugepages: 0

--- a/roles/yocto/hugepages/tasks/main.yaml
+++ b/roles/yocto/hugepages/tasks/main.yaml
@@ -8,7 +8,7 @@
 ---
 - name: Setup hugepages number
   copy:
-    content: "{{ hugepages | string }}"
+    content: "{{ yocto_hugepages | string }}"
     dest: /etc/hugepages_nb.conf
   notify:
     - Restart hugepages service

--- a/roles/yocto/kernel_params/tasks/main.yaml
+++ b/roles/yocto/kernel_params/tasks/main.yaml
@@ -19,19 +19,21 @@
     - extra_kernel_parameters is defined
     - extra_param_raw.rc == 1
 
-- block:
+- when: extra_param_needed is defined
+  block:
     - name: Mount the boot partition if needed
       command: /usr/share/update/mount_boot.sh
+      changed_when: true
     - name: Set extra kernel parameters
       replace:
-        path: "{{ config_file }}"
+        path: "{{ yocto_config_file }}"
         regexp: '(root=.*)'
         replace: '\1 {{ extra_kernel_parameters }}'
       when: extra_param_needed is defined
     - name: Umount the boot partition
       command: /usr/share/update/mount_boot.sh umount
+      changed_when: true
     - include_tasks: soft_restart_machine.yaml
       when:
         - kernel_parameters_restart is defined
         - kernel_parameters_restart
-  when: extra_param_needed is defined

--- a/roles/yocto/kernel_params/vars/main.yaml
+++ b/roles/yocto/kernel_params/vars/main.yaml
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-config_file: "/boot/EFI/BOOT/grub.cfg"
+yocto_config_file: "/boot/EFI/BOOT/grub.cfg"

--- a/roles/yocto/meta/main.yml
+++ b/roles/yocto/meta/main.yml
@@ -6,9 +6,4 @@ galaxy_info:
   description: Prerequisite for all yocto machine
   min_ansible_version: 2.9.10
   license: Apache-2.0
-  platforms:
-  - name: Yocto
-    versions:
-    - all
 dependencies: []
-

--- a/vars/network_defaults.yml
+++ b/vars/network_defaults.yml
@@ -37,7 +37,7 @@ br0vlan_systemd_networkd_network:
   79-wired:
     - Match:
         - Name: "{{ network_interface }}"
-    - Network: "{{ [ {'Bridge': 'br0'} ] + extra_network_config | default([]) }}"
+    - Network: "{{ [{'Bridge': 'br0'}] + extra_network_config | default([]) }}"
     - BridgeVLAN:
         - VLAN: "1-4094"
 
@@ -57,7 +57,7 @@ br0_systemd_networkd_network:
   79-wired:
     - Match:
         - Name: "{{ network_interface }}"
-    - Network: "{{ [ {'Bridge': 'br0'} ] + extra_network_config | default([]) }}"
+    - Network: "{{ [{'Bridge': 'br0'}] + extra_network_config | default([]) }}"
 
 wired_systemd_networkd_netdev: "{{ br0vlan_systemd_networkd_netdev if br0vlan is defined else br0_systemd_networkd_netdev }}"
 wired_systemd_networkd_network: "{{ br0vlan_systemd_networkd_network if br0vlan is defined else br0_systemd_networkd_network }}"
@@ -65,5 +65,6 @@ wired_systemd_networkd_network: "{{ br0vlan_systemd_networkd_network if br0vlan 
 systemd_networkd_netdev_nocluster: "{{ wired_systemd_networkd_netdev | combine(systemd_networkd_netdev_custom) }}"
 systemd_networkd_network_nocluster: "{{ wired_systemd_networkd_network | combine(systemd_networkd_network_custom) }}"
 
-systemd_networkd_network: "{{ systemd_networkd_network_nocluster|combine(team0_systemd_networkd_network) if cluster_ip_addr is defined else systemd_networkd_network_nocluster}}"
+systemd_networkd_network: "{{ systemd_networkd_network_nocluster | combine(team0_systemd_networkd_network) if
+ cluster_ip_addr is defined else systemd_networkd_network_nocluster }}"
 systemd_networkd_netdev: "{{ systemd_networkd_netdev_nocluster }}"

--- a/vars/network_team0.yml
+++ b/vars/network_team0.yml
@@ -9,15 +9,15 @@ team0_systemd_networkd_network:
     - Match:
         - Name: "team0"
     - Network:
-        - Address: "{{ cluster_ip_addr|default('0') }}/{{ team0subnet | default(24) }}"
+        - Address: "{{ cluster_ip_addr | default('0') }}/{{ team0subnet | default(24) }}"
   79-team0_0:
     - Match:
-        - Name: "{{ team0_0|default('0') }}"
+        - Name: "{{ team0_0 | default('0') }}"
     - Link:
         - MTUBytes: 1800
   79-team0_1:
     - Match:
-        - Name: "{{ team0_1|default('0') }}"
+        - Name: "{{ team0_1 | default('0') }}"
     - Link:
         - MTUBytes: 1800
 


### PR DESCRIPTION
Moving to newest version of ceph and then ansible will make seapath use the newest version of ansible lint, for which the current configuration reports more than a thousands errors.
We choose to add the "fqcn-builtins" exception (and spare 500 errors that way) and then adapt the code to solve the other 500-600 errors.