### PR TITLE
deploy_cukinia_tests: fix owner of copied files

### DIFF
--- a/roles/deploy_cukinia_tests/tasks/main.yml
+++ b/roles/deploy_cukinia_tests/tasks/main.yml
@@ -7,6 +7,7 @@
     src: cukinia-tests/cukinia
     dest: /etc/
     delete: true
+    owner: false
     rsync_opts:
       - "--exclude=*.j2"
 - name: Copy Cukinia's tests templates


### PR DESCRIPTION
If the user running ansible-playbook is not root, the owner of the copied files will be the user running the playbook. This is not desirable, as the files should be owned by root.