### PR TITLE
Switch setup_ovs installation to pip-based instead of the deprecated setup.py

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,6 +14,7 @@
 [submodule "roles/deploy_python3_setup_ovs/files/python3-setup-ovs"]
 	path = roles/deploy_python3_setup_ovs/files/python3-setup-ovs
 	url = https://github.com/seapath/python3-setup-ovs.git
+        branch = main
 [submodule "roles/deploy_vm_manager/files/vm_manager"]
 	path = roles/deploy_vm_manager/files/vm_manager
 	url = https://github.com/seapath/vm_manager.git

--- a/roles/deploy_python3_setup_ovs/files/seapath-config_ovs.service
+++ b/roles/deploy_python3_setup_ovs/files/seapath-config_ovs.service
@@ -10,7 +10,7 @@ Before=systemd-networkd.service
 [Service]
 Type=oneshot
 RemainAfterExit=true
-ExecStart=/usr/local/bin/setup_ovs.py
+ExecStart=/usr/local/bin/setup_ovs
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/deploy_python3_setup_ovs/tasks/main.yml
+++ b/roles/deploy_python3_setup_ovs/tasks/main.yml
@@ -10,7 +10,7 @@
       - "--chown=root:root"
 - name: Install python3-setup-ovs
   command:
-    cmd: /usr/bin/python3 setup.py install
+    cmd: /usr/bin/pip install --root-user-action=ignore --prefix=/usr/ .
     chdir: /tmp/src/python3-setup-ovs
 - name: Copy seapath-config_ovs.service
   ansible.builtin.copy:

--- a/roles/network_configovs/vars/CentOS.yml
+++ b/roles/network_configovs/vars/CentOS.yml
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-setup_ovs_command_path: "/usr/local/bin/setup_ovs.py"
+setup_ovs_command_path: "/usr/local/bin/setup_ovs"

--- a/roles/network_configovs/vars/Debian.yml
+++ b/roles/network_configovs/vars/Debian.yml
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-setup_ovs_command_path: "setup_ovs.py"
+setup_ovs_command_path: "setup_ovs"

--- a/roles/network_configovs/vars/Yocto.yml
+++ b/roles/network_configovs/vars/Yocto.yml
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-setup_ovs_command_path: "/usr/bin/setup_ovs.py"
+setup_ovs_command_path: "/usr/bin/setup_ovs"


### PR DESCRIPTION
Switch setup_ovs installation to pip-based instead of the deprecated setup.py
This prevents a warning with python 3.12