### PR TITLE
debian hardening: add cap_setpcap to pacemaker

### DIFF
--- a/roles/debian_hardening_physical_machine/files/pacemaker_hardening.conf
+++ b/roles/debian_hardening_physical_machine/files/pacemaker_hardening.conf
@@ -8,6 +8,6 @@ ProtectControlGroups=yes
 RestrictSUIDSGID=true
 RestrictNamespaces=true
 MemoryDenyWriteExecute=yes
-CapabilityBoundingSet=cap_chown cap_dac_override cap_kill cap_setgid cap_setuid cap_net_admin
+CapabilityBoundingSet=cap_chown cap_dac_override cap_kill cap_setgid cap_setuid cap_net_admin cap_setpcap
 PrivateDevices=yes
 SystemCallFilter=@system-service


### PR DESCRIPTION
Without this, hardening prevents live-migration from working