### PR TITLE
Debian: fix typo in initramfs rebuild handler

### DIFF
--- a/roles/debian_physical_machine/handlers/main.yml
+++ b/roles/debian_physical_machine/handlers/main.yml
@@ -12,5 +12,5 @@
 
 - name: Rebuild initramfs if necessary
   command:
-    cmd: /usr/bin/dracut --regenerate-all --force
+    cmd: /usr/sbin/update-initramfs -u
   changed_when: true

--- a/roles/debian_physical_machine/tasks/main.yml
+++ b/roles/debian_physical_machine/tasks/main.yml
@@ -171,6 +171,7 @@
 - name: Enable docker.service
   ansible.builtin.systemd:
     name: docker.service
+
 - name: "Add initramfs-tools scripts: script file (LVM rebooter and log handling)"
   ansible.builtin.copy:
     src: initramfs-tools/scripts/


### PR DESCRIPTION
Dracut is for CentOS
Debian uses initramfs