### PR TITLE
ci_yocto: clean the log after update in the ARM CI

### DIFF
--- a/roles/ci_yocto/clean_arm_machines/tasks/main.yaml
+++ b/roles/ci_yocto/clean_arm_machines/tasks/main.yaml
@@ -39,5 +39,7 @@
     - /mnt/persistent/etc
     - /mnt/persistent/home
     - /mnt/persistent/var
+    - /var/log/journal
+    - /var/log/syslog-ng
 - name: Reboot the system
   reboot:


### PR DESCRIPTION
The logs are not cleaned after the update of the ARM machines in the CI. This can lead to a full log partition and the machine will not be able to run the tests.

This patch adds the cleaning of the journal and syslog-ng logs after the update of the ARM machines in the CI.