### PR TITLE
debian/pip: need --no-build-isolation

### DIFF
--- a/roles/deploy_python3_setup_ovs/tasks/main.yml
+++ b/roles/deploy_python3_setup_ovs/tasks/main.yml
@@ -10,7 +10,7 @@
       - "--chown=root:root"
 - name: Install python3-setup-ovs
   command:
-    cmd: /usr/bin/pip install --root-user-action=ignore --prefix=/usr/ .
+    cmd: /usr/bin/pip install --root-user-action=ignore --no-build-isolation --prefix=/usr/ .
     chdir: /tmp/src/python3-setup-ovs
   changed_when: true
 - name: Copy seapath-config_ovs.service

--- a/roles/deploy_vm_manager/tasks/main.yml
+++ b/roles/deploy_vm_manager/tasks/main.yml
@@ -10,7 +10,7 @@
       - "--chown=root:root"
 - name: Install vm_manager
   command:
-    cmd: /usr/bin/pip install --root-user-action=ignore --prefix=/usr/ .
+    cmd: /usr/bin/pip install --root-user-action=ignore --no-build-isolation --prefix=/usr/ .
     chdir: /tmp/src/vm_manager
   changed_when: true
 - name: Create a symbolic link


### PR DESCRIPTION
Otherwise, pip does not see python3-setuptools and tries to download it, which requires internet access.