### PR TITLE
configure_ha: rollback renaming enable_vmmgr_api_http

### DIFF
--- a/roles/configure_ha/README.md
+++ b/roles/configure_ha/README.md
@@ -13,8 +13,8 @@ No requirement.
 | seapath_distro                       | yes      | String      |         | SEAPATH variant. *CentOS*, *Debian* or *Yocto*. The variable can be set automatically using the *detect_seapath_distro role* |
 | corosync_node_list                   | yes      | String list |         | List of all corosync nodes. Usually `{{ groups['cluster_machines'] \| list }}` |
 | configure_ha_tmpdir                  | no       | String      | /tmp    | Temporary directory path to use                                                |
-| configure_ha_enable_vmmgr_http_api   | no       | Bool        | false   | Set to true to enable SEAPATH vm-manager REST API                              |
-| admin_cluster_ip                     | no       | String      |         | IP of the REST API. If not set the m-manager REST API will be disabled even if `configure_ha_enable_vmmgr_http_api is set to true` |
+| enable_vmmgr_http_api   | no       | Bool        | false   | Set to true to enable SEAPATH vm-manager REST API                              |
+| admin_cluster_ip                     | no       | String      |         | IP of the REST API. If not set the m-manager REST API will be disabled even if `enable_vmmgr_http_api is set to true` |
 | extra_crm_cmd_to_run                 | no       | String      |         | List of `crm configure` commands to run separate by a new line.                |
 
 ## Example Playbook

--- a/roles/configure_ha/defaults/main.yml
+++ b/roles/configure_ha/defaults/main.yml
@@ -3,4 +3,3 @@
 
 ---
 configure_ha_tmpdir: "/tmp"
-configure_ha_enable_vmmgr_http_api: false

--- a/roles/configure_ha/tasks/main.yml
+++ b/roles/configure_ha/tasks/main.yml
@@ -148,7 +148,8 @@
     cmd: crm -d config load update -
     stdin: "{{ vmmgrapi_cmd_list }}"
   when:
-    - configure_ha_enable_vmmgr_http_api is true
+    - enable_vmmgr_http_api is defined
+    - enable_vmmgr_http_api is true
     - admin_cluster_ip is defined
   run_once: true
   register: vmmgrapi_cmd_list_task


### PR DESCRIPTION
enable_vmmgr_api_http is a variable mostly related to the vmmgrapi role, this is not a "configure_ha" variable.
This was renamed because of ansible lint and the fact that a default was set for this variable in the configure_ha role.
This commit removes the default, renames the variable back to before, and set a "is defined" condition in the configure_ha role which has the same effect as having a "false" default.