### PR TITLE
cqfd: use prebuilt image for cqfd

### DIFF
--- a/.cqfdrc
+++ b/.cqfdrc
@@ -2,6 +2,7 @@
 org='seapath'
 name='ansible'
 flavors='prepare manual module_documentation ansible-lint export'
+custom_img_name=ghcr.io/seapath/ansible_cqfd:v1.1.0
 
 [build]
 command='check_yaml && ansible-lint -c ansible-lint.conf'


### PR DESCRIPTION
This commit updates the .cqfdrc file to use the prebuilt Docker image from the SEAPATH GitHub Container Registry. This image is built from the Dockerfile in the cqfd directory.

To update the image you have to create a GitHub token with delete:packages, repo, write:packages permissions in the Developer Settings of your GitHub account. Then you can run the following commands:

```bash
docker login ghcr.io # Use your GitHub username and the token as password
cqfd init
docker push ghcr.io/seapath/ansible_cqfd:v1.1.0
docker tag ghcr.io/seapath/ansible_cqfd:v1.1.0 ghcr.io/seapath/ansible_cqfd:latest
docker push ghcr.io/seapath/ansible_cqfd:latest
```