### PR TITLE
use deb822 repo format

### DIFF
--- a/roles/debian/tasks/main.yml
+++ b/roles/debian/tasks/main.yml
@@ -173,12 +173,17 @@
   block:
     - name: Remove all file in /etc/apt/sources.list.d
       file:
-        path: /etc/apt/sources.list.d
+        path: /etc/apt/sources.list
         state: absent
     - name: Configure apt repositories
-      template:
-        src: sources.list.j2
-        dest: /etc/apt/sources.list
+      deb822_repository:
+        name: "{{ item.name }}"
+        types: deb
+        uris: "{{ item.uris }}"
+        suites: "{{ item.suites }}"
+        components: "{{ item.components }}"
+        signed_by: "{{ item.signed_by }}"
+      loop: "{{ apt_repo }}"
 
 - name: Remove /etc/default/grub.d/*.cfg (FAI)
   file:

--- a/roles/debian/templates/sources.list.j2
+++ b/roles/debian/templates/sources.list.j2
@@ -1,3 +1,0 @@
-{% for repo in apt_repo %}
-deb {{ repo }}
-{% endfor %}


### PR DESCRIPTION
This commits changes the way the debian repos are verified, according to the deb822 format.
https://repolib.readthedocs.io/en/latest/deb822-format.html