### PR TITLE
vm template: use "q35" machine type

### DIFF
--- a/templates/vm/guest.xml.j2
+++ b/templates/vm/guest.xml.j2
@@ -40,7 +40,7 @@
     <currentMemory unit="MiB">{{ vm.memory | default ("2048") }}</currentMemory>
 {% endif %}
     <os firmware="efi">
-        <type arch="x86_64" machine="pc-q35-3.1">hvm</type>
+        <type arch="x86_64" machine="q35">hvm</type>
         <boot dev="hd" />
         <bootmenu enable="no" />
         <bios useserial="yes" rebootTimeout="0" />


### PR DESCRIPTION
This is an alias to the default q35 machine, so this approach is more portable.