### PR TITLE
systemd unit: add not "not-found" condition

### DIFF
--- a/roles/timemaster/tasks/main.yml
+++ b/roles/timemaster/tasks/main.yml
@@ -11,7 +11,7 @@
     name: "systemd-timesyncd"
     state: stopped
     enabled: false
-  when: "'systemd-timesyncd.service' in services"
+  when: "'systemd-timesyncd.service' in services and (services['systemd-timesyncd.service'].status != 'not-found')"
 - name: Create timemaster configuration
   template:
     src: timemaster.conf.j2


### PR DESCRIPTION
Sometimes the unit is present in the list of services even though the service is not on the node, in which case it has a "not found" status. This commit makes sure the unit is actually present.