### PR TITLE
roles/network_resolved: do not disable systemd-resolved on Yocto

### DIFF
--- a/roles/network_resolved/tasks/main.yml
+++ b/roles/network_resolved/tasks/main.yml
@@ -38,4 +38,6 @@
     name: systemd-resolved
     state: stopped
     enabled: false
-  when: dns_servers is not defined
+  when:
+    - dns_servers is not defined
+    - seapath_distro != "Yocto"


### PR DESCRIPTION
On SEAPATH Yocto, libvirt installs as dependency dnsmasq. dnsmasq.service is then started along libvirtd and requires /etc/resolv.conf to exist, or be a link to an existing file.

However, /etc/resolv.conf points to /run/systemd/resolve/resolv.conf, which is created by the systemd-resolved service.
If systemd-resolved is disabled, dnsmasq will also fail because /etc/resolv.conf points to nothing, and the cukinia test checking for failed service will fail.

As a temporary workaround to prevent dnsmasq.service failure on Yocto, do not disable systemd-resolved.service even when no dns server is specified.