### PR TITLE
bugfix and ABB SSC600SW example refactoring

### DIFF
--- a/inventories/examples/seapath-vm-deployement.yaml
+++ b/inventories/examples/seapath-vm-deployement.yaml
@@ -16,7 +16,7 @@ VMs:
   hosts:
     rtvm:
       vm_template: "../templates/vm/guest.xml.j2" # TODO: Replace with your template
-      vm_disk: "../vm_images/guest.qcow2" # TODO : Replace with your image name
+      vm_disk: "../files/guest.qcow2" # TODO : Replace with your image name
 
       # Connection test part. Remove if your vm has no ssh connection
       ansible_host: 10.132.170.8 # TODO : Put the IP of your VM
@@ -32,7 +32,7 @@ VMs:
 
     vm:
       vm_template: "../templates/vm/guest.xml.j2" # TODO: Replace with your template
-      vm_disk: "../vm_images/guest.qcow2" # TODO : Replace with your image name
+      vm_disk: "../files/guest.qcow2" # TODO : Replace with your image name
 
       # Connection test part. Remove if your vm has no ssh connection
       ansible_host: 10.132.170.9 # TODO : Put the IP of your VM

--- a/inventories/providers/abb/README.md
+++ b/inventories/providers/abb/README.md
@@ -2,7 +2,7 @@
 
 This directory contains the example inventory files for the SSC600 SW from ABB. It can configure a standalone yocto hypervisor and a SSC600 SW VM.
 The VM name must contain the string "ssc600" to be recognized by the qemu hook provided by ABB. (See the files needed section).
-The VM deployment has been tested on a yocto and a debian hypervisor.
+The VM deployment has been tested on a Yocto and a Debian hypervisor using the version 1.5.0 of ABB SSC600 SW.
 
 ## Structure
 
@@ -12,14 +12,18 @@ The VM deployment has been tested on a yocto and a debian hypervisor.
 ## Files needed
 
 Some files provided by ABB are needed to use these inventories:
-- ssc600_disk.img.gz
+- ssc600\_disk.img.gz
 - qemu.hook
 
 To use them, they can be copied in the `files` directory at the root of ansible.
 
-> The raw image disk can be converted to qcow2 format. The disk_extract variable has to be set to false.
+> The raw image disk ssc600\_disk.img.gz has to be converted to qcow2 format to work on SEAPATH.
 
-In a cluster, the deployment playbook wants a qcow2 file. The conversion is needed and can be done with `qemu-img convert`
+This can be done with the following commands:
+- `gunzip ssc600sw_disk.img.gz`
+- `qemu-img convert -f raw -O qcow2 ssc600_disk.img ssc600_disk.qcow2`
+
+*Warning: Both the img.gz and the qcow2 files are less than 1Gib. However, the intermediate `ssc600sw_disk.img` file is 30GiB*
 
 ## Prerequisite
 
@@ -39,3 +43,12 @@ The default br0 bridge is use.
 ## Cache L3 partitioning
 
 The L3 cache partitioning is not supported and would need to be tested with and without to see the impact.
+
+## Access to ABB HMI
+
+Once the VM has booted, the only access referenced in ABB Documentation is through a web HMI accessible on 192.168.2.10/24.
+In order for this HMI to be accessible outside of the hypervisor, the br0 bridge must have an IP on this subnet (for example 192.168.2.11).
+
+This can be done either :
+- directly in the inventory by setting the IP of your hypervisor `ansible_host: 192.168.2.11`
+- by logging into the hypervisor and typing `sudo ip addr add 192.168.2.11/24 dev br0`

--- a/inventories/providers/abb/ssc600_hypervisor_standalone_example.yaml
+++ b/inventories/providers/abb/ssc600_hypervisor_standalone_example.yaml
@@ -1,45 +1,42 @@
-# Copyright (C) 2024, SFL (https://savoirfairelinux.com)
+# Copyright (C) 2024-2025, SFL (https://savoirfairelinux.com)
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-all:
+standalone_machine:
   children:
-    standalone_machine:
-      children:
-        hypervisors:
-          hosts:
-            abb-demoHyp:
-              ansible_host: "192.168.216.78" # Change to your hypervisor IP
-              gateway_addr: "192.168.216.1" # Change to your gateway IP
-              network_interface: "enp0s20f0u7" # Change to your management interface
-              ptp_interface: "{{ network_interface }}" # Change to your PTP interface
-              ip_addr: "{{ ansible_host }}"
-              cluster_interface: "{{ network_interface }}"
-              ntp_servers: "{{ gateway_addr }}"
-              syslog_server_ip: "{{ gateway_addr }}"
-              apply_network_config: false
-              kernel_parameters_restart: false
-              ignored_bridges: []
-              nics_affinity:
-              - enp88s0: 3  # Change to your NICs
-              upload_files: # This file is given with the ssc600 sw package
-                - src: '../files/qemu.hook'
-                  dest: '/etc/libvirt/hooks/'
-                  mode: "0744"
+    hypervisors:
+      hosts:
+        abb-demoHyp:
+          ansible_host: "192.168.216.78" # Change to your hypervisor IP
+          network_interface: "enp0s20f0u7" # Change to your management interface
+
+          ptp_interface: "enp7s0" # Change to your PTP interface
+
+          nics_affinity:
+          - enp88s0: 3  # Change to your NICs
+          upload_files: # This file is given with the ssc600 sw package
+            - src: '../files/qemu.hook'
+              dest: '/etc/libvirt/hooks/'
+              mode: "0744"
 
   vars:
-    ansible_user: admin # Change to `ansible` if using seapath debian
-    grub_append: "default_hugepagesz=1G hugepagesz=1G hugepages=6" # Set hugepages for debian only
-    hugepages: 6 # Set hugepages for Yocto only
-    isolcpus: "4-N" # isolate CPUs for debian only
     ansible_connection: ssh
     ansible_python_interpreter: /usr/bin/python3
-    admin_user: admin
-    ansible_become: true
-    ansible_become_method: sudo
-    ansible_become_flags: "-n -E"
-    ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
     ansible_remote_tmp: /tmp/.ansible/tmp
-    bootloader_config_file: /boot/EFI/BOOT/grub.cfg
-    ansible_ssh_private_key_file: ~/.ssh/sfl-seapath
+    ansible_user: admin # Change to `ansible` if using seapath debian
 
+    gateway_addr: "192.168.216.1" # Change to your gateway IP
+    dns_serverts: "192.168.216.1" # Change to your DNS IP. Remove if not needed.
+    ip_addr: "{{ ansible_host }}"
+    apply_network_config: true
+
+    ntp_servers: "192.168.216.1" # Change to your ntp server. Remove if not needed.
+
+    # Debian required variables
+    admin_user: admin
+    isolcpus: "4-N"
+    grub_append: "default_hugepagesz=1G hugepagesz=1G hugepages=6"
+
+    # Yocto required variables
+    yocto_hugepages: 6
+    bootloader_config_file: /boot/EFI/BOOT/grub.cfg

--- a/inventories/providers/abb/ssc600_vm_example.yaml
+++ b/inventories/providers/abb/ssc600_vm_example.yaml
@@ -6,11 +6,7 @@ VMs:
     ssc600example:
       description: "SSC600 VM Standalone Example"
       vm_template: "../templates/vm/ssc600.xml.j2"
-      vm_disk: "../files/ssc600_disk.img.gz"
-      disk_extract: true
-      # In cluster mode, the disk has to be in qcow2 format:
-      #vm_disk: "../files/ssc600_disk.qcow2"
-      #disk_extract: false
+      vm_disk: "../files/ssc600_disk.qcow2"
       memory: 6
       cpuset: [4, 5, 6, 7]
       emulatorpin: 3

--- a/inventories/providers/abb/ssc600_vm_example.yaml
+++ b/inventories/providers/abb/ssc600_vm_example.yaml
@@ -1,32 +1,25 @@
 # Copyright (C) 2024, SFL (https://savoirfairelinux.com)
 # SPDX-License-Identifier: Apache-2.0
 
-all:
-  children:
-    VMs:
-      hosts:
-        ssc600example:
-          description: "SSC600 VM Standalone Example"
-          vm_template: "../templates/vm/ssc600.xml.j2"
-          vm_disk: "../files/ssc600_disk.img.gz"
-          disk_extract: true
-          # In cluster mode, the disk has to be in qcow2 format:
-          #vm_disk: "../files/ssc600_disk.qcow2"
-          #disk_extract: false
-          memory: 6
-          cpuset: [4, 5, 6, 7]
-          emulatorpin: 3
-          rt_priority: 50
-          bridges:
-            - name: "br0"
-              mac_address: "52:54:00:c4:ff:06"
-          sv_interfaces:
-            - name: "enp88s0" # Change to your SV interface
-              mac_address: "52:54:00:c4:ff:07"
-              mode: "vepa"
-      vars:
-        ansible_user: admin
-        ansible_become: true
-        ansible_become_method: sudo
-        apply_network_config: true
-        wait_for_connection: false
+VMs:
+  hosts:
+    ssc600example:
+      description: "SSC600 VM Standalone Example"
+      vm_template: "../templates/vm/ssc600.xml.j2"
+      vm_disk: "../files/ssc600_disk.img.gz"
+      disk_extract: true
+      # In cluster mode, the disk has to be in qcow2 format:
+      #vm_disk: "../files/ssc600_disk.qcow2"
+      #disk_extract: false
+      memory: 6
+      cpuset: [4, 5, 6, 7]
+      emulatorpin: 3
+      rt_priority: 50
+      bridges:
+        - name: "br0"
+          mac_address: "52:54:00:c4:ff:06"
+      sv_interfaces:
+        - name: "enp88s0" # Change to your SV interface
+          mac_address: "52:54:00:c4:ff:07"
+          mode: "vepa"
+      wait_for_connection: false

--- a/playbooks/seapath_setup_prerequisyocto.yaml
+++ b/playbooks/seapath_setup_prerequisyocto.yaml
@@ -9,6 +9,7 @@
   hosts:
     - cluster_machines
     - standalone_machine
+  become: true
   roles:
     - yocto/kernel_params
 


### PR DESCRIPTION
- Correct a bug on kernel parameter modification on Yocto
- Refactor ABB SSC600SW inventory examples
- Only propose to use qcow2 files in the examples (no img.gz)