### PR TITLE
adds oraclelinux to seapath supported distros

### DIFF
--- a/.github/workflows/ci-oraclelinux.yml
+++ b/.github/workflows/ci-oraclelinux.yml
@@ -1,0 +1,59 @@
+# Copyright (C) 2023, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+name: CI OracleLinux
+
+env:
+  WORK_DIR: /tmp/seapath_ci_${{ github.run_id }}_${{ github.run_attempt }}_${{ github.sha }}
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches: [main]
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  checks: write
+
+jobs:
+  CI:
+    runs-on: [self-hosted, runner-RTE-OL9]
+    steps:
+
+      - name: Initialize sources
+        run: mkdir ${{ env.WORK_DIR }}; cd ${{ env.WORK_DIR }};
+             git clone -q --depth 1 --recurse-submodules -b ol https://github.com/seapath/ci ci;
+             echo "CI sources downloaded successfully";
+             ci/launch-oraclelinux.sh init;
+
+      - name: Launch Ansible-lint
+        run: |-
+          cd ${{ env.WORK_DIR }}/ansible
+          cqfd -b ansible-lint
+
+      - name: Configure OracleLinux
+        id: conf
+        run: cd ${{ env.WORK_DIR }};
+             ci/launch-oraclelinux.sh conf;
+
+      - name: Launch system tests
+        if: ${{ always() && steps.conf.conclusion == 'success' }}
+        run: cd ${{ env.WORK_DIR }};
+             ci/launch-oraclelinux.sh system;
+
+      - name: Launch VM tests
+        if: ${{ always() && steps.conf.conclusion == 'success' }}
+        run: cd ${{ env.WORK_DIR }};
+             ci/launch-oraclelinux.sh vm;
+
+      - name: Upload test report
+        if: ${{ always() && steps.conf.conclusion == 'success' }}
+        run: cd ${{ env.WORK_DIR }};
+             git -C ci/test-report-pdf checkout 0156f2d35ba7d5983f22b6054aa83f92a42f0f2d;
+             ci/launch-oraclelinux.sh report;
+
+      - name: Clean
+        if: always()
+        run: rm -rf $WORK_DIR;

--- a/oraclelinux.ks
+++ b/oraclelinux.ks
@@ -1,0 +1,232 @@
+# Installation process
+text
+reboot
+#cdrom
+
+# localization
+lang en_US
+keyboard --xlayouts='fr'
+timezone Europe/Paris --utc
+
+# System bootloader configuration
+bootloader --append="crashkernel=1G-4G:192M,4G-64G:256M,64G-:512M console=ttyS0 efi=runtime ipv6.disable=1 inst.wait_for_network=1 selinux=0"
+
+# Disks and partitions
+# UPDATE: Change device path for your correct installation disk
+ignoredisk --only-use=/dev/vda
+# Clear the Master Boot Record
+zerombr
+# Partition clearing information
+clearpart --all --initlabel
+
+# Disk partitioning information
+reqpart
+# UPDATE: Change device path for your correct installation disk
+part /boot/efi --fstype=efi --ondisk=/dev/vda --size=512 --asprimary
+part /boot --fstype=ext4 --ondisk=/dev/vda --size=400 --asprimary
+part pv.0 --fstype=lvmpv --ondisk=/dev/vda  --size=22000
+part pv.1 --fstype=lvmpv --ondisk=/dev/vda  --size=5000 --grow
+volgroup vg1 --pesize=4096 pv.0
+logvol / --vgname=vg1 --name=root --fstype=ext4 --size=10000
+logvol /var/log --vgname=vg1 --name=varlog --fstype=ext4 --size=1000
+logvol swap --vgname=vg1 --name=swap --fstype=swap --size=500
+volgroup vg_ceph --pesize=4096 pv.1
+
+# Network information
+# UPDATE: change device name and static IP to your correct settings (gateway and nameserver might also be needed)
+network --device=enp3s0 --bootproto=static --ip=10.10.10.51 --netmask=255.255.255.0 --gateway=10.10.10.1 --nameserver=8.8.8.8 --hostname=testol --onboot=yes
+
+# Do not configure the X Window System
+skipx
+
+# system services
+services --disabled=corosync,pacemaker,NetworkManager,firewalld
+services --enabled=openvswitch
+
+# Users
+# UPDATE: The password is "toto" for all users
+user --uid=1000 --gid=1000 --groups=wheel --name=admin --iscrypted --password="$6$BZGBti/HRUWlyHhY$8zI5CFPcuBJw7pKupU4d9QLTqphBDyDpkW8zMySquiKO/qcRZoEcqvCJraJXJ5y0sdNdJ2vHb6.z/UvvLJSrM/"
+
+user --uid=1005 --gid=1005 --groups=wheel,haclient --name=ansible --iscrypted --password="$6$BZGBti/HRUWlyHhY$8zI5CFPcuBJw7pKupU4d9QLTqphBDyDpkW8zMySquiKO/qcRZoEcqvCJraJXJ5y0sdNdJ2vHb6.z/UvvLJSrM/"
+
+user --uid=902 --gid=902  --name=oraclelinux-snmp
+user --uid=1033 --gid=1033  --name=www-data
+
+rootpw  --iscrypted $6$2Aj/yELlJst1TZMM$3JVT2YYjrbMpNGoHs.2O.SvcbtGSZqQvz5Ot5CdDmU/IsRFASnSqmlvS8bg8eGoOHmQ5i7dak0VWQWtziqYjh0
+
+
+# ssh keys
+# UPDATE: input your ssh-keys for
+sshkey --username=admin "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAukkqkApL2haZYMVVdpDR/B9fRU/g5sQUggtfS3ObbAN90oAgAHlGYA9a/Q254qC03vh51GAdc6GQ0RYnTZehx8hib4QoaesVlXi5Ch8vhuTL0oe600Jvqp0e4TJnkfl/N9h1myr6prycAH0wP2UrkUGnUl9yToqBQalpSyvuPVqdDaUtnJAEDIT5XcPwTYKOZVP/akbtMd4X3Ok9On4TlR5vhNQGmIOUHgr9kW8ePVF7vpz4EyC072PdM42d3le1xCisiwRrRJIhEFHQSjCTQEp9pxzerq9UVK76Ruylj43xhFx+OVneDlVgX+bE9+axpErMsJ+hAeVbvWoLwgoKvw=="
+sshkey --username=ansible "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDb+9b1kDbeqeTrQ+lM6YlVdq6dVmw9beOLDh4r0yYrQs0I+mDA+c5q6PFCCiN6DVIjvP7YZdvFdT5w5E5eQc6hDLLLUMvWf8z9P/VHeyfnG3RCaVCKQImFelenO6fR+Wm4UtGd2Goi8Vend/wVW9n8b1E8FQqYCCGUsk8UT/TCrqjBhpfVVh9AdCgYuj8TyBAHVRN7LL+8MkwbNotzn26SlM1975heaQ0Mlmj7gSG3mUtAIGv0TkUZq9DJ0ClL6Xvldzlnupkk8JCsqSvbQXbPUNOWBEGZyJ7D/t+8lbxLWAWNVmsjuMOgyEJF+J1XD/9dwI3pABbptKAKMjsSrTywPCA1lXUqnkfKlINpoc1yjVEcZyXuWeTF9aRMF/WrAdQQSpHIo5mtGXwGZoHOvH2k+3kN/MexdyUiVjk5CLP+zIyI91STfmfx6Mns/xz7bLelsxVGT1nOu840l2y6KLYbOcfYN7dOuSXiFiMVsrpS8ltzhAcZPanvLJfdJsva2hE= virtu@ci-seapath"
+sshkey --username=root "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAukkqkApL2haZYMVVdpDR/B9fRU/g5sQUggtfS3ObbAN90oAgAHlGYA9a/Q254qC03vh51GAdc6GQ0RYnTZehx8hib4QoaesVlXi5Ch8vhuTL0oe600Jvqp0e4TJnkfl/N9h1myr6prycAH0wP2UrkUGnUl9yToqBQalpSyvuPVqdDaUtnJAEDIT5XcPwTYKOZVP/akbtMd4X3Ok9On4TlR5vhNQGmIOUHgr9kW8ePVF7vpz4EyC072PdM42d3le1xCisiwRrRJIhEFHQSjCTQEp9pxzerq9UVK76Ruylj43xhFx+OVneDlVgX+bE9+axpErMsJ+hAeVbvWoLwgoKvw=="
+
+# adding needed repositories
+
+repo --name="ol9_AppStream" --baseurl="https://yum.oracle.com/repo/OracleLinux/OL9/appstream/x86_64"
+repo --name="ol9_UEKR7" --baseurl="https://yum.oracle.com/repo/OracleLinux/OL9/UEKR7/x86_64"
+repo --name="ol9_BaseOS" --baseurl="https://yum.oracle.com/repo/OracleLinux/OL9/baseos/latest/x86_64"
+repo --name="ol9_EPEL" --baseurl="https://yum.oracle.com/repo/OracleLinux/OL9/developer/EPEL/x86_64" --install
+repo --name="ol9_addons" --baseurl="https://yum.oracle.com/repo/OracleLinux/OL9/addons/x86_64"
+#repo --name="docker-ce" --baseurl="https://download.docker.com/linux/centos/9/x86_64/stable" --install
+repo --name=openvswitch --baseurl="https://mirror.stream.centos.org/SIGs/9-stream/nfv/x86_64/openvswitch-2/" --install
+
+url --url="https://yum.oracle.com/repo/OracleLinux/OL9/baseos/latest/x86_64"
+
+%packages
+linux-firmware
+microcode_ctl
+at
+audispd-plugins
+audit
+bridge-utils
+ca-certificates
+chrony
+curl
+pcp-system-tools
+gnupg
+hddtemp
+irqbalance
+jq
+lbzip2
+linuxptp
+net-tools
+openssh-server
+edk2-ovmf
+podman
+python3-dnf
+python3-cffi
+python3-setuptools
+python3.11
+python3.11-lxml
+python3.11-pip
+net-snmp
+net-snmp-utils
+sudo
+sysfsutils
+syslog-ng
+sysstat
+vim
+wget
+rsync
+pciutils
+conntrack-tools
+
+busybox
+ipmitool
+nginx
+ntfs-3g
+python3-flask-wtf
+python3-pip
+python3-gunicorn
+corosync
+pacemaker
+openvswitch3.4
+
+#kernel-rt
+grubby
+#kernel-rt-kvm
+qemu-kvm
+
+#ceph
+#ceph-base
+#ceph-common
+#ceph-mgr
+#ceph-mgr-diskprediction-local
+#ceph-mon
+#ceph-osd
+#libcephfs2
+libvirt
+libvirt-daemon
+libvirt-daemon-driver-storage-rbd
+#python3-ceph-argparse
+#python3-cephfs
+#tuna
+
+#tuned
+#tuned-profiles-nfv
+#tuned-profiles-realtime
+
+virt-install
+
+pcs
+pcs-snmp
+
+systemd-networkd
+systemd-resolved
+
+#for crmsh build
+@development
+
+#libvirt-clients
+#lm-sensors
+
+@virtualization-hypervisor
+
+%end
+
+# additional file changes
+%post
+cat <<EOF > /etc/motd
+ ____  _____    _    ____   _  _____ _   _
+/ ___|| ____|  / \  |  _ \ / \|_   _| | | |
+\___ \|  _|   / _ \ | |_) / _ \ | | | |_| |
+ ___) | |___ / ___ \|  __/ ___ \| | |  _  |
+|____/|_____/_/   \_\_| /_/   \_\_| |_| |_|
+EOF
+
+rpm --import https://yum.oracle.com/RPM-GPG-KEY-oracle-ol9
+rpm --import http://sumaproxy.rtsystem.com/pub/oracle-gpg-pubkey-BC4D06A08D8B756F.key
+rpm --import https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-NFV
+
+echo "EDITOR=vim" >> /etc/environment
+echo "SYSTEMD_EDITOR=vim" >> /etc/environment
+echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
+
+echo "Defaults:ansible !requiretty" >> /etc/sudoers
+echo "ansible    ALL=NOPASSWD:EXEC:SETENV: /bin/sh" >> /etc/sudoers
+echo "ansible    ALL=NOPASSWD: /usr/bin/rsync" >> /etc/sudoers
+echo "ansible    ALL=NOPASSWD: /usr/local/bin/crm" >> /etc/sudoers
+echo "ansible    ALL=NOPASSWD: /usr/bin/ceph" >> /etc/sudoers
+
+echo "admin   ALL=NOPASSWD: ALL" >> /etc/sudoers
+
+cat <<EOF > /etc/profile.d/custom-path.sh
+PATH=$PATH:/usr/local/bin/
+EOF
+
+cat <<EOF > /etc/systemd/network/01-init.network
+[Match]
+Name=enp1s0
+[Network]
+Address=10.10.10.51/24
+Gateway=10.10.10.1
+EOF
+
+echo "DNS=8.8.8.8" >> /etc/systemd/resolved.conf
+
+pip-3.11 install packaging python-dateutil PyYAML
+git clone https://github.com/ClusterLabs/crmsh.git /tmp/crmsh
+cd /tmp/crmsh
+git checkout 9b1bfe5ff7a20826da90212220f3d7dc7b905afa
+./autogen.sh
+PYTHON=/usr/bin/python3.11 ./configure
+make
+make install
+ln -s /usr/local/bin/crm /usr/bin/crm
+mkdir -p  /var/log/crmsh/
+
+dnf -y remove @development
+
+CEPH_RELEASE=19.2.1
+curl -o /tmp/cephadm --silent --remote-name --location https://download.ceph.com/rpm-${CEPH_RELEASE}/el9/noarch/cephadm
+chmod +x /tmp/cephadm
+mv /tmp/cephadm /usr/local/bin/cephadm
+/usr/local/bin/cephadm add-repo --release squid
+/usr/local/bin/cephadm install ceph-common ceph-volume
+
+lvcreate -l 100%FREE -n lv_ceph vg_ceph
+
+grubby --set-default-index=0
+
+%end

--- a/playbooks/seapath_setup_main.yaml
+++ b/playbooks/seapath_setup_main.yaml
@@ -21,6 +21,10 @@
   import_playbook: seapath_setup_prerequiscentos.yaml
   when: seapath_distro == "CentOS"
 
+- name: Import seapath_setup_prerequisoraclelinux playbook
+  import_playbook: seapath_setup_prerequisoraclelinux.yaml
+  when: seapath_distro == "OracleLinux"
+
 - name: Import seapath_setup_prerequisdebian playbook
   import_playbook: seapath_setup_prerequisdebian.yaml
   when: seapath_distro == "Debian"

--- a/playbooks/seapath_setup_prerequisoraclelinux.yaml
+++ b/playbooks/seapath_setup_prerequisoraclelinux.yaml
@@ -1,0 +1,91 @@
+# Copyright (C) 2025 RTE
+# SPDX-License-Identifier: Apache-2.0
+
+- name: Prerequis machine oraclelinux
+  gather_facts: true
+  hosts:
+    - cluster_machines
+    - standalone_machine
+    - VMs
+  become: true
+  roles:
+    - oraclelinux
+- name: Prerequis physical machine oraclelinux
+  hosts:
+    - cluster_machines
+    - standalone_machine
+  become: true
+  roles:
+    - oraclelinux_physical_machine
+- name: Prerequis physical machine oraclelinux
+  hosts:
+    - cluster_machines
+  become: true
+  roles:
+    - backup_restore
+#- name: Prerequis hypervisor oraclelinux
+#  hosts:
+#    - hypervisors
+#    - standalone_machine
+#  become: true
+#  roles:
+#    - oraclelinux_hypervisor
+
+- name: Add admin user to haclient group
+  hosts:
+    - cluster_machines
+  become: true
+  tasks:
+    - name: Add admin user to haclient group
+      user:
+        name: "{{ admin_user }}"
+        groups: haclient
+        append: yes
+
+- name: Disable libvirt-guests.service
+  hosts:
+    - cluster_machines
+  become: true
+  tasks:
+    - name: Disable libvirt-guests.service
+      ansible.builtin.systemd:
+        name: libvirt-guests.service
+        enabled: no
+        state: stopped
+
+- name: Upload extra files
+  hosts:
+    - cluster_machines
+    - standalone_machine
+    - VMs
+  become: true
+  tasks:
+    - name: Upload extra files
+      copy:
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
+        owner: "{{ item.owner | default('root') }}"
+        group: "{{ item.group | default('root') }}"
+        mode: "{{ item.mode | default('0644') }}"
+        backup: yes
+      with_items: "{{ upload_files }}"
+      when:
+        - upload_files is defined
+        - item.extract is not defined or item.extract is false
+    - name: Upload extra files and extract them
+      unarchive:
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
+        owner: "{{ item.owner | default('root') }}"
+        group: "{{ item.group | default('root') }}"
+        mode: "{{ item.mode | default('0644') }}"
+      with_items: "{{ upload_files }}"
+      when:
+        - upload_files is defined
+        - item.extract is defined and item.extract is true
+    - name: Run extra commands after upload
+      shell: "{{ item }}"
+      tags:
+        - skip_ansible_lint
+      loop: "{{ commands_to_run_after_upload }}"
+      when: commands_to_run_after_upload is defined

--- a/playbooks/test_deploy_cukinia_tests.yaml
+++ b/playbooks/test_deploy_cukinia_tests.yaml
@@ -11,4 +11,17 @@
   gather_facts: True
   roles:
     - deploy_cukinia
-    - debian_tests
+    - detect_seapath_distro
+
+- name: Deploy Cukinia's tests
+  hosts:
+    - cluster_machines
+    - standalone_machine
+    - VMs
+  become: true
+  gather_facts: True
+  roles:
+    - role: debian_tests
+      when: seapath_distro == "Debian"
+    - role: oraclelinux_tests
+      when: seapath_distro == "OracleLinux"

--- a/roles/ci_restore_snapshot/tasks/main.yml
+++ b/roles/ci_restore_snapshot/tasks/main.yml
@@ -33,7 +33,7 @@
   command: lvs -a
   register: result
   until: result.stdout | regex_search('root-snap', ignorecase=True) is none
-  retries: 24
+  retries: 40
   delay: 10
   changed_when: false
 

--- a/roles/ci_restore_snapshot/vars/OracleLinux.yml
+++ b/roles/ci_restore_snapshot/vars/OracleLinux.yml
@@ -1,0 +1,5 @@
+# Copyright (C) 2025, RTE
+# SPDX-License-Identifier: Apache-2.0
+
+---
+ci_restore_snapshot_grub_update_command: "grub2-mkconfig -o /boot/grub2/grub.cfg"

--- a/roles/configure_admin_user/tasks/main.yml
+++ b/roles/configure_admin_user/tasks/main.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-- when: seapath_distro in [ "CentOS", "Debian" ]
+- when: seapath_distro in [ "CentOS", "Debian", "OracleLinux" ]
   block:
     - name: Get root user's home directory
       shell:

--- a/roles/configure_ha/vars/OracleLinux.yml
+++ b/roles/configure_ha/vars/OracleLinux.yml
@@ -1,0 +1,5 @@
+# Copyright (C) 2025, RTE
+# SPDX-License-Identifier: Apache-2.0
+
+---
+configure_ha_crm_command_path: "/usr/local/bin/crm"

--- a/roles/configure_libvirt/handlers/main.yml
+++ b/roles/configure_libvirt/handlers/main.yml
@@ -2,6 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 - name: Restart libvirtd
-  ansible.builtin.systemd:
-    name: libvirtd
-    state: restarted
+  include_tasks: restart_libvirtd.yaml

--- a/roles/configure_libvirt/tasks/restart_libvirtd.yaml
+++ b/roles/configure_libvirt/tasks/restart_libvirtd.yaml
@@ -1,0 +1,25 @@
+# Copyright (C) 2025 RTE
+# SPDX-License-Identifier: Apache-2.0
+
+- name: Restart libvirtd
+  ansible.builtin.systemd:
+   name: libvirtd
+   state: restarted
+- name: Enable and start virtsecretd.socket
+  ansible.builtin.systemd:
+    name: virtsecretd.socket
+    state: started
+    enabled: true
+  when: seapath_distro == "OracleLinux"  
+- name: Enable and start virtqemud.socket
+  ansible.builtin.systemd:
+    name: virtqemud.socket
+    state: started
+    enabled: true
+  when: seapath_distro == "OracleLinux"  
+- name: Enable and start virtstoraged.socket
+  ansible.builtin.systemd:
+    name: virtstoraged.socket
+    state: started
+    enabled: true
+  when: seapath_distro == "OracleLinux"  

--- a/roles/detect_seapath_distro/tasks/main.yaml
+++ b/roles/detect_seapath_distro/tasks/main.yaml
@@ -16,6 +16,11 @@
     seapath_distro: CentOS
   when: ansible_distribution | regex_search("CentOS|RedHat")
 
+- name: Detect OracleLinux distribution
+  set_fact:
+    seapath_distro: OracleLinux
+  when: ansible_distribution | regex_search("Oracle")
+
 - name: Detect Yocto distribution
   when: seapath_distro is not defined
   block:

--- a/roles/network_configovs/vars/OracleLinux.yml
+++ b/roles/network_configovs/vars/OracleLinux.yml
@@ -1,0 +1,5 @@
+# Copyright (C) 2024 RTE
+# SPDX-License-Identifier: Apache-2.0
+
+---
+network_configovs_setup_ovs_command_path: "/usr/local/bin/setup_ovs"

--- a/roles/oraclelinux/README.md
+++ b/roles/oraclelinux/README.md
@@ -1,0 +1,29 @@
+# OracleLinux Role
+
+This role apply the basic SEAPATH prerequisites for any OracleLinux machine
+
+## Requirements
+
+no requirement.
+
+## Role Variables
+
+| Variable             | Required | Type        | Comments                                                           |
+|----------------------|----------|-------------|--------------------------------------------------------------------|
+| syslog_tls_ca        |  No      | String      | Syslog TLS public key                                              |
+| syslog_tls_key       |  No      | String      | Syslog TLS private key                                             |
+| syslog_tls_server_ca |  No      | String      | Syslog TLS CA                                                      |
+| admin_user           |  Yes     | String      | User to use for administration                                     |
+| admin_passwd         |  No      | String      | Optional user password                                             |
+| admin_ssh_keys       |  No      | String list | List of SSH public keys used to connect to the administration user |
+| grub_append          |  No      | String list | List of extra kernel parameters                                    |
+| syslog_server_ip     |  No      | String      | IP address of the Syslog server to send logs                       |
+| apt_repo             |  No      | String list | List of apt repositories                                           |
+
+## Example Playbook
+
+```yaml
+- hosts: cluster_machines
+  roles:
+    - { role: seapath_ansible.oraclelinux }
+```

--- a/roles/oraclelinux/files/00-panicreboot.conf
+++ b/roles/oraclelinux/files/00-panicreboot.conf
@@ -1,0 +1,1 @@
+kernel.panic = 20

--- a/roles/oraclelinux/files/journald.conf
+++ b/roles/oraclelinux/files/journald.conf
@@ -1,0 +1,44 @@
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+#
+# Entries in this file show the compile time defaults.
+# You can change settings by editing this file.
+# Defaults can be restored by simply deleting this file.
+#
+# See journald.conf(5) for details.
+
+[Journal]
+Storage=persistent
+#Compress=yes
+#Seal=yes
+#SplitMode=uid
+#SyncIntervalSec=5m
+#RateLimitIntervalSec=30s
+#RateLimitBurst=10000
+#SystemMaxUse=
+#SystemKeepFree=
+#SystemMaxFileSize=
+#SystemMaxFiles=100
+#RuntimeMaxUse=
+#RuntimeKeepFree=
+#RuntimeMaxFileSize=
+#RuntimeMaxFiles=100
+#MaxRetentionSec=
+#MaxFileSec=1month
+#ForwardToSyslog=yes
+#ForwardToKMsg=no
+#ForwardToConsole=no
+#ForwardToWall=yes
+#TTYPath=/dev/console
+#MaxLevelStore=debug
+#MaxLevelSyslog=debug
+#MaxLevelKMsg=notice
+#MaxLevelConsole=info
+#MaxLevelWall=emerg
+#LineMax=48K
+#ReadKMsg=yes
+#Audit=no

--- a/roles/oraclelinux/handlers/main.yml
+++ b/roles/oraclelinux/handlers/main.yml
@@ -1,0 +1,18 @@
+# Copyright (C) 2025 RTE
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Restart systemd-journald
+  ansible.builtin.systemd:
+    name: systemd-journald
+    state: restarted
+
+- name: Restart syslog-ng
+  ansible.builtin.systemd:
+    name: syslog-ng
+    state: restarted
+    enabled: yes
+
+- name: Update-grub
+  command: grub2-mkconfig -o /boot/grub2/grub.cfg
+  changed_when: true

--- a/roles/oraclelinux/meta/main.yml
+++ b/roles/oraclelinux/meta/main.yml
@@ -1,0 +1,14 @@
+# Copyright (C) 2024 RTE
+# SPDX-License-Identifier: Apache-2.0
+---
+galaxy_info:
+  author: "Seapath"
+  description: Prerequisite for all debian machine
+  min_ansible_version: 2.9.10
+  license: Apache-2.0
+  platforms:
+  - name: Debian
+    versions:
+    - all
+dependencies: []
+

--- a/roles/oraclelinux/tasks/main.yml
+++ b/roles/oraclelinux/tasks/main.yml
@@ -1,0 +1,256 @@
+# Copyright (C) 2025 RTE
+# SPDX-License-Identifier: Apache-2.0
+
+---
+
+- name: Stop and Disable firewalld
+  service:
+    name: firewalld
+    state: stopped
+    enabled: no
+
+- name: Disable vim defaults
+  lineinfile:
+    dest: /etc/vimrc
+    regexp: '^"? *let g:skip_defaults_vim = 1$'
+    line: "let g:skip_defaults_vim = 1"
+    state: present
+- name: Vim color syntax
+  lineinfile:
+    dest: /etc/vimrc
+    regexp: '^"? *syntax on$'
+    line: "syntax on"
+    state: present
+- name: Remove vimrc.local file
+  file:
+    path: /etc/vimrc.local
+    state: absent
+
+- name: Create /var/log/syslog-ng folder on hosts
+  file:
+    path: /var/log/syslog-ng
+    state: directory
+    mode: '0755'
+- name: Copy syslog-ng conf file
+  template:
+    src: syslog-ng.conf.j2
+    dest: /etc/syslog-ng/syslog-ng.conf
+    mode: '0644'
+  notify: Restart syslog-ng
+- when:
+    - syslog_tls_ca is defined
+    - syslog_tls_key is defined
+    - syslog_tls_server_ca is defined
+  block:
+  - name: Create /etc/syslog-ng/cert.d
+    file:
+      path: /etc/syslog-ng/cert.d
+      state: directory
+      mode: '0755'
+    notify: Restart syslog-ng
+  - name: Create /etc/syslog-ng/ca.d
+    file:
+      path: /etc/syslog-ng/ca.d/
+      state: directory
+      mode: '0755'
+    notify: Restart syslog-ng
+  - name: Copy syslog client certificate
+    ansible.builtin.copy:
+      src: "{{ syslog_tls_ca }}"
+      dest: /etc/syslog-ng/cert.d/clientcert.pem
+      mode: '0644'
+    notify: Restart syslog-ng
+  - name: Copy syslog key
+    ansible.builtin.copy:
+      src: "{{ syslog_tls_key }}"
+      dest: /etc/syslog-ng/cert.d/clientkey.pem
+      mode: '0400'
+    notify: Restart syslog-ng
+  - name: Copy syslog server ca
+    ansible.builtin.copy:
+      src: "{{ syslog_tls_server_ca }}"
+      dest: /etc/syslog-ng/ca.d/serverca.pem
+      mode: '0644'
+    notify: Restart syslog-ng
+
+- name: Retrieve user information for UID 1000
+  ansible.builtin.command: getent passwd 1000
+  register: user_info
+  changed_when: false
+- name: Extract username from the result
+  ansible.builtin.set_fact:
+    old_admin_user: "{{ user_info.stdout.split(':')[0] }}"
+
+- name: Removing or not the old admin user created by the iso
+  when: admin_user != old_admin_user
+  block:
+    - name: Remove old admin user from sudoers file
+      lineinfile:
+        dest: /etc/sudoers
+        state: absent
+        regexp: "^{{ old_admin_user }}"
+        validate: visudo -cf %s
+    - name: Remove the old admin user
+      ansible.builtin.user:
+        name: "{{ old_admin_user }}"
+        state: absent
+        remove: yes
+    - name: Remove the old admin group
+      ansible.builtin.group:
+        name: "{{ old_admin_user }}"
+        state: absent
+
+- name: Copy journald conf file
+  ansible.builtin.copy:
+    src: journald.conf
+    dest: /etc/systemd/journald.conf
+    mode: '0644'
+  notify: Restart systemd-journald
+
+- name: Ensure admin group exists
+  ansible.builtin.group:
+    name: "{{ admin_user }}"
+    state: present
+    gid: 1000
+- name: Adding admin user
+  user:
+    name: "{{ admin_user }}"
+    shell: /bin/bash
+    group: "{{ admin_user }}"
+    uid: 1000
+    password: "{{ admin_passwd | default(omit) }}"
+    append: no
+- name: Add authorized keys to admin user
+  ansible.posix.authorized_key:
+    user: "{{ admin_user }}"
+    key: "{{ item }}"
+  with_items: "{{ admin_ssh_keys }}"
+  when: admin_ssh_keys is defined and admin_ssh_keys is iterable
+- name: Install sudo admin user rules
+  copy:
+    content: |
+      {{ admin_user }}   ALL=NOPASSWD:EXEC: ALL
+    dest: "/etc/sudoers.d/{{ admin_user }}"
+    owner: root
+    group: root
+    mode: '0440'
+- name: Remove admin sudoers line created by build_debian_iso
+  lineinfile:
+    dest: /etc/sudoers
+    state: absent
+    regexp: '^{{ admin_user }}'
+    validate: visudo -cf %s
+
+- name: Copy sysctl rules
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: /etc/sysctl.d/{{ item }}
+    mode: '0644'
+  with_items:
+    - 00-panicreboot.conf
+
+- name: Customize /etc/environment
+  ansible.builtin.lineinfile:
+    dest: "/etc/environment"
+    state: present
+    regexp: "^{{ item.key }}="
+    line: "{{ item.key }}={{ item.value }}"
+  vars:
+    env_list:
+      HISTSIZE: 2000000
+      HISTFILESIZE: 2000000
+      LIBVIRT_DEFAULT_URI: "qemu:///system"
+      HISTTIMEFORMAT: '"%F %T "'
+      EDITOR: 'vim'
+      SYSTEMD_EDITOR: 'vim'
+  with_items: "{{ env_list | dict2items }}"
+
+- name: PATH for admin user
+  lineinfile:
+    dest: "/home/{{ admin_user }}/.bash_profile"
+    regexp: '^export PATH'
+    line: "export PATH=$PATH:/usr/sbin:/usr/local/sbin:/sbin"
+    state: present
+    create: yes
+    owner: "{{ admin_user }}"
+    group: "{{ admin_user }}"
+    mode: '0644'
+
+- name: Remove quiet from GRUB_CMDLINE_LINUX_DEFAULT option in grub conf
+  lineinfile:
+    dest: /etc/default/grub
+    regexp: "^(GRUB_CMDLINE_LINUX_DEFAULT=\")(.*?[ ])?quiet([ ].*)?(\")$"
+    line: '\1\2\3\4'
+    backrefs: yes
+  notify: Update-grub
+
+- name: Make sure GRUB_CMDLINE_LINUX_DEFAULT has no double space
+  lineinfile:
+    dest: /etc/default/grub
+    regexp: "^(GRUB_CMDLINE_LINUX_DEFAULT=\".*)[ ][ ](.*\")"
+    line: '\1 \2'
+    state: present
+    backrefs: yes
+  register: doublespace
+  until: not doublespace.changed
+  delay: 1
+  retries: 10
+
+- name: Make sure GRUB_CMDLINE_LINUX exists 1/2
+  lineinfile:
+    path: /etc/default/grub
+    regexp: "^GRUB_CMDLINE_LINUX=\".*\""
+    state: absent
+  check_mode: true
+  changed_when: false
+  register: check_grub_cmdline_linux
+
+- name: Make sure GRUB_CMDLINE_LINUX exists 2/2
+  lineinfile:
+    path: /etc/default/grub
+    state: present
+    line: "GRUB_CMDLINE_LINUX=\" \""
+  when: check_grub_cmdline_linux.found == 0
+
+- name: Make sure GRUB_CMDLINE_LINUX starts with a space
+  lineinfile:
+    dest: /etc/default/grub
+    regexp: "^(GRUB_CMDLINE_LINUX=)\"([ ]*)(.*)\""
+    line: '\1" \3"'
+    state: present
+    backrefs: yes
+
+- name: Make grub conf
+  lineinfile:
+    dest: /etc/default/grub
+    regexp: "^(GRUB_CMDLINE_LINUX=(?!.* {{ item }})\"[^\"]*)(\".*)"
+    line: '\1 {{ item }}\2'
+    state: present
+    backrefs: yes
+  notify: Update-grub
+  with_items:
+    - ipv6.disable=1
+    - efi=runtime
+    - fsck.mode=force
+    - fsck.repair=yes
+    - "{{ grub_append | default([]) }}"
+
+- name: Grub conf osprober
+  lineinfile:
+    dest: /etc/default/grub
+    regexp: '^#?GRUB_DISABLE_OS_PROBER=.*$'
+    line: 'GRUB_DISABLE_OS_PROBER=true'
+    state: present
+  notify: Update-grub
+
+- name: Stop and Disable NetworkManager
+  service:
+    name: NetworkManager
+    state: stopped
+    enabled: no
+
+- name: Start and Enable systemd-networkd
+  service:
+    name: systemd-networkd
+    state: started
+    enabled: yes

--- a/roles/oraclelinux/templates/syslog-ng.conf.j2
+++ b/roles/oraclelinux/templates/syslog-ng.conf.j2
@@ -1,0 +1,86 @@
+@version: 3.27
+# Copyright (C) 2022, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+# First, set some global options.
+options {
+        chain_hostnames(off);
+        flush_lines(0);
+        use_dns(no);
+        dns_cache(no);
+        use_fqdn(no);
+        owner("root");
+        group("adm");
+        perm(0640);
+        stats_freq(0);
+        bad_hostname("^gconfd$");
+};
+
+########################
+# Sources
+########################
+# This is the default behavior of sysklogd package
+# Logs may come from unix stream, but not from another machine.
+#
+source s_src {
+        systemd_journal();
+        internal();
+        file("/proc/kmsg" program_override("kernel"));
+};
+
+########################
+# Destinations
+########################
+destination d_syslog { file("/var/log/syslog-ng/syslog.local"); };
+
+{% if syslog_server_ip is defined %}
+# Network destination
+# mem-buff-size is set to 163840000 ~= 156MB (default value)
+# disk-buf-size is set to 1073741824 = 1GB
+destination d_net {
+        network(
+                "{{ syslog_server_ip }}"
+{% if syslog_tls_ca is defined and syslog_tls_key is defined %}
+                port({{ syslog_tls_port | default(6514) }})
+                transport("tls")
+                tls(
+                        key-file("/etc/syslog-ng/cert.d/clientkey.pem")
+                        cert-file("/etc/syslog-ng/cert.d/clientcert.pem")
+                        ca-dir("/etc/syslog-ng/ca.d")
+                )
+{% else %}
+                port({{ syslog_tcp_port | default(601) }})
+                transport("tcp")
+{% endif %}
+                time_zone("UTC")
+                disk-buffer(
+                        mem-buf-size(16384000)
+                        disk-buf-size(107374182)
+                        reliable(yes)
+                        dir("/var/log/syslog-ng")
+                )
+        );
+ };
+{% endif %}
+
+########################
+# Log paths
+########################
+{% if syslog_local is defined %}
+log {
+    source(s_src);
+    destination(d_syslog);
+};
+{% endif %}
+{% if syslog_server_ip is defined %}
+log {
+    source(s_src);
+{% if ansible_distribution == 'Debian' and ansible_distribution_version | int < 12 %}
+    if (program("libvirtd")) {
+      rewrite { set-facility("daemon"); };
+    };
+{% endif %}
+    destination(d_net);
+};
+{% endif %}
+

--- a/roles/oraclelinux_physical_machine/README.md
+++ b/roles/oraclelinux_physical_machine/README.md
@@ -1,0 +1,27 @@
+# OracleLinux Physical Machine Role
+
+This role apply the SEAPATH prerequisites for any OracleLinux physical machine (hypervisor, observer, or standalone).
+
+## Requirements
+
+No requirement.
+
+## Role Variables
+
+| Variable                       | Type        | Comments                                                                                                                             |
+|--------------------------------|-------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| extra_sysctl_physical_machines | String      | Custom systctl configuration separate by new spaces                                                                                  |
+| extra_kernel_modules           | String list | List of Kernel modules to load when booting                                                                                          |
+| admin_user                     | String      | Administrator Unix username                                                                                                          |
+| logstash_server_ip             | String      | Address IP of the logstash server                                                                                                    |
+| pacemaker_shutdown_timeout     | String      | Custom timeout for stopping the systemd Pacemaker service. Time is a seconds, but support the min suffix to use minutes.Default 2min |
+| chrony_wait_timeout_sec        | String      | Custom timeout for stopping the systemd Chrony service. Time is a seconds, but support the min suffix to use minutes.Default 180     |
+
+
+## Example Playbook
+
+```yaml
+- hosts: cluster_machines
+  roles:
+    - { role: seapath_ansible.oraclelinux_physical_machine }
+```

--- a/roles/oraclelinux_physical_machine/files/00-bridge_nf_call.conf
+++ b/roles/oraclelinux_physical_machine/files/00-bridge_nf_call.conf
@@ -1,0 +1,3 @@
+net.bridge.bridge-nf-call-arptables = 0
+net.bridge.bridge-nf-call-ip6tables = 0
+net.bridge.bridge-nf-call-iptables = 0

--- a/roles/oraclelinux_physical_machine/files/69-lvm.rules
+++ b/roles/oraclelinux_physical_machine/files/69-lvm.rules
@@ -1,0 +1,94 @@
+# Copyright (C) 2012,2021 Red Hat, Inc. All rights reserved.
+#
+# This file is part of LVM.
+#
+# This rule requires blkid to be called on block devices before so only devices
+# used as LVM PVs are processed (ID_FS_TYPE="LVM2_member").
+
+SUBSYSTEM!="block", GOTO="lvm_end"
+
+
+ENV{DM_UDEV_DISABLE_OTHER_RULES_FLAG}=="1", GOTO="lvm_end"
+
+# Only process devices already marked as a PV - this requires blkid to be called before.
+ENV{ID_FS_TYPE}!="LVM2_member", GOTO="lvm_end"
+ENV{DM_MULTIPATH_DEVICE_PATH}=="1", GOTO="lvm_end"
+ACTION=="remove", GOTO="lvm_end"
+
+# Create /dev/disk/by-id/lvm-pv-uuid-<PV_UUID> symlink for each PV
+ENV{ID_FS_UUID_ENC}=="?*", SYMLINK+="disk/by-id/lvm-pv-uuid-$env{ID_FS_UUID_ENC}"
+
+# If the PV is a special device listed below, scan only if the device is
+# properly activated. These devices are not usable after an ADD event,
+# but they require an extra setup and they are ready after a CHANGE event.
+# Also support coldplugging with ADD event but only if the device is already
+# properly activated.
+# This logic should be eventually moved to rules where those particular
+# devices are processed primarily (MD and loop).
+
+# DM device:
+KERNEL!="dm-[0-9]*", GOTO="next"
+ENV{DM_UDEV_PRIMARY_SOURCE_FLAG}=="1", ENV{DM_ACTIVATION}=="1", GOTO="lvm_scan"
+GOTO="lvm_end"
+
+# MD device:
+LABEL="next"
+KERNEL!="md[0-9]*", GOTO="next"
+IMPORT{db}="LVM_MD_PV_ACTIVATED"
+ACTION=="add", ENV{LVM_MD_PV_ACTIVATED}=="1", GOTO="lvm_scan"
+ACTION=="change", ENV{LVM_MD_PV_ACTIVATED}!="1", TEST=="md/array_state", ENV{LVM_MD_PV_ACTIVATED}="1", GOTO="lvm_scan"
+ACTION=="add", KERNEL=="md[0-9]*p[0-9]*", GOTO="lvm_scan"
+ENV{LVM_MD_PV_ACTIVATED}!="1", ENV{SYSTEMD_READY}="0"
+GOTO="lvm_end"
+
+# Loop device:
+LABEL="next"
+KERNEL!="loop[0-9]*", GOTO="next"
+ACTION=="add", ENV{LVM_LOOP_PV_ACTIVATED}=="1", GOTO="lvm_scan"
+ACTION=="change", ENV{LVM_LOOP_PV_ACTIVATED}!="1", TEST=="loop/backing_file", ENV{LVM_LOOP_PV_ACTIVATED}="1", GOTO="lvm_scan"
+ENV{LVM_LOOP_PV_ACTIVATED}!="1", ENV{SYSTEMD_READY}="0"
+GOTO="lvm_end"
+
+LABEL="next"
+ACTION!="add", GOTO="lvm_end"
+
+LABEL="lvm_scan"
+
+ENV{SYSTEMD_READY}="1"
+
+# pvscan will check if this device completes a VG,
+# i.e. all PVs in the VG are now present with the
+# arrival of this PV.  If so, it prints to stdout:
+# LVM_VG_NAME_COMPLETE='foo'
+#
+# When the VG is complete it can be activated, so
+# vgchange -aay <vgname> is run.  It is run via
+# systemd since it can take longer to run than
+# udev wants to block when processing rules.
+# (if there are hundreds of LVs to activate,
+# the vgchange can take many seconds.)
+#
+# pvscan only reads the single device specified,
+# and uses temp files under /run/lvm to check if
+# other PVs in the VG are present.
+#
+# If event_activation=0 in lvm.conf, this pvscan
+# (using checkcomplete) will do nothing, so that
+# no event-based autoactivation will be happen.
+#
+# TODO: adjust the output of vgchange -aay so that
+# it's better suited to appearing in the journal.
+
+IMPORT{program}="/sbin/lvm pvscan --cache --listvg --checkcomplete --vgonline --autoactivation event --udevoutput --journal=output $env{DEVNAME}"
+TEST!="/run/systemd/system", GOTO="lvm_direct_vgchange"
+
+ENV{LVM_VG_NAME_COMPLETE}=="?*", RUN+="/usr/bin/systemd-run --no-block --property DefaultDependencies=no --unit lvm-activate-$env{LVM_VG_NAME_COMPLETE} /sbin/lvm vgchange -aay --autoactivation event $env{LVM_VG_NAME_COMPLETE}"
+GOTO="lvm_end"
+
+LABEL="lvm_direct_vgchange"
+ENV{LVM_VG_NAME_COMPLETE}=="?*", RUN+="/sbin/lvm vgchange -aay --autoactivation event $env{LVM_VG_NAME_COMPLETE}"
+TEST!="/run/initramfs", GOTO="lvm_end"
+ENV{LVM_VG_NAME_INCOMPLETE}=="?*", RUN+="/sbin/lvm vgchange --sysinit -aay --activation degraded $env{LVM_VG_NAME_INCOMPLETE}"
+GOTO="lvm_end"
+
+LABEL="lvm_end"

--- a/roles/oraclelinux_physical_machine/files/etc_apparmor.d_abstractions_libvirt-qemu.conf
+++ b/roles/oraclelinux_physical_machine/files/etc_apparmor.d_abstractions_libvirt-qemu.conf
@@ -1,0 +1,252 @@
+  #include <abstractions/base>
+  #include <abstractions/consoles>
+  #include <abstractions/nameservice>
+
+  # required for reading disk images
+  capability dac_override,
+  capability dac_read_search,
+  capability chown,
+
+  # needed to drop privileges
+  capability setgid,
+  capability setuid,
+
+  network inet stream,
+  network inet6 stream,
+
+  ptrace (readby, tracedby) peer=libvirtd,
+  ptrace (readby, tracedby) peer=/usr/sbin/libvirtd,
+
+  signal (receive) peer=libvirtd,
+  signal (receive) peer=/usr/sbin/libvirtd,
+
+  /dev/kvm rw,
+  /dev/net/tun rw,
+  /dev/ptmx rw,
+  @{PROC}/*/status r,
+  # When qemu is signaled to terminate, it will read cmdline of signaling
+  # process for reporting purposes. Allowing read access to a process
+  # cmdline may leak sensitive information embedded in the cmdline.
+  @{PROC}/@{pid}/cmdline r,
+  # Per man(5) proc, the kernel enforces that a thread may
+  # only modify its comm value or those in its thread group.
+  owner @{PROC}/@{pid}/task/@{tid}/comm rw,
+  @{PROC}/sys/kernel/cap_last_cap r,
+  @{PROC}/sys/vm/overcommit_memory r,
+  # detect hardware capabilities via qemu_getauxval
+  owner @{PROC}/*/auxv r,
+
+  # For hostdev access. The actual devices will be added dynamically
+  /sys/bus/usb/devices/ r,
+  /sys/devices/**/usb[0-9]*/** r,
+  # libusb needs udev data about usb devices (~equal to content of lsusb -v)
+  /run/udev/data/+usb* r,
+  /run/udev/data/c16[6,7]* r,
+  /run/udev/data/c18[0,8,9]* r,
+
+  # WARNING: this gives the guest direct access to host hardware and specific
+  # portions of shared memory. This is required for sound using ALSA with kvm,
+  # but may constitute a security risk. If your environment does not require
+  # the use of sound in your VMs, feel free to comment out or prepend 'deny' to
+  # the rules for files in /dev.
+  /dev/snd/* rw,
+  /{dev,run}/shm r,
+  /{dev,run}/shmpulse-shm* r,
+  /{dev,run}/shmpulse-shm* rwk,
+  capability ipc_lock,
+  # spice
+  owner /{dev,run}/shm/spice.* rw,
+  # 'kill' is not required for sound and is a security risk. Do not enable
+  # unless you absolutely need it.
+  deny capability kill,
+
+  # Uncomment the following if you need access to /dev/fb*
+  #/dev/fb* rw,
+
+  /etc/pulse/client.conf r,
+  @{HOME}/.pulse-cookie rwk,
+  owner /root/.pulse-cookie rwk,
+  owner /root/.pulse/ rw,
+  owner /root/.pulse/* rw,
+  /usr/share/alsa/** r,
+  owner /tmp/pulse-*/ rw,
+  owner /tmp/pulse-*/* rw,
+  /var/lib/dbus/machine-id r,
+
+  # access to firmware's etc
+  /usr/share/AAVMF/** r,
+  /usr/share/bochs/** r,
+  /usr/share/edk2-ovmf/** rk,
+  /usr/share/kvm/** r,
+  /usr/share/misc/sgabios.bin r,
+  /usr/share/openbios/** r,
+  /usr/share/openhackware/** r,
+  /usr/share/OVMF/** rk,
+  /usr/share/ovmf/** rk,
+  /usr/share/proll/** r,
+  /usr/share/qemu-efi/** r,
+  /usr/share/qemu-kvm/** r,
+  /usr/share/qemu/** r,
+  /usr/share/seabios/** r,
+  /usr/share/sgabios/** r,
+  /usr/share/slof/** r,
+  /usr/share/vgabios/** r,
+
+  # pki for libvirt-vnc and libvirt-spice (LP: #901272, #1690140)
+  /etc/pki/CA/ r,
+  /etc/pki/CA/* r,
+  /etc/pki/libvirt{,-spice,-vnc}/ r,
+  /etc/pki/libvirt{,-spice,-vnc}/** r,
+  /etc/pki/qemu/ r,
+  /etc/pki/qemu/** r,
+
+  # the various binaries
+  /usr/bin/kvm rmix,
+  /usr/bin/kvm-spice rmix,
+  /usr/bin/qemu rmix,
+  /usr/bin/qemu-aarch64 rmix,
+  /usr/bin/qemu-alpha rmix,
+  /usr/bin/qemu-arm rmix,
+  /usr/bin/qemu-armeb rmix,
+  /usr/bin/qemu-cris rmix,
+  /usr/bin/qemu-i386 rmix,
+  /usr/bin/qemu-kvm rmix,
+  /usr/bin/qemu-m68k rmix,
+  /usr/bin/qemu-microblaze rmix,
+  /usr/bin/qemu-microblazeel rmix,
+  /usr/bin/qemu-mips rmix,
+  /usr/bin/qemu-mips64 rmix,
+  /usr/bin/qemu-mips64el rmix,
+  /usr/bin/qemu-mipsel rmix,
+  /usr/bin/qemu-mipsn32 rmix,
+  /usr/bin/qemu-mipsn32el rmix,
+  /usr/bin/qemu-or32 rmix,
+  /usr/bin/qemu-ppc rmix,
+  /usr/bin/qemu-ppc64 rmix,
+  /usr/bin/qemu-ppc64abi32 rmix,
+  /usr/bin/qemu-ppc64le rmix,
+  /usr/bin/qemu-s390x rmix,
+  /usr/bin/qemu-sh4 rmix,
+  /usr/bin/qemu-sh4eb rmix,
+  /usr/bin/qemu-sparc rmix,
+  /usr/bin/qemu-sparc32plus rmix,
+  /usr/bin/qemu-sparc64 rmix,
+  /usr/bin/qemu-system-aarch64 rmix,
+  /usr/bin/qemu-system-alpha rmix,
+  /usr/bin/qemu-system-arm rmix,
+  /usr/bin/qemu-system-cris rmix,
+  /usr/bin/qemu-system-hppa rmix,
+  /usr/bin/qemu-system-i386 rmix,
+  /usr/bin/qemu-system-lm32 rmix,
+  /usr/bin/qemu-system-m68k rmix,
+  /usr/bin/qemu-system-microblaze rmix,
+  /usr/bin/qemu-system-microblazeel rmix,
+  /usr/bin/qemu-system-mips rmix,
+  /usr/bin/qemu-system-mips64 rmix,
+  /usr/bin/qemu-system-mips64el rmix,
+  /usr/bin/qemu-system-mipsel rmix,
+  /usr/bin/qemu-system-moxie rmix,
+  /usr/bin/qemu-system-nios2 rmix,
+  /usr/bin/qemu-system-or1k rmix,
+  /usr/bin/qemu-system-or32 rmix,
+  /usr/bin/qemu-system-ppc rmix,
+  /usr/bin/qemu-system-ppc64 rmix,
+  /usr/bin/qemu-system-ppcemb rmix,
+  /usr/bin/qemu-system-riscv32 rmix,
+  /usr/bin/qemu-system-riscv64 rmix,
+  /usr/bin/qemu-system-s390x rmix,
+  /usr/bin/qemu-system-sh4 rmix,
+  /usr/bin/qemu-system-sh4eb rmix,
+  /usr/bin/qemu-system-sparc rmix,
+  /usr/bin/qemu-system-sparc64 rmix,
+  /usr/bin/qemu-system-tricore rmix,
+  /usr/bin/qemu-system-unicore32 rmix,
+  /usr/bin/qemu-system-x86_64 rmix,
+  /usr/bin/qemu-system-xtensa rmix,
+  /usr/bin/qemu-system-xtensaeb rmix,
+  /usr/bin/qemu-unicore32 rmix,
+  /usr/bin/qemu-x86_64 rmix,
+  # for Debian/Ubuntu qemu-block-extra / RPMs qemu-block-* (LP: #1554761)
+  /usr/{lib,lib64}/qemu/*.so mr,
+  /usr/lib/@{multiarch}/qemu/*.so mr,
+
+  # let qemu load old shared objects after upgrades (LP: #1847361)
+  /{var/,}run/qemu/*/*.so mr,
+  # but explicitly deny writing to these files
+  audit deny /{var/,}run/qemu/*/*.so w,
+
+  # swtpm
+  /{usr/,}bin/swtpm rmix,
+  /usr/{lib,lib64}/libswtpm_libtpms.so mr,
+  /usr/lib/@{multiarch}/libswtpm_libtpms.so mr,
+
+  # for save and resume
+  /{usr/,}bin/dash rmix,
+  /{usr/,}bin/dd rmix,
+  /{usr/,}bin/cat rmix,
+
+  # for restore
+  /{usr/,}bin/bash rmix,
+
+  # for usb access
+  /dev/bus/usb/ r,
+  /etc/udev/udev.conf r,
+  /sys/bus/ r,
+  /sys/class/ r,
+
+  # for rbd
+  /etc/ceph/ceph.conf r,
+
+  # Various functions will need to enumerate /tmp (e.g. ceph), allow the base
+  # dir and a few known functions like samba support.
+  # We want to avoid to give blanket rw permission to everything under /tmp,
+  # users are expected to add site specific addons for more uncommon cases.
+  # Qemu processes usually all run as the same users, so the "owner"
+  # restriction prevents access to other services files, but not across
+  # different instances.
+  # This is a tradeoff between usability and security - if paths would be more
+  # predictable that would be preferred - at least for write rules we would
+  # want more unique paths per rule.
+  /{,var/}tmp/ r,
+  owner /{,var/}tmp/**/ r,
+
+  # for file-posix getting limits since 9103f1ce
+  /sys/devices/**/block/*/queue/max_segments r,
+
+  # for ppc device-tree access
+  @{PROC}/device-tree/ r,
+  @{PROC}/device-tree/** r,
+  /sys/firmware/devicetree/** r,
+
+  # allow connect with openGraphicsFD to work
+  unix (send, receive) type=stream addr=none peer=(label=libvirtd),
+  unix (send, receive) type=stream addr=none peer=(label=/usr/sbin/libvirtd),
+
+  # for gathering information about available host resources
+  /sys/devices/system/cpu/ r,
+  /sys/devices/system/node/ r,
+  /sys/devices/system/node/node[0-9]*/meminfo r,
+  /sys/module/vhost/parameters/max_mem_regions r,
+
+  # silence refusals to open lttng files (see LP: #1432644)
+  deny /dev/shm/lttng-ust-wait-* r,
+  deny /run/shm/lttng-ust-wait-* r,
+
+  # for vfio hotplug on systems without static vfio (LP: #1775777)
+  /dev/vfio/vfio rw,
+
+  # required for sasl GSSAPI plugin
+  /etc/gss/mech.d/ r,
+  /etc/gss/mech.d/* r,
+
+  # required by libpmem init to fts_open()/fts_read() the symlinks in
+  # /sys/bus/nd/devices
+  / r, # harmless on any lsb compliant system
+  /sys/bus/nd/devices/{,**/} r,
+
+  # Site-specific additions and overrides. See local/README for details.
+  #include <local/abstractions/libvirt-qemu>
+
+  # required for QEMU accessing UEFI nvram variables
+  owner /var/lib/libvirt/qemu/nvram/*_VARS.fd rwk,
+  owner /var/lib/libvirt/qemu/nvram/*_VARS.ms.fd rwk,

--- a/roles/oraclelinux_physical_machine/files/modules/netfilter.conf
+++ b/roles/oraclelinux_physical_machine/files/modules/netfilter.conf
@@ -1,0 +1,1 @@
+br_netfilter

--- a/roles/oraclelinux_physical_machine/files/modules/raid6_pq.conf
+++ b/roles/oraclelinux_physical_machine/files/modules/raid6_pq.conf
@@ -1,0 +1,1 @@
+br_netfilter

--- a/roles/oraclelinux_physical_machine/files/pacemaker_ra/VirtualDomain
+++ b/roles/oraclelinux_physical_machine/files/pacemaker_ra/VirtualDomain
@@ -1,0 +1,1209 @@
+#!/bin/sh
+#
+# Support:	  users@clusterlabs.org
+# License:	  GNU General Public License (GPL)
+#
+#   Resource Agent for domains managed by the libvirt API.
+#   Requires a running libvirt daemon (libvirtd).
+#
+#   (c) 2008-2010 Florian Haas, Dejan Muhamedagic,
+#				 and Linux-HA contributors
+#
+#		usage: $0 {start|stop|status|monitor|migrate_to|migrate_from|meta-data|validate-all}
+#
+#######################################################################
+# Initialization:
+: ${OCF_FUNCTIONS_DIR=${OCF_ROOT}/lib/heartbeat}
+. ${OCF_FUNCTIONS_DIR}/ocf-shellfuncs
+
+# Defaults
+OCF_RESKEY_config_default=""
+OCF_RESKEY_migration_transport_default=""
+OCF_RESKEY_migration_downtime_default=0
+OCF_RESKEY_migration_speed_default=0
+OCF_RESKEY_migration_network_suffix_default=""
+OCF_RESKEY_force_stop_default=0
+OCF_RESKEY_monitor_scripts_default=""
+OCF_RESKEY_autoset_utilization_cpu_default="true"
+OCF_RESKEY_autoset_utilization_host_memory_default="true"
+OCF_RESKEY_autoset_utilization_hv_memory_default="true"
+OCF_RESKEY_unset_utilization_cpu_default="false"
+OCF_RESKEY_unset_utilization_host_memory_default="false"
+OCF_RESKEY_unset_utilization_hv_memory_default="false"
+OCF_RESKEY_migrateport_default=$(( 49152 + $(ocf_maybe_random) % 64 ))
+OCF_RESKEY_CRM_meta_timeout_default=90000
+OCF_RESKEY_save_config_on_stop_default=false
+OCF_RESKEY_sync_config_on_stop_default=false
+OCF_RESKEY_snapshot_default=""
+OCF_RESKEY_backingfile_default=""
+OCF_RESKEY_stateless_default="false"
+OCF_RESKEY_copyindirs_default=""
+OCF_RESKEY_shutdown_mode_default=""
+OCF_RESKEY_start_resources_default="false"
+OCF_RESKEY_seapath_default="false"
+
+: ${OCF_RESKEY_config=${OCF_RESKEY_config_default}}
+: ${OCF_RESKEY_migration_transport=${OCF_RESKEY_migration_transport_default}}
+: ${OCF_RESKEY_migration_downtime=${OCF_RESKEY_migration_downtime_default}}
+: ${OCF_RESKEY_migration_speed=${OCF_RESKEY_migration_speed_default}}
+: ${OCF_RESKEY_migration_network_suffix=${OCF_RESKEY_migration_network_suffix_default}}
+: ${OCF_RESKEY_force_stop=${OCF_RESKEY_force_stop_default}}
+: ${OCF_RESKEY_monitor_scripts=${OCF_RESKEY_monitor_scripts_default}}
+: ${OCF_RESKEY_autoset_utilization_cpu=${OCF_RESKEY_autoset_utilization_cpu_default}}
+: ${OCF_RESKEY_autoset_utilization_host_memory=${OCF_RESKEY_autoset_utilization_host_memory_default}}
+: ${OCF_RESKEY_autoset_utilization_hv_memory=${OCF_RESKEY_autoset_utilization_hv_memory_default}}
+: ${OCF_RESKEY_unset_utilization_cpu=${OCF_RESKEY_unset_utilization_cpu_default}}
+: ${OCF_RESKEY_unset_utilization_host_memory=${OCF_RESKEY_unset_utilization_host_memory_default}}
+: ${OCF_RESKEY_unset_utilization_hv_memory=${OCF_RESKEY_unset_utilization_hv_memory_default}}
+: ${OCF_RESKEY_migrateport=${OCF_RESKEY_migrateport_default}}
+: ${OCF_RESKEY_CRM_meta_timeout=${OCF_RESKEY_CRM_meta_timeout_default}}
+: ${OCF_RESKEY_save_config_on_stop=${OCF_RESKEY_save_config_on_stop_default}}
+: ${OCF_RESKEY_sync_config_on_stop=${OCF_RESKEY_sync_config_on_stop_default}}
+: ${OCF_RESKEY_snapshot=${OCF_RESKEY_snapshot_default}}
+: ${OCF_RESKEY_backingfile=${OCF_RESKEY_backingfile_default}}
+: ${OCF_RESKEY_stateless=${OCF_RESKEY_stateless_default}}
+: ${OCF_RESKEY_copyindirs=${OCF_RESKEY_copyindirs_default}}
+: ${OCF_RESKEY_shutdown_mode=${OCF_RESKEY_shutdown_mode_default}}
+: ${OCF_RESKEY_start_resources=${OCF_RESKEY_start_resources_default}}
+: ${OCF_RESKEY_seapath=${OCF_RESKEY_seapath_default}}
+
+if ocf_is_true ${OCF_RESKEY_sync_config_on_stop}; then
+	OCF_RESKEY_save_config_on_stop="true"
+fi
+#######################################################################
+
+## I'd very much suggest to make this RA use bash,
+## and then use magic $SECONDS.
+## But for now:
+NOW=$(date +%s)
+
+usage() {
+  echo "usage: $0 {start|stop|status|monitor|migrate_to|migrate_from|meta-data|validate-all}"
+}
+
+VirtualDomain_meta_data() {
+		cat <<EOF
+<?xml version="1.0"?>
+<!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
+<resource-agent name="VirtualDomain" version="1.1">
+<version>1.0</version>
+
+<longdesc lang="en">
+Resource agent for a virtual domain (a.k.a. domU, virtual machine,
+virtual environment etc., depending on context) managed by libvirtd.
+</longdesc>
+<shortdesc lang="en">Manages virtual domains through the libvirt virtualization framework</shortdesc>
+
+<parameters>
+
+<parameter name="config" unique="1" required="1">
+<longdesc lang="en">
+Absolute path to the libvirt configuration file,
+for this virtual domain.
+</longdesc>
+<shortdesc lang="en">Virtual domain configuration file</shortdesc>
+<content type="string" default="${OCF_RESKEY_config_default}" />
+</parameter>
+
+<parameter name="hypervisor" unique="0" required="0">
+<longdesc lang="en">
+Hypervisor URI to connect to. See the libvirt documentation for
+details on supported URI formats. The default is system dependent.
+Determine the system's default uri by running 'virsh --quiet uri'.
+</longdesc>
+<shortdesc lang="en">Hypervisor URI</shortdesc>
+<content type="string"/>
+</parameter>
+
+<parameter name="force_stop" unique="0" required="0">
+<longdesc lang="en">
+Always forcefully shut down ("destroy") the domain on stop. The default
+behavior is to resort to a forceful shutdown only after a graceful
+shutdown attempt has failed. You should only set this to true if
+your virtual domain (or your virtualization backend) does not support
+graceful shutdown.
+</longdesc>
+<shortdesc lang="en">Always force shutdown on stop</shortdesc>
+<content type="boolean" default="${OCF_RESKEY_force_stop_default}" />
+</parameter>
+
+<parameter name="migration_transport" unique="0" required="0">
+<longdesc lang="en">
+Transport used to connect to the remote hypervisor while
+migrating. Please refer to the libvirt documentation for details on
+transports available. If this parameter is omitted, the resource will
+use libvirt's default transport to connect to the remote hypervisor.
+</longdesc>
+<shortdesc lang="en">Remote hypervisor transport</shortdesc>
+<content type="string" default="${OCF_RESKEY_migration_transport_default}" />
+</parameter>
+
+<parameter name="migration_user" unique="0" required="0">
+<longdesc lang="en">
+The username will be used in the remote libvirt remoteuri/migrateuri. No user will be
+given (which means root) in the username if omitted
+
+If remoteuri is set, migration_user will be ignored.
+</longdesc>
+<shortdesc lang="en">Remote username for the remoteuri</shortdesc>
+<content type="string" />
+</parameter>
+
+<parameter name="migration_downtime" unique="0" required="0">
+<longdesc lang="en">
+Define max downtime during live migration in milliseconds
+</longdesc>
+<shortdesc lang="en">Live migration downtime</shortdesc>
+<content type="integer" default="${OCF_RESKEY_migration_downtime_default}" />
+</parameter>
+
+<parameter name="migration_speed" unique="0" required="0">
+<longdesc lang="en">
+Define live migration speed per resource in MiB/s
+</longdesc>
+<shortdesc lang="en">Live migration speed</shortdesc>
+<content type="integer" default="${OCF_RESKEY_migration_speed_default}" />
+</parameter>
+
+<parameter name="migration_network_suffix" unique="0" required="0">
+<longdesc lang="en">
+Use a dedicated migration network. The migration URI is composed by
+adding this parameters value to the end of the node name. If the node
+name happens to be an FQDN (as opposed to an unqualified host name),
+insert the suffix immediately prior to the first period (.) in the FQDN.
+At the moment Qemu/KVM and Xen migration via a dedicated network is supported.
+
+Note: Be sure this composed host name is locally resolvable and the
+associated IP is reachable through the favored network. This suffix will
+be added to the remoteuri and migrateuri parameters.
+
+See also the migrate_options parameter below.
+</longdesc>
+<shortdesc lang="en">Migration network host name suffix</shortdesc>
+<content type="string" default="${OCF_RESKEY_migration_network_suffix_default}" />
+</parameter>
+
+<parameter name="migrateuri" unique="0" required="0">
+<longdesc lang="en">
+You can also specify here if the calculated migrate URI is unsuitable for your
+environment.
+
+If migrateuri is set then migration_network_suffix, migrateport and
+--migrateuri in migrate_options are effectively ignored. Use "%n" as the
+placeholder for the target node name.
+
+Please refer to the libvirt documentation for details on guest
+migration.
+</longdesc>
+<shortdesc lang="en">Custom migrateuri for migration state transfer</shortdesc>
+<content type="string" />
+</parameter>
+
+<parameter name="migrate_options" unique="0" required="0">
+<longdesc lang="en">
+Extra virsh options for the guest live migration. You can also specify
+here --migrateuri if the calculated migrate URI is unsuitable for your
+environment. If --migrateuri is set then migration_network_suffix
+and migrateport are effectively ignored. Use "%n" as the placeholder
+for the target node name.
+
+Please refer to the libvirt documentation for details on guest
+migration.
+</longdesc>
+<shortdesc lang="en">live migrate options</shortdesc>
+<content type="string" />
+</parameter>
+
+<parameter name="monitor_scripts" unique="0" required="0">
+<longdesc lang="en">
+To additionally monitor services within the virtual domain, add this
+parameter with a list of scripts to monitor.
+
+Note: when monitor scripts are used, the start and migrate_from operations
+will complete only when all monitor scripts have completed successfully.
+Be sure to set the timeout of these operations to accommodate this delay.
+</longdesc>
+<shortdesc lang="en">space-separated list of monitor scripts</shortdesc>
+<content type="string" default="${OCF_RESKEY_monitor_scripts_default}" />
+</parameter>
+
+<parameter name="autoset_utilization_cpu" unique="0" required="0">
+<longdesc lang="en">
+If set true, the agent will detect the number of domainU's vCPUs from virsh, and put it
+into the CPU utilization of the resource when the monitor is executed.
+</longdesc>
+<shortdesc lang="en">Enable auto-setting the CPU utilization of the resource</shortdesc>
+<content type="boolean" default="${OCF_RESKEY_autoset_utilization_cpu_default}" />
+</parameter>
+
+<parameter name="autoset_utilization_host_memory" unique="0" required="0">
+<longdesc lang="en">
+If set true, the agent will detect the number of *Max memory* from virsh, and put it
+into the host_memory utilization of the resource when the monitor is executed.
+</longdesc>
+<shortdesc lang="en">Enable auto-setting the host_memory utilization of the resource</shortdesc>
+<content type="boolean" default="${OCF_RESKEY_autoset_utilization_host_memory_default}" />
+</parameter>
+
+<parameter name="autoset_utilization_hv_memory" unique="0" required="0">
+<longdesc lang="en">
+If set true, the agent will detect the number of *Max memory* from virsh, and put it
+into the hv_memory utilization of the resource when the monitor is executed.
+</longdesc>
+<shortdesc lang="en">Enable auto-setting the hv_memory utilization of the resource</shortdesc>
+<content type="boolean" default="${OCF_RESKEY_autoset_utilization_hv_memory_default}" />
+</parameter>
+
+<parameter name="unset_utilization_cpu" unique="0" required="0">
+<longdesc lang="en">
+If set true then the agent will remove the cpu utilization resource when the monitor
+is executed.
+</longdesc>
+<shortdesc lang="en">Enable auto-removing the CPU utilization of the resource</shortdesc>
+<content type="boolean" default="${OCF_RESKEY_unset_utilization_cpu_default}" />
+</parameter>
+
+<parameter name="unset_utilization_host_memory" unique="0" required="0">
+<longdesc lang="en">
+If set true then the agent will remove the host_memory utilization resource when the monitor
+is executed.
+</longdesc>
+<shortdesc lang="en">Enable auto-removing the host_memory utilization of the resource</shortdesc>
+<content type="boolean" default="${OCF_RESKEY_unset_utilization_host_memory_default}" />
+</parameter>
+
+<parameter name="unset_utilization_hv_memory" unique="0" required="0">
+<longdesc lang="en">
+If set true then the agent will remove the hv_memory utilization resource when the monitor
+is executed.
+</longdesc>
+<shortdesc lang="en">Enable auto-removing the hv_memory utilization of the resource</shortdesc>
+<content type="boolean" default="${OCF_RESKEY_unset_utilization_hv_memory_default}" />
+</parameter>
+
+<parameter name="migrateport" unique="0" required="0">
+<longdesc lang="en">
+This port will be used in the qemu migrateuri. If unset, the port will be a random highport.
+</longdesc>
+<shortdesc lang="en">Port for migrateuri</shortdesc>
+<content type="integer" />
+</parameter>
+
+<parameter name="remoteuri" unique="0" required="0">
+<longdesc lang="en">
+Use this URI as virsh connection URI to commuicate with a remote hypervisor.
+
+If remoteuri is set then migration_user and migration_network_suffix are
+effectively ignored. Use "%n" as the placeholder for the target node name.
+
+Please refer to the libvirt documentation for details on guest
+migration.
+</longdesc>
+<shortdesc lang="en">Custom remoteuri to communicate with a remote hypervisor</shortdesc>
+<content type="string" />
+</parameter>
+
+<parameter name="save_config_on_stop" unique="0" required="0">
+<longdesc lang="en">
+Changes to a running VM's config are normally lost on stop.
+This parameter instructs the RA to save the configuration back to the xml file provided in the "config" parameter.
+</longdesc>
+<shortdesc lang="en">Save running VM's config back to its config file</shortdesc>
+<content type="boolean" />
+</parameter>
+
+<parameter name="sync_config_on_stop" unique="0" required="0">
+<longdesc lang="en">
+Setting this automatically enables save_config_on_stop.
+When enabled this parameter instructs the RA to
+call csync2 -x to synchronize the file to all nodes.
+csync2 must be properly set up for this to work.
+</longdesc>
+<shortdesc lang="en">Save running VM's config back to its config file</shortdesc>
+<content type="boolean" />
+</parameter>
+
+<parameter name="snapshot">
+<longdesc lang="en">
+Path to the snapshot directory where the virtual machine image will be stored.  When this
+parameter is set, the virtual machine's RAM state will be saved to a file in the snapshot
+directory when stopped.  If on start a state file is present for the domain, the domain
+will be restored to the same state it was in right before it stopped last.  This option
+is incompatible with the 'force_stop' option.
+</longdesc>
+<shortdesc lang="en">
+Restore state on start/stop
+</shortdesc>
+<content type="string" default="${OCF_RESKEY_snapshot_default}"/>
+</parameter>
+
+<parameter name="backingfile" unique="0" required="0">
+<longdesc lang="en">
+When the VM is used in Copy-On-Write mode, this is the backing file to use (with its full path).
+The VMs image will be created based on this backing file.
+This backing file will never be changed during the life of the VM.
+</longdesc>
+<shortdesc lang="en">If the VM is wanted to work with Copy-On-Write mode, this is the backing file to use (with its full path)</shortdesc>
+<content type="string" default="${OCF_RESKEY_backingfile_default}" />
+</parameter>
+
+<parameter name="stateless" unique="0" required="0">
+<longdesc lang="en">
+If set to true and backingfile is defined, the start of the VM will systematically create a new qcow2 based on
+the backing file, therefore the VM will always be stateless.  If set to false, the start of the VM will use the
+COW (&lt;vmname&gt;.qcow2) file if it exists, otherwise the first start will create a new qcow2 based on the backing
+file given as backingfile.
+</longdesc>
+<shortdesc lang="en">If set to true, the (&lt;vmname&gt;.qcow2) file will be re-created at each start, based on the backing file (if defined)</shortdesc>
+<content type="boolean" default="${OCF_RESKEY_stateless_default}" />
+</parameter>
+
+<parameter name="copyindirs" unique="0" required="0">
+<longdesc lang="en">
+List of directories for the virt-copy-in before booting the VM. Used only in stateless mode.
+</longdesc>
+<shortdesc lang="en">List of directories for the virt-copy-in before booting the VM stateless mode.</shortdesc>
+<content type="string" default="${OCF_RESKEY_copyindirs_default}" />
+</parameter>
+
+<parameter name="shutdown_mode">
+<longdesc lang="en">
+virsh shutdown method to use. Please verify that it is supported by your virsh toolsed with 'virsh help shutdown'
+When this parameter is set --mode shutdown_mode is passed as an additional argument to the 'virsh shutdown' command.
+One can use this option in case default acpi method does not work. Verify that this mode is supported
+by your VM.  By default --mode is not passed.
+</longdesc>
+<shortdesc lang="en">
+Instruct virsh to use specific shutdown mode
+</shortdesc>
+<content type="string" default="${OCF_RESKEY_shutdown_mode_default}"/>
+</parameter>
+
+<parameter name="start_resources">
+<longdesc lang="en">
+Start the virtual storage pools and networks used by the virtual machine before starting it or before live migrating it.
+</longdesc>
+<shortdesc lang="en">
+Ensure the needed virtual storage pools and networks are started
+</shortdesc>
+<content type="boolean" default="${OCF_RESKEY_start_resources_default}"/>
+</parameter>
+
+<parameter name="seapath" unique="0" required="0">
+<longdesc lang="en">
+Work on Seapath cluster.
+</longdesc>
+<shortdesc lang="en">Enable seapath cluster support</shortdesc>
+<content type="boolean" default="${OCF_RESKEY_seapath_default}"/>
+</parameter>
+
+</parameters>
+
+<actions>
+<action name="start" timeout="90s" />
+<action name="stop" timeout="90s" />
+<action name="status" depth="0" timeout="30s" interval="10s" />
+<action name="monitor" depth="0" timeout="30s" interval="10s" />
+<action name="migrate_from" timeout="60s" />
+<action name="migrate_to" timeout="120s" />
+<action name="meta-data" timeout="5s" />
+<action name="validate-all" timeout="5s" />
+</actions>
+</resource-agent>
+EOF
+}
+
+set_util_attr() {
+	local attr=$1 val=$2
+	local cval outp
+
+	cval=$(crm_resource -Q -r $OCF_RESOURCE_INSTANCE -z -g $attr 2>/dev/null)
+	if [ $? -ne 0 ] && [ -z "$cval" ]; then
+		crm_resource -Q -r $OCF_RESOURCE_INSTANCE -z -g $attr 2>&1 | grep -e "not connected" > /dev/null 2>&1
+		if [ $? -eq 0 ]; then
+			ocf_log debug "Unable to set utilization attribute, cib is not available"
+			return
+		fi
+	fi
+
+	if [ "$cval" != "$val" ]; then
+		outp=$(crm_resource -r $OCF_RESOURCE_INSTANCE -z -p $attr -v $val 2>&1) ||
+		ocf_log warn "crm_resource failed to set utilization attribute $attr: $outp"
+	fi
+}
+
+unset_util_attr() {
+	local attr=$1
+	local cval outp
+
+	outp=$(crm_resource --resource=$OCF_RESOURCE_INSTANCE --utilization --delete-parameter=$attr 2>&1) ||
+	ocf_log warn "crm_resource failed to unset utilization attribute $attr: $outp"
+}
+
+update_utilization() {
+	local dom_cpu dom_mem
+
+	if ocf_is_true "$OCF_RESKEY_autoset_utilization_cpu"; then
+		dom_cpu=$(LANG=C virsh $VIRSH_OPTIONS dominfo ${DOMAIN_NAME} 2>/dev/null | awk '/CPU\(s\)/{print $2}')
+		test -n "$dom_cpu" && set_util_attr cpu $dom_cpu
+	elif ocf_is_true "$OCF_RESKEY_unset_utilization_cpu"; then
+		unset_util_attr cpu
+	fi
+
+	if ocf_is_true "$OCF_RESKEY_autoset_utilization_host_memory"; then
+		dom_mem=$(LANG=C virsh $VIRSH_OPTIONS dominfo ${DOMAIN_NAME} 2>/dev/null | awk '/Max memory/{printf("%d", $3/1024)}')
+		test -n "$dom_mem" && set_util_attr host_memory "$dom_mem"
+	elif ocf_is_true "$OCF_RESKEY_unset_utilization_host_memory"; then
+		unset_util_attr host_memory
+	fi
+
+	if ocf_is_true "$OCF_RESKEY_autoset_utilization_hv_memory"; then
+		dom_mem=$(LANG=C virsh $VIRSH_OPTIONS dominfo ${DOMAIN_NAME} 2>/dev/null | awk '/Max memory/{printf("%d", $3/1024)}')
+		test -n "$dom_mem" && set_util_attr hv_memory "$dom_mem"
+	elif ocf_is_true "$OCF_RESKEY_unset_utilization_hv_memory"; then
+		unset_util_attr hv_memory
+	fi
+}
+
+get_emulator()
+{
+	local emulator=""
+
+	emulator=$(virsh $VIRSH_OPTIONS dumpxml $DOMAIN_NAME 2>/dev/null | sed -n -e 's/^.*<emulator>\(.*\)<\/emulator>.*$/\1/p')
+	if [ -z "$emulator" ] && [ -e "$EMULATOR_STATE" ]; then
+		emulator=$(cat $EMULATOR_STATE)
+	fi
+	if [ -z "$emulator" ]; then
+		emulator=$(cat ${OCF_RESKEY_config} | sed -n -e 's/^.*<emulator>\(.*\)<\/emulator>.*$/\1/p')
+	fi
+
+	if [ -n "$emulator" ]; then
+		basename $emulator
+	fi
+}
+
+update_emulator_cache()
+{
+	local emulator
+
+	emulator=$(get_emulator)
+	if [ -n "$emulator" ]; then
+		echo $emulator > $EMULATOR_STATE
+	fi
+}
+
+# attempt to check domain status outside of libvirt using the emulator process
+pid_status()
+{
+	local rc=$OCF_ERR_GENERIC
+	local emulator=$(get_emulator)
+	# An emulator is not required, so only report message in debug mode
+	local loglevel="debug"
+
+	if ocf_is_probe; then
+		loglevel="notice"
+	fi
+
+	case "$emulator" in
+		qemu-kvm|qemu-dm|qemu-system-*)
+			rc=$OCF_NOT_RUNNING
+			ps awx | grep -E "[q]emu-(kvm|dm|system).*-name ($DOMAIN_NAME|[^ ]*guest=$DOMAIN_NAME(,[^ ]*)?) " > /dev/null 2>&1
+			if [ $? -eq 0 ]; then
+				rc=$OCF_SUCCESS
+			fi
+			;;
+		libvirt_lxc)
+			rc=$OCF_NOT_RUNNING
+			ps awx | grep -E "[l]ibvirt_lxc.*-name ($DOMAIN_NAME|[^ ]*guest=$DOMAIN_NAME(,[^ ]*)?) " > /dev/null 2>&1
+			if [ $? -eq 0 ]; then
+				rc=$OCF_SUCCESS
+			fi
+			;;
+		# This can be expanded to check for additional emulators
+		*)
+			# We may be running xen with PV domains, they don't
+			# have an emulator set. try xl list or xen-lists
+			if have_binary xl; then
+				rc=$OCF_NOT_RUNNING
+				xl list $DOMAIN_NAME >/dev/null 2>&1
+				if [ $? -eq 0 ]; then
+					rc=$OCF_SUCCESS
+				fi
+			elif have_binary xen-list; then
+				rc=$OCF_NOT_RUNNING
+				xen-list $DOMAIN_NAME 2>/dev/null | grep -qs "State.*[-r][-b][-p]--" 2>/dev/null
+				if [ $? -eq 0 ]; then
+					rc=$OCF_SUCCESS
+				fi
+			else
+				ocf_log $loglevel "Unable to determine emulator for $DOMAIN_NAME"
+			fi
+			;;
+	esac
+
+	if [ $rc -eq $OCF_SUCCESS ]; then
+		ocf_log debug "Virtual domain $DOMAIN_NAME is currently running."
+	elif [ $rc -eq $OCF_NOT_RUNNING ]; then
+		ocf_log debug "Virtual domain $DOMAIN_NAME is currently not running."
+	fi
+
+	return $rc
+}
+
+VirtualDomain_status() {
+	local try=0
+	rc=$OCF_ERR_GENERIC
+	status="no state"
+	while [ "$status" = "no state" ]; do
+		try=$(($try + 1 ))
+		status=$(LANG=C virsh $VIRSH_OPTIONS domstate $DOMAIN_NAME 2>&1 | tr 'A-Z' 'a-z')
+		case "$status" in
+			*"error:"*"domain not found"|*"error:"*"failed to get domain"*|"shut off")
+				# shut off: domain is defined, but not started, will not happen if
+				#   domain is created but not defined
+				# "Domain not found" or "failed to get domain": domain is not defined
+				#   and thus not started
+				ocf_log debug "Virtual domain $DOMAIN_NAME is not running: $(echo $status | sed s/error://g)"
+				rc=$OCF_NOT_RUNNING
+				;;
+			running|paused|idle|blocked|"in shutdown")
+				# running: domain is currently actively consuming cycles
+				# paused: domain is paused (suspended)
+				# idle: domain is running but idle
+				# blocked: synonym for idle used by legacy Xen versions
+				# in shutdown: the domain is in process of shutting down, but has not completely shutdown or crashed.
+				ocf_log debug "Virtual domain $DOMAIN_NAME is currently $status."
+				rc=$OCF_SUCCESS
+				;;
+			""|*"failed to "*"connect to the hypervisor"*|"no state")
+				# Empty string may be returned when virsh does not
+				# receive a reply from libvirtd.
+				# "no state" may occur when the domain is currently
+				# being migrated (on the migration target only), or
+				# whenever virsh can't reliably obtain the domain
+				# state.
+				status="no state"
+				if [ "$__OCF_ACTION" = "stop" ] && [ $try -ge 3 ]; then
+					# During the stop operation, we want to bail out
+					# quickly, so as to be able to force-stop (destroy)
+					# the domain if necessary.
+					ocf_exit_reason "Virtual domain $DOMAIN_NAME has no state during stop operation, bailing out."
+					return $OCF_ERR_GENERIC;
+				elif [ "$__OCF_ACTION" = "monitor" ]; then
+					pid_status
+					rc=$?
+					if [ $rc -ne $OCF_ERR_GENERIC ]; then
+						# we've successfully determined the domains status outside of libvirt
+						return $rc
+					fi
+
+				else
+					# During all other actions, we just wait and try
+					# again, relying on the CRM/LRM to time us out if
+					# this takes too long.
+					ocf_log info "Virtual domain $DOMAIN_NAME currently has no state, retrying."
+				fi
+				sleep 1
+				;;
+			*)
+				# any other output is unexpected.
+				ocf_log error "Virtual domain $DOMAIN_NAME has unknown status \"$status\"!"
+				sleep 1
+				;;
+		esac
+	done
+	return $rc
+}
+
+# virsh undefine removes configuration files if they are in
+# directories which are managed by libvirt. such directories
+# include also subdirectories of /etc (for instance
+# /etc/libvirt/*) which may be surprising. VirtualDomain didn't
+# include the undefine call before, hence this wasn't an issue
+# before.
+#
+# There seems to be no way to find out which directories are
+# managed by libvirt.
+#
+verify_undefined() {
+	local tmpf
+	if virsh --connect=${OCF_RESKEY_hypervisor} list --all --name 2>/dev/null | grep -wqs "$DOMAIN_NAME"
+	then
+		tmpf=$(mktemp -t vmcfgsave.XXXXXX)
+		if [ ! -r "$tmpf" ]; then
+			ocf_log warn "unable to create temp file, disk full?"
+			# we must undefine the domain
+			virsh $VIRSH_OPTIONS undefine --nvram $DOMAIN_NAME > /dev/null 2>&1
+		else
+			cp -p $OCF_RESKEY_config $tmpf
+			virsh $VIRSH_OPTIONS undefine --nvram $DOMAIN_NAME > /dev/null 2>&1
+			[ -f $OCF_RESKEY_config ] || cp -f $tmpf $OCF_RESKEY_config
+			rm -f $tmpf
+		fi
+	fi
+}
+
+start_resources() {
+	local virsh_opts="--connect=$1 --quiet"
+	local pool_state net_state
+	for pool in `sed -n "s/^.*pool=['\"]\([^'\"]\+\)['\"].*\$/\1/gp" ${OCF_RESKEY_config} | sort | uniq`; do
+			pool_state=`LANG=C virsh ${virsh_opts} pool-info ${pool} | sed -n 's/^State: \+\(.*\)$/\1/gp'`
+			if [ "$pool_state" != "running" ]; then
+					virsh ${virsh_opts} pool-start $pool
+					if [ $? -ne 0 ]; then
+							ocf_exit_reason "Failed to start required virtual storage pool ${pool}."
+							return $OCF_ERR_GENERIC
+					fi
+			else
+					virsh ${virsh_opts} pool-refresh $pool
+			fi
+	done
+
+	for net in `sed -n "s/^.*network=['\"]\([^'\"]\+\)['\"].*\$/\1/gp" ${OCF_RESKEY_config} | sort | uniq`; do
+			net_state=`LANG=C virsh ${virsh_opts} net-info ${net} | sed -n 's/^Active: \+\(.*\)$/\1/gp'`
+			if [ "$net_state" != "yes" ]; then
+					virsh ${virsh_opts} net-start $net
+					if [ $? -ne 0 ]; then
+							ocf_exit_reason "Failed to start required virtual network ${net}."
+							return $OCF_ERR_GENERIC
+					fi
+			fi
+	done
+
+	return $OCF_SUCCESS
+}
+
+restore_config() {
+	if ocf_is_true $OCF_RESKEY_seapath  ; then
+		local disk_name=system_$DOMAIN_NAME
+		if rbd info $disk_name > /dev/null 2>&1 ; then
+			rbd image-meta get $disk_name xml > $OCF_RESKEY_config
+		fi
+	fi
+}
+
+VirtualDomain_start() {
+	local snapshotimage
+
+	if VirtualDomain_status; then
+		ocf_log info "Virtual domain $DOMAIN_NAME already running."
+		return $OCF_SUCCESS
+	fi
+
+	# systemd drop-in to stop domain before libvirtd terminates services
+	# during shutdown/reboot
+	if systemd_is_running ; then
+		systemd_drop_in "99-VirtualDomain-libvirt" "After" "libvirtd.service"
+		systemd_drop_in "99-VirtualDomain-machines" "Wants" "virt-guest-shutdown.target"
+		systemctl start virt-guest-shutdown.target
+	fi
+
+	snapshotimage="$OCF_RESKEY_snapshot/${DOMAIN_NAME}.state"
+	if [ -n "$OCF_RESKEY_snapshot" -a -f "$snapshotimage" ]; then
+		virsh restore $snapshotimage
+		if [ $? -eq 0 ]; then
+			rm -f $snapshotimage
+			return $OCF_SUCCESS
+		fi
+		ocf_exit_reason "Failed to restore ${DOMAIN_NAME} from state file in ${OCF_RESKEY_snapshot} directory."
+		return $OCF_ERR_GENERIC
+	fi
+
+	restore_config
+	# Make sure domain is undefined before creating.
+	# The 'create' command guarantees that the domain will be
+	# undefined on shutdown, but requires the domain to be undefined.
+	# if a user defines the domain
+	# outside of this agent, we have to ensure that the domain
+	# is restored to an 'undefined' state before creating.
+	verify_undefined
+
+	if ocf_is_true "${OCF_RESKEY_start_resources}"; then
+		start_resources ${OCF_RESKEY_hypervisor}
+		rc=$?
+		if [ $rc -eq $OCF_ERR_GENERIC ]; then
+			return $rc
+		fi
+	fi
+
+	if [ -z "${OCF_RESKEY_backingfile}" ]; then
+		virsh $VIRSH_OPTIONS create ${OCF_RESKEY_config}
+		if [ $? -ne 0 ]; then
+			ocf_exit_reason "Failed to start virtual domain ${DOMAIN_NAME}."
+			return $OCF_ERR_GENERIC
+		fi
+	else
+		if ocf_is_true "${OCF_RESKEY_stateless}" || [ ! -s "${OCF_RESKEY_config%%.*}.qcow2" ]; then
+			# Create the Stateless image
+			dirconfig=`dirname ${OCF_RESKEY_config}`
+			qemu-img create -f qcow2 -b ${OCF_RESKEY_backingfile} ${OCF_RESKEY_config%%.*}.qcow2
+			if [ $? -ne 0 ]; then
+				ocf_exit_reason "Failed qemu-img create ${DOMAIN_NAME} with backing file ${OCF_RESKEY_backingfile}."
+				return $OCF_ERR_GENERIC
+			fi
+
+			virsh define ${OCF_RESKEY_config}
+			if [ $? -ne 0 ]; then
+				ocf_exit_reason "Failed to define virtual domain ${DOMAIN_NAME}."
+				return $OCF_ERR_GENERIC
+			fi
+
+			if [ -n "${OCF_RESKEY_copyindirs}" ]; then
+				# Inject copyindirs directories and files
+				virt-copy-in -d ${DOMAIN_NAME}  ${OCF_RESKEY_copyindirs}  /
+				if [ $? -ne 0 ]; then
+					ocf_exit_reason "Failed on virt-copy-in command ${DOMAIN_NAME}."
+					return $OCF_ERR_GENERIC
+				fi
+			fi
+		else
+			virsh define ${OCF_RESKEY_config}
+			if [ $? -ne 0 ]; then
+				ocf_exit_reason "Failed to define virtual domain ${DOMAIN_NAME}."
+				return $OCF_ERR_GENERIC
+			fi
+		fi
+
+		virsh $VIRSH_OPTIONS start ${DOMAIN_NAME}
+		if [ $? -ne 0 ]; then
+			ocf_exit_reason "Failed to start virtual domain ${DOMAIN_NAME}."
+			return $OCF_ERR_GENERIC
+		fi
+	fi
+
+	while ! VirtualDomain_monitor; do
+		sleep 1
+	done
+
+	return $OCF_SUCCESS
+}
+
+force_stop()
+{
+	local out ex translate
+	local status=0
+
+	ocf_log info "Issuing forced shutdown (destroy) request for domain ${DOMAIN_NAME}."
+	out=$(LANG=C virsh $VIRSH_OPTIONS destroy ${DOMAIN_NAME} 2>&1)
+	ex=$?
+	translate=$(echo $out|tr 'A-Z' 'a-z')
+	echo >&2 "$translate"
+	case $ex$translate in
+		*"error:"*"domain is not running"*|*"error:"*"domain not found"*|\
+		*"error:"*"failed to get domain"*)
+			: ;; # unexpected path to the intended outcome, all is well
+		[!0]*)
+			ocf_exit_reason "forced stop failed"
+			return $OCF_ERR_GENERIC ;;
+		0*)
+			while [ $status != $OCF_NOT_RUNNING ]; do
+				VirtualDomain_status
+				status=$?
+			done ;;
+	esac
+	return $OCF_SUCCESS
+}
+
+sync_config(){
+	ocf_log info "Syncing $DOMAIN_NAME config file with csync2 -x ${OCF_RESKEY_config}"
+	if ! csync2 -x ${OCF_RESKEY_config}; then
+		ocf_log warn "Syncing ${OCF_RESKEY_config} failed.";
+	fi
+}
+
+save_config(){
+	CFGTMP=$(mktemp -t vmcfgsave.XXX)
+	virsh $VIRSH_OPTIONS dumpxml --inactive --security-info ${DOMAIN_NAME} > ${CFGTMP}
+	if [ -s ${CFGTMP} ]; then
+		if ! cmp -s ${CFGTMP} ${OCF_RESKEY_config}; then
+			if virt-xml-validate ${CFGTMP} domain 2>/dev/null ;	then
+				ocf_log info "Saving domain $DOMAIN_NAME to ${OCF_RESKEY_config}. Please make sure it's present on all nodes or sync_config_on_stop is on."
+				if cat ${CFGTMP} > ${OCF_RESKEY_config} ; then
+					if ocf_is_true "$OCF_RESKEY_seapath" ; then
+						if rbd image-meta set system_${DOMAIN_NAME} xml "$(cat ${CFGTMP})" ; then
+							ocf_log info "Saved $DOMAIN_NAME domain's configuration to ${OCF_RESKEY_config} and rbd system_${DOMAIN_NAME} metadata"
+						else
+							ocf_log warn "Saving $DOMAIN_NAME domain's configuration to rbd system_${DOMAIN_NAME} metadata failed."
+						fi
+					else
+						ocf_log info "Saved $DOMAIN_NAME domain's configuration to ${OCF_RESKEY_config}."
+					fi
+					if ocf_is_true "$OCF_RESKEY_sync_config_on_stop"; then
+						sync_config
+					fi
+				else
+					ocf_log warn "Moving ${CFGTMP} to ${OCF_RESKEY_config} failed."
+				fi
+			else
+				ocf_log warn "Domain $DOMAIN_NAME config failed to validate after dump. Skipping config update."
+			fi
+		fi
+	else
+		ocf_log warn "Domain $DOMAIN_NAME config has 0 size. Skipping config update."
+	fi
+	rm -f ${CFGTMP}
+}
+
+VirtualDomain_stop() {
+	local i
+	local status
+	local shutdown_timeout
+	local needshutdown=1
+
+	VirtualDomain_status
+	status=$?
+
+	case $status in
+		$OCF_SUCCESS)
+			if ocf_is_true $OCF_RESKEY_force_stop; then
+				# if force stop, don't bother attempting graceful shutdown.
+				force_stop
+				return $?
+			fi
+
+			ocf_log info "Issuing graceful shutdown request for domain ${DOMAIN_NAME}."
+
+			if [ -n "$OCF_RESKEY_snapshot" ]; then
+				virsh save $DOMAIN_NAME "$OCF_RESKEY_snapshot/${DOMAIN_NAME}.state"
+				if [ $? -eq 0 ]; then
+					needshutdown=0
+				else
+					ocf_log error "Failed to save snapshot state of ${DOMAIN_NAME} on stop"
+				fi
+			fi
+
+			# save config if needed
+			if ocf_is_true "$OCF_RESKEY_save_config_on_stop"; then
+				save_config
+			fi
+
+			# issue the shutdown if save state didn't shutdown for us
+			if [ $needshutdown -eq 1 ]; then
+				# Issue a graceful shutdown request
+				if [ -n "${OCF_RESKEY_CRM_shutdown_mode}" ]; then
+					shutdown_opts="--mode ${OCF_RESKEY_CRM_shutdown_mode}"
+				fi
+				ocf_log info "virsh $VIRSH_OPTIONS shutdown ${DOMAIN_NAME} $shutdown_opts"
+				timeout 1s virsh $VIRSH_OPTIONS shutdown ${DOMAIN_NAME} $shutdown_opts
+				virsh_timeout_status=$?
+				if [ $virsh_timeout_status -eq 124 ] #timeout, there's something wrong with the guest
+				then
+					# Something went wrong, break from switch case, and resort to forced stop (destroy).
+					ocf_log info "${DOMAIN_NAME} shutdown problem, force_stop"
+					force=1
+				else
+					force=0
+				fi
+			fi
+
+			# The "shutdown_timeout" we use here is the operation
+			# timeout specified in the CIB, minus 17 seconds (because it has been seen cases where the destroy operation takes more than 15s)
+			shutdown_timeout=$(( $NOW + ($OCF_RESKEY_CRM_meta_timeout/1000) -17 ))
+			# Loop on status until we reach $shutdown_timeout
+                        ocf_log info "${DOMAIN_NAME} shutdown_timeout=$shutdown_timeout, NOW=$NOW"
+			while [ $NOW -lt $shutdown_timeout -a $force -ne 1 ]; do
+				VirtualDomain_status
+				status=$?
+                                ocf_log info "${DOMAIN_NAME} VirtualDomain_status $status"
+				case $status in
+					$OCF_NOT_RUNNING)
+						# This was a graceful shutdown.
+                                                ocf_log info "${DOMAIN_NAME} This was a graceful shutdown."
+						return $OCF_SUCCESS
+						;;
+					$OCF_SUCCESS)
+						# Domain is still running, keep
+						# waiting (until shutdown_timeout
+						# expires)
+                                                ocf_log info "${DOMAIN_NAME} sleep 1."
+						sleep 1
+						;;
+					*)
+						# Something went wrong. Bail out and
+						# resort to forced stop (destroy).
+						break;
+				esac
+				NOW=$(date +%s)
+			done
+			;;
+		$OCF_NOT_RUNNING)
+			ocf_log info "Domain $DOMAIN_NAME already stopped."
+			return $OCF_SUCCESS
+	esac
+
+	# OK. Now if the above graceful shutdown hasn't worked, kill
+	# off the domain with destroy. If that too does not work,
+	# have the LRM time us out.
+        ocf_log info "${DOMAIN_NAME} force_stop"
+	force_stop
+}
+
+mk_migrateuri() {
+	local target_node
+	local migrate_target
+	local hypervisor
+
+	target_node="$OCF_RESKEY_CRM_meta_migrate_target"
+
+	# A typical migration URI via a special  migration network looks
+	# like "tcp://bar-mig:49152". The port would be randomly chosen
+	# by libvirt from the range 49152-49215 if omitted, at least since
+	# version 0.7.4 ...
+	if [ -n "${OCF_RESKEY_migration_network_suffix}" ]; then
+		hypervisor="${OCF_RESKEY_hypervisor%%[+:]*}"
+		# Hostname might be a FQDN
+		migrate_target=$(echo ${target_node} | sed -e "s,^\([^.]\+\),\1${OCF_RESKEY_migration_network_suffix},")
+		case $hypervisor in
+			qemu)
+				# For quiet ancient libvirt versions a migration port is needed
+				# and the URI must not contain the "//". Newer versions can handle
+				# the "bad" URI.
+				echo "tcp:${migrate_target}:${OCF_RESKEY_migrateport}"
+				;;
+			xen)
+				echo "${migrate_target}"
+				;;
+			*)
+				ocf_log warn "$DOMAIN_NAME: Migration via dedicated network currently not supported for ${hypervisor}."
+				;;
+		esac
+	fi
+}
+
+VirtualDomain_migrate_to() {
+	local rc
+	local target_node
+	local remoteuri
+	local transport_suffix
+	local migrateuri
+	local migrate_opts
+	local migrate_pid
+
+	target_node="$OCF_RESKEY_CRM_meta_migrate_target"
+
+	if VirtualDomain_status; then
+		# Find out the remote hypervisor to connect to. That is, turn
+		# something like "qemu://foo:9999/system" into
+		# "qemu+tcp://bar:9999/system"
+
+		if [ -n "${OCF_RESKEY_remoteuri}" ]; then
+			remoteuri=`echo "${OCF_RESKEY_remoteuri}" |
+				sed "s/%n/$target_node/g"`
+		else
+			if [ -n "${OCF_RESKEY_migration_transport}" ]; then
+				transport_suffix="+${OCF_RESKEY_migration_transport}"
+			fi
+
+			# append user defined suffix if virsh target should differ from cluster node name
+			if [ -n "${OCF_RESKEY_migration_network_suffix}" ]; then
+				# Hostname might be a FQDN
+				target_node=$(echo ${target_node} | sed -e "s,^\([^.]\+\),\1${OCF_RESKEY_migration_network_suffix},")
+			fi
+
+			# a remote user has been defined to connect to target_node
+			if echo ${OCF_RESKEY_migration_user} | grep -q "^[a-z][-a-z0-9]*$" ; then
+				target_node="${OCF_RESKEY_migration_user}@${target_node}"
+			fi
+
+			# Scared of that sed expression? So am I. :-)
+			remoteuri=$(echo ${OCF_RESKEY_hypervisor} | sed -e "s,\(.*\)://[^/:]*\(:\?[0-9]*\)/\(.*\),\1${transport_suffix}://${target_node}\2/\3,")
+		fi
+
+		# User defined migrateuri or do we make one?
+		migrate_opts="$OCF_RESKEY_migrate_options"
+
+		# migration_uri is directly set
+		if [ -n "${OCF_RESKEY_migrateuri}" ]; then
+			migrateuri=`echo "${OCF_RESKEY_migrateuri}" |
+				sed "s/%n/$target_node/g"`
+
+		# extract migrationuri from options
+		elif echo "$migrate_opts" | fgrep -qs -- "--migrateuri="; then
+			migrateuri=`echo "$migrate_opts" |
+				sed "s/.*--migrateuri=\([^ ]*\).*/\1/;s/%n/$target_node/g"`
+
+		# auto generate
+		else
+			migrateuri=`mk_migrateuri`
+		fi
+
+		# remove --migrateuri from migration_opts
+		migrate_opts=`echo "$migrate_opts" |
+			sed "s/\(.*\)--migrateuri=[^ ]*\(.*\)/\1\2/"`
+
+
+		# save config if needed
+		if ocf_is_true "$OCF_RESKEY_save_config_on_stop"; then
+			save_config
+		fi
+
+		if ocf_is_true "${OCF_RESKEY_start_resources}"; then
+			start_resources $remoteuri
+			rc=$?
+			if [ $rc -eq $OCF_ERR_GENERIC ]; then
+				return $rc
+			fi
+		fi
+
+		# Live migration speed limit
+		if [ ${OCF_RESKEY_migration_speed} -ne 0 ]; then
+			ocf_log info "$DOMAIN_NAME: Setting live migration speed limit for $DOMAIN_NAME (using: virsh ${VIRSH_OPTIONS} migrate-setspeed $DOMAIN_NAME ${OCF_RESKEY_migration_speed})."
+			virsh ${VIRSH_OPTIONS} migrate-setspeed $DOMAIN_NAME ${OCF_RESKEY_migration_speed}
+		fi
+
+		# OK, we know where to connect to. Now do the actual migration.
+		ocf_log info "$DOMAIN_NAME: Starting live migration to ${target_node} (using: virsh ${VIRSH_OPTIONS} migrate --live $migrate_opts $DOMAIN_NAME $remoteuri $migrateuri)."
+		virsh ${VIRSH_OPTIONS} migrate --live $migrate_opts $DOMAIN_NAME $remoteuri $migrateuri &
+
+		migrate_pid=${!}
+
+		# Live migration downtime interval
+		# Note: You can set downtime only while live migration is in progress
+		if [ ${OCF_RESKEY_migration_downtime} -ne 0 ]; then
+			sleep 2
+			ocf_log info "$DOMAIN_NAME: Setting live migration downtime for $DOMAIN_NAME (using: virsh ${VIRSH_OPTIONS} migrate-setmaxdowntime $DOMAIN_NAME ${OCF_RESKEY_migration_downtime})."
+			virsh ${VIRSH_OPTIONS} migrate-setmaxdowntime $DOMAIN_NAME ${OCF_RESKEY_migration_downtime}
+		fi
+
+		wait ${migrate_pid}
+
+		rc=$?
+		if [ $rc -ne 0 ]; then
+			ocf_exit_reason "$DOMAIN_NAME: live migration to ${target_node} failed: $rc"
+			return $OCF_ERR_GENERIC
+		else
+			ocf_log info "$DOMAIN_NAME: live migration to ${target_node} succeeded."
+			return $OCF_SUCCESS
+		fi
+	else
+		ocf_exit_reason "$DOMAIN_NAME: migrate_to: Not active locally!"
+		return $OCF_ERR_GENERIC
+	fi
+}
+
+VirtualDomain_migrate_from() {
+	# systemd drop-in to stop domain before libvirtd terminates services
+	# during shutdown/reboot
+	if systemd_is_running ; then
+		systemd_drop_in "99-VirtualDomain-libvirt" "After" "libvirtd.service"
+		systemd_drop_in "99-VirtualDomain-machines" "Wants" "virt-guest-shutdown.target"
+		systemctl start virt-guest-shutdown.target
+	fi
+
+	while ! VirtualDomain_monitor; do
+		sleep 1
+	done
+	ocf_log info "$DOMAIN_NAME: live migration from ${OCF_RESKEY_CRM_meta_migrate_source} succeeded."
+	# save config if needed
+	if ocf_is_true "$OCF_RESKEY_save_config_on_stop"; then
+		save_config
+	fi
+	return $OCF_SUCCESS
+}
+
+VirtualDomain_monitor() {
+	# First, check the domain status. If that returns anything other
+	# than $OCF_SUCCESS, something is definitely wrong.
+	VirtualDomain_status
+	rc=$?
+	if [ ${rc} -eq ${OCF_SUCCESS} ]; then
+		# OK, the generic status check turned out fine.  Now, if we
+		# have monitor scripts defined, run them one after another.
+		for script in ${OCF_RESKEY_monitor_scripts}; do
+			script_output="$($script 2>&1)"
+			script_rc=$?
+			if [ ${script_rc} -ne ${OCF_SUCCESS} ]; then
+				# A monitor script returned a non-success exit
+				# code. Stop iterating over the list of scripts, log a
+				# warning message, and propagate $OCF_ERR_GENERIC.
+				ocf_exit_reason "Monitor command \"${script}\" for domain ${DOMAIN_NAME} returned ${script_rc} with output: ${script_output}"
+				rc=$OCF_ERR_GENERIC
+				break
+			else
+				ocf_log debug "Monitor command \"${script}\" for domain ${DOMAIN_NAME} completed successfully with output: ${script_output}"
+			fi
+		done
+	fi
+
+	update_emulator_cache
+	update_utilization
+   # Save configuration on monitor as well, so we will have a better chance of
+	# having fresh and up to date config files on all nodes.
+	if ocf_is_true "$OCF_RESKEY_save_config_on_stop"; then
+		save_config
+	fi
+
+	return ${rc}
+}
+
+VirtualDomain_validate_all() {
+	if ocf_is_true $OCF_RESKEY_force_stop && [ -n "$OCF_RESKEY_snapshot" ]; then
+		ocf_exit_reason "The 'force_stop' and 'snapshot' options can not be used together."
+		return $OCF_ERR_CONFIGURED
+	fi
+
+	if [ ! -r $OCF_RESKEY_config ] ; then
+		restore_config
+	fi
+
+	# check if we can read the config file (otherwise we're unable to
+	# deduce $DOMAIN_NAME from it, see below)
+	if [ ! -r $OCF_RESKEY_config ]; then
+		if ocf_is_probe; then
+			ocf_log info "Configuration file $OCF_RESKEY_config not readable during probe."
+		elif [ "$__OCF_ACTION" = "stop" ]; then
+			ocf_log info "Configuration file $OCF_RESKEY_config not readable, resource considered stopped."
+		else
+			ocf_exit_reason "Configuration file $OCF_RESKEY_config does not exist or not readable."
+		fi
+		return $OCF_ERR_INSTALLED
+	fi
+
+	if [ -z $DOMAIN_NAME ]; then
+		ocf_exit_reason "Unable to determine domain name."
+		return $OCF_ERR_INSTALLED
+	fi
+
+	# Check if csync2 is available when config tells us we might need it.
+	if ocf_is_true $OCF_RESKEY_sync_config_on_stop; then
+		check_binary csync2
+	fi
+
+	# Check if migration_speed is a decimal value
+	if ! ocf_is_decimal ${OCF_RESKEY_migration_speed}; then
+		ocf_exit_reason "migration_speed has to be a decimal value"
+		return $OCF_ERR_CONFIGURED
+	fi
+
+	# Check if migration_downtime is a decimal value
+	if ! ocf_is_decimal ${OCF_RESKEY_migration_downtime}; then
+		ocf_exit_reason "migration_downtime has to be a decimal value"
+		return $OCF_ERR_CONFIGURED
+	fi
+
+	if ocf_is_true "${OCF_RESKEY_stateless}" && [ -z "${OCF_RESKEY_backingfile}" ]; then
+		ocf_exit_reason "Stateless functionality can't be achieved without a backing file."
+		return $OCF_ERR_CONFIGURED
+	fi
+}
+
+VirtualDomain_getconfig() {
+	# Grab the virsh uri default, but only if hypervisor isn't set
+	: ${OCF_RESKEY_hypervisor=$(virsh --quiet uri 2>/dev/null)}
+
+	# Set options to be passed to virsh:
+	VIRSH_OPTIONS="--connect=${OCF_RESKEY_hypervisor} --quiet"
+	if ocf_is_true $OCF_RESKEY_seapath ; then
+		# Retrieve the domain name from xml filename
+		DOMAIN_NAME=`basename ${OCF_RESKEY_config} | cut -d '.' -f 1`
+	else
+		# Retrieve the domain name from the xml file.
+		DOMAIN_NAME=`egrep '[[:space:]]*<name>.*</name>[[:space:]]*$' ${OCF_RESKEY_config} 2>/dev/null | sed -e 's/[[:space:]]*<name>\(.*\)<\/name>[[:space:]]*$/\1/'`
+	fi
+
+	EMULATOR_STATE="${HA_RSCTMP}/VirtualDomain-${DOMAIN_NAME}-emu.state"
+}
+
+OCF_REQUIRED_PARAMS="config"
+OCF_REQUIRED_BINARIES="virsh sed"
+ocf_rarun $*

--- a/roles/oraclelinux_physical_machine/files/pacemaker_ra/ntpstatus
+++ b/roles/oraclelinux_physical_machine/files/pacemaker_ra/ntpstatus
@@ -1,0 +1,320 @@
+#!/bin/sh
+#
+# ocf:seapath:ntpstatus resource agent
+#
+# Original copyright 2004 SUSE LINUX AG, Lars Marowsky-Br<E9>e
+# Later changes copyright 2008-2019 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
+#
+# This source code is licensed under the GNU General Public License version 2
+# (GPLv2) WITHOUT ANY WARRANTY.
+#
+# crm config example:
+#primitive ntpstatus_test ocf:seapath:ntpstatus \
+#        op monitor timeout=10 interval=10
+#clone cl_ntpstatus_test ntpstatus_test \
+#        meta target-role=Started
+#location ntp_test_debian debian \
+#        rule ntpstatus: defined ntpstatus
+#
+#######################################################################
+# Initialization:
+
+: ${OCF_FUNCTIONS:="${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs"}
+. "${OCF_FUNCTIONS}"
+: ${__OCF_ACTION:="$1"}
+
+#######################################################################
+
+meta_data() {
+    cat <<END
+<?xml version="1.0"?>
+<!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
+<resource-agent name="ntpstatus" version="1.0">
+<version>1.0</version>
+
+<longdesc lang="en">
+Checks the status of the connectivity to a ntp server
+</longdesc>
+<shortdesc lang="en">Checks the status of the connectivity to a ntp server</shortdesc>
+
+<parameters>
+<parameter name="state" unique="1">
+<longdesc lang="en">
+Location to store the resource state in.
+</longdesc>
+<shortdesc lang="en">State file</shortdesc>
+<content type="string" default="${HA_VARRUN%%/}/ntpstatus-${OCF_RESOURCE_INSTANCE}.state" />
+</parameter>
+
+<parameter name="ntpstatus" unique="1">
+<longdesc lang="en">
+ntpstatus
+</longdesc>
+<shortdesc lang="en">ntpstatus</shortdesc>
+<content type="string" default="" />
+</parameter>
+
+<parameter name="op_sleep" unique="1">
+<longdesc lang="en">
+Number of seconds to sleep during operations.  This can be used to test how
+the cluster reacts to operation timeouts.
+</longdesc>
+<shortdesc lang="en">Operation sleep duration in seconds.</shortdesc>
+<content type="string" default="0" />
+</parameter>
+
+<parameter name="fail_start_on" unique="0">
+<longdesc lang="en">
+Start actions will return failure if running on the host specified here, but
+the resource will start successfully anyway (future monitor calls will find it
+running). This can be used to test on-fail=ignore.
+</longdesc>
+<shortdesc lang="en">Report bogus start failure on specified host</shortdesc>
+<content type="string" default="" />
+</parameter>
+
+<parameter name="envfile" unique="1">
+<longdesc lang="en">
+If this is set, the environment will be dumped to this file for every call.
+</longdesc>
+<shortdesc lang="en">Environment dump file</shortdesc>
+<content type="string" default="" />
+</parameter>
+
+<parameter name="multiplier" unique="0">
+<longdesc lang="en">
+The number by which to multiply the connectivity (0 or 1) by
+</longdesc>
+<shortdesc lang="en">Value multiplier</shortdesc>
+<content type="integer" default="1"/>
+</parameter>
+
+<parameter name="host_ip" unique="0" required="1">
+<longdesc lang="en">
+ip address to check the connectivity to
+</longdesc>
+<shortdesc lang="en">Host IP</shortdesc>
+<content type="string" default=""/>
+</parameter>
+
+</parameters>
+
+<actions>
+<action name="start"        timeout="20s" />
+<action name="stop"         timeout="20s" />
+<action name="monitor"      timeout="20s" interval="10s" depth="0"/>
+<action name="reload"       timeout="20s" />
+<action name="migrate_to"   timeout="20s" />
+<action name="migrate_from" timeout="20s" />
+<action name="validate-all" timeout="20s" />
+<action name="meta-data"    timeout="5s" />
+</actions>
+</resource-agent>
+END
+}
+
+#######################################################################
+
+# don't exit on TERM, to test that pacemaker-execd makes sure that we do exit
+trap sigterm_handler TERM
+sigterm_handler() {
+    ocf_log info "They use TERM to bring us down. No such luck."
+
+    # Since we're likely going to get KILLed, clean up any monitor
+    # serialization in progress, so the next probe doesn't return an error.
+    rm -f "${VERIFY_SERIALIZED_FILE}"
+    return
+}
+
+ntpstatus_usage() {
+    cat <<END
+usage: $0 {start|stop|monitor|migrate_to|migrate_from|validate-all|meta-data}
+
+Expects to have a fully populated OCF RA-compliant environment set.
+END
+}
+
+dump_env() {
+    if [ "${OCF_RESKEY_envfile}" != "" ]; then
+            echo "### ${__OCF_ACTION} @ $(date) ###
+$(env | sort)
+###" >> "${OCF_RESKEY_envfile}"
+    fi
+}
+
+ntpstatus_update() {
+    # get the 5th column from chrony sources output (reach), convert from octal to binary and get the last digit (last contact with server)
+    # 1 --> last contact fine
+    # 0 --> last contact problem
+    status=`echo $(/usr/bin/chronyc -n sources | grep -E "$OCF_RESKEY_host_ip" | awk '{print $5}') | python3 -c "print(\"{0:b}\".format(int(input() or \"0\",8))[-1])"`
+    case "${status#[+]}" in
+        ''|*[!0-9]*)
+            status=0
+          ;;
+    esac
+    status=$(expr $status \* $OCF_RESKEY_multiplier)
+    if [ "$__OCF_ACTION" = "start" ] ; then
+        attrd_updater -n "$OCF_RESKEY_ntpstatus" -B "$status" -d "$OCF_RESKEY_dampen" $attrd_options
+    else
+        attrd_updater -n "$OCF_RESKEY_ntpstatus" -v "$status" -d "$OCF_RESKEY_dampen" $attrd_options
+    fi
+    rc=$?
+    case $rc in
+        0) #ocf_log info "Updated $OCF_RESKEY_ntpstatus = $status"
+          ;;
+        *) ocf_log warn "Could not update $OCF_RESKEY_ntpstatus = $status: rc=$rc";;
+    esac
+    if [ $rc -ne 0 ]; then
+        return $rc
+    fi
+}
+
+ntpstatus_start() {
+    ntpstatus_monitor
+
+    DS_RETVAL=$?
+    if [ $DS_RETVAL -eq $OCF_SUCCESS ]; then
+        if [ "$(uname -n)" = "${OCF_RESKEY_fail_start_on}" ]; then
+            DS_RETVAL=$OCF_ERR_GENERIC
+        fi
+        return $DS_RETVAL
+    fi
+
+    touch "${OCF_RESKEY_state}"
+    DS_RETVAL=$?
+    if [ "$(uname -n)" = "${OCF_RESKEY_fail_start_on}" ]; then
+        DS_RETVAL=$OCF_ERR_GENERIC
+    fi
+    ntpstatus_update
+    return $DS_RETVAL
+}
+
+ntpstatus_stop() {
+    ntpstatus_monitor --force
+    attrd_updater -D -n "$OCF_RESKEY_ntpstatus" -d "$OCF_RESKEY_dampen" $attrd_options
+    if [ $? -eq $OCF_SUCCESS ]; then
+        rm "${OCF_RESKEY_state}"
+    fi
+    rm -f "${VERIFY_SERIALIZED_FILE}"
+    return $OCF_SUCCESS
+}
+
+ntpstatus_monitor() {
+    if [ $OCF_RESKEY_op_sleep -ne 0 ]; then
+        if [ "$1" = "" ] && [ -f "${VERIFY_SERIALIZED_FILE}" ]; then
+            # two monitor ops have occurred at the same time.
+            # This verifies a condition in pacemaker-execd regression tests.
+            ocf_log err "$VERIFY_SERIALIZED_FILE exists already"
+            ocf_exit_reason "alternate universe collision"
+            return $OCF_ERR_GENERIC
+        fi
+
+        touch "${VERIFY_SERIALIZED_FILE}"
+        sleep ${OCF_RESKEY_op_sleep}
+        rm "${VERIFY_SERIALIZED_FILE}"
+    fi
+
+    if [ -f "${OCF_RESKEY_state}" ]; then
+	ntpstatus_update
+        # Multiple monitor levels are defined to support various tests
+        case "$OCF_CHECK_LEVEL" in
+            10)
+            # monitor level with delay, useful for testing timeouts
+            sleep 30
+            ;;
+
+            20)
+            # monitor level that fails intermittently
+            n=$(expr "$(dd if=/dev/urandom bs=1 count=1 2>/dev/null | od | head -1 | cut -f2 -d' ')" % 5)
+            if [ $n -eq 1 ]; then
+                ocf_exit_reason "smoke detected near CPU fan"
+                return $OCF_ERR_GENERIC
+            fi
+            ;;
+
+            30)
+            # monitor level that always fails
+            ocf_exit_reason "hyperdrive quota reached"
+            return $OCF_ERR_GENERIC
+            ;;
+
+            40)
+            # monitor level that returns error code from state file
+            rc=$(cat ${OCF_RESKEY_state})
+            [ -n "$rc" ] && ocf_exit_reason "CPU ejected. Observed leaving the Kronosnet galaxy at $rc times the speed of light." && return $rc
+            ;;
+
+            *)
+            ;;
+        esac
+        return $OCF_SUCCESS
+    fi
+    return $OCF_NOT_RUNNING
+}
+
+ntpstatus_validate() {
+    # Is the state directory writable?
+    state_dir=$(dirname "$OCF_RESKEY_state")
+    [ -d "$state_dir" ] && [ -w "$state_dir" ] && [ -x "$state_dir" ]
+    if [ $? -ne 0 ]; then
+        return $OCF_ERR_ARGS
+    fi
+
+    # Check the host ip
+    if [ -z "$OCF_RESKEY_host_ip" ]; then
+        ocf_log err "Empty host_ip.  Please specify a host to check"
+        exit $OCF_ERR_CONFIGURED
+    fi
+    return $OCF_SUCCESS
+}
+
+: ${OCF_RESKEY_op_sleep:=0}
+: ${OCF_RESKEY_CRM_meta_interval:=0}
+: ${OCF_RESKEY_CRM_meta_globally_unique:="false"}
+: ${OCF_RESKEY_ntpstatus:="ntpstatus"}
+: ${OCF_RESKEY_dampen:=75}
+: ${OCF_RESKEY_multiplier:=1000}
+
+if [ -z "$OCF_RESKEY_state" ]; then
+    OCF_RESKEY_state="${HA_VARRUN%%/}/ntpstatus-${OCF_RESOURCE_INSTANCE}.state"
+
+    if [ "${OCF_RESKEY_CRM_meta_globally_unique}" = "false" ]; then
+        # Strip off the trailing clone marker (note + is not portable in sed)
+        OCF_RESKEY_state=$(echo $OCF_RESKEY_state | sed s/:[0-9][0-9]*\.state/.state/)
+    fi
+fi
+VERIFY_SERIALIZED_FILE="${OCF_RESKEY_state}.serialized"
+
+dump_env
+
+case "$__OCF_ACTION" in
+meta-data)      meta_data
+                exit $OCF_SUCCESS
+                ;;
+start)          ntpstatus_start;;
+stop)           ntpstatus_stop;;
+monitor)        ntpstatus_monitor;;
+migrate_to)     ocf_log info "Migrating ${OCF_RESOURCE_INSTANCE} to ${OCF_RESKEY_CRM_meta_migrate_target}."
+                ntpstatus_stop
+                ;;
+migrate_from)   ocf_log info "Migrating ${OCF_RESOURCE_INSTANCE} from ${OCF_RESKEY_CRM_meta_migrate_source}."
+                ntpstatus_start
+                ;;
+reload)         ocf_log err "Reloading..."
+                ntpstatus_start
+                ;;
+validate-all)   ntpstatus_validate;;
+usage|help)     ntpstatus_usage
+                exit $OCF_SUCCESS
+                ;;
+*)              ntpstatus_usage
+                exit $OCF_ERR_UNIMPLEMENTED
+                ;;
+esac
+rc=$?
+ocf_log debug "${OCF_RESOURCE_INSTANCE} $__OCF_ACTION : $rc"
+exit $rc
+
+# vim: set filetype=sh expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=80:

--- a/roles/oraclelinux_physical_machine/files/pacemaker_ra/ptpstatus
+++ b/roles/oraclelinux_physical_machine/files/pacemaker_ra/ptpstatus
@@ -1,0 +1,303 @@
+#!/bin/sh
+#
+# ocf:seapath:ptpstatus resource agent
+#
+# Original copyright 2004 SUSE LINUX AG, Lars Marowsky-Br<E9>e
+# Later changes copyright 2008-2019 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
+#
+# This source code is licensed under the GNU General Public License version 2
+# (GPLv2) WITHOUT ANY WARRANTY.
+#
+# crm config example:
+#primitive ptpstatus_test ocf:seapath:ptpstatus \
+#        op monitor timeout=10 interval=10
+#clone cl_ptpstatus_test ptpstatus_test \
+#        meta target-role=Started
+#location ptp_test_debian debian \
+#        rule ptpstatus: defined ptpstatus
+#
+#######################################################################
+# Initialization:
+
+: ${OCF_FUNCTIONS:="${OCF_ROOT}/resource.d/heartbeat/.ocf-shellfuncs"}
+. "${OCF_FUNCTIONS}"
+: ${__OCF_ACTION:="$1"}
+
+#######################################################################
+
+meta_data() {
+    cat <<END
+<?xml version="1.0"?>
+<!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
+<resource-agent name="ptpstatus" version="1.0">
+<version>1.0</version>
+
+<longdesc lang="en">
+Checks the status of the PTP synchronization
+</longdesc>
+<shortdesc lang="en">Checks the status of the PTP synchronization</shortdesc>
+
+<parameters>
+<parameter name="state" unique="1">
+<longdesc lang="en">
+Location to store the resource state in.
+</longdesc>
+<shortdesc lang="en">State file</shortdesc>
+<content type="string" default="${HA_VARRUN%%/}/ptpstatus-${OCF_RESOURCE_INSTANCE}.state" />
+</parameter>
+
+<parameter name="ptpstatus" unique="1">
+<longdesc lang="en">
+ptpstatus
+</longdesc>
+<shortdesc lang="en">ptpstatus</shortdesc>
+<content type="string" default="" />
+</parameter>
+
+<parameter name="op_sleep" unique="1">
+<longdesc lang="en">
+Number of seconds to sleep during operations.  This can be used to test how
+the cluster reacts to operation timeouts.
+</longdesc>
+<shortdesc lang="en">Operation sleep duration in seconds.</shortdesc>
+<content type="string" default="0" />
+</parameter>
+
+<parameter name="fail_start_on" unique="0">
+<longdesc lang="en">
+Start actions will return failure if running on the host specified here, but
+the resource will start successfully anyway (future monitor calls will find it
+running). This can be used to test on-fail=ignore.
+</longdesc>
+<shortdesc lang="en">Report bogus start failure on specified host</shortdesc>
+<content type="string" default="" />
+</parameter>
+
+<parameter name="envfile" unique="1">
+<longdesc lang="en">
+If this is set, the environment will be dumped to this file for every call.
+</longdesc>
+<shortdesc lang="en">Environment dump file</shortdesc>
+<content type="string" default="" />
+</parameter>
+
+<parameter name="multiplier" unique="0">
+<longdesc lang="en">
+The number by which to multiply the connectivity (0 or 1) by
+</longdesc>
+<shortdesc lang="en">Value multiplier</shortdesc>
+<content type="integer" default="1"/>
+</parameter>
+
+</parameters>
+
+<actions>
+<action name="start"        timeout="20s" />
+<action name="stop"         timeout="20s" />
+<action name="monitor"      timeout="20s" interval="10s" depth="0"/>
+<action name="reload"       timeout="20s" />
+<action name="migrate_to"   timeout="20s" />
+<action name="migrate_from" timeout="20s" />
+<action name="validate-all" timeout="20s" />
+<action name="meta-data"    timeout="5s" />
+</actions>
+</resource-agent>
+END
+}
+
+#######################################################################
+
+# don't exit on TERM, to test that pacemaker-execd makes sure that we do exit
+trap sigterm_handler TERM
+sigterm_handler() {
+    ocf_log info "They use TERM to bring us down. No such luck."
+
+    # Since we're likely going to get KILLed, clean up any monitor
+    # serialization in progress, so the next probe doesn't return an error.
+    rm -f "${VERIFY_SERIALIZED_FILE}"
+    return
+}
+
+ptpstatus_usage() {
+    cat <<END
+usage: $0 {start|stop|monitor|migrate_to|migrate_from|validate-all|meta-data}
+
+Expects to have a fully populated OCF RA-compliant environment set.
+END
+}
+
+dump_env() {
+    if [ "${OCF_RESKEY_envfile}" != "" ]; then
+            echo "### ${__OCF_ACTION} @ $(date) ###
+$(env | sort)
+###" >> "${OCF_RESKEY_envfile}"
+    fi
+}
+
+ptpstatus_update() {
+    status=`/usr/bin/chronyc -n sources | grep -E "#[*+] PTP0" | wc -l`
+    case "${status#[+]}" in
+        ''|*[!0-9]*)
+            status=0
+          ;;
+    esac
+    status=$(expr $status \* $OCF_RESKEY_multiplier)
+    if [ "$__OCF_ACTION" = "start" ] ; then
+        attrd_updater -n "$OCF_RESKEY_ptpstatus" -B "$status" -d "$OCF_RESKEY_dampen" $attrd_options
+    else
+        attrd_updater -n "$OCF_RESKEY_ptpstatus" -v "$status" -d "$OCF_RESKEY_dampen" $attrd_options
+    fi
+    rc=$?
+    case $rc in
+        0) #ocf_log info "Updated $OCF_RESKEY_ptpstatus = $status"
+          ;;
+        *) ocf_log warn "Could not update $OCF_RESKEY_ptpstatus = $status: rc=$rc";;
+    esac
+    if [ $rc -ne 0 ]; then
+        return $rc
+    fi
+}
+
+ptpstatus_start() {
+    ptpstatus_monitor
+
+    DS_RETVAL=$?
+    if [ $DS_RETVAL -eq $OCF_SUCCESS ]; then
+        if [ "$(uname -n)" = "${OCF_RESKEY_fail_start_on}" ]; then
+            DS_RETVAL=$OCF_ERR_GENERIC
+        fi
+        return $DS_RETVAL
+    fi
+
+    touch "${OCF_RESKEY_state}"
+    DS_RETVAL=$?
+    if [ "$(uname -n)" = "${OCF_RESKEY_fail_start_on}" ]; then
+        DS_RETVAL=$OCF_ERR_GENERIC
+    fi
+    ptpstatus_update
+    return $DS_RETVAL
+}
+
+ptpstatus_stop() {
+    ptpstatus_monitor --force
+    attrd_updater -D -n "$OCF_RESKEY_ptpstatus" -d "$OCF_RESKEY_dampen" $attrd_options
+    if [ $? -eq $OCF_SUCCESS ]; then
+        rm "${OCF_RESKEY_state}"
+    fi
+    rm -f "${VERIFY_SERIALIZED_FILE}"
+    return $OCF_SUCCESS
+}
+
+ptpstatus_monitor() {
+    if [ $OCF_RESKEY_op_sleep -ne 0 ]; then
+        if [ "$1" = "" ] && [ -f "${VERIFY_SERIALIZED_FILE}" ]; then
+            # two monitor ops have occurred at the same time.
+            # This verifies a condition in pacemaker-execd regression tests.
+            ocf_log err "$VERIFY_SERIALIZED_FILE exists already"
+            ocf_exit_reason "alternate universe collision"
+            return $OCF_ERR_GENERIC
+        fi
+
+        touch "${VERIFY_SERIALIZED_FILE}"
+        sleep ${OCF_RESKEY_op_sleep}
+        rm "${VERIFY_SERIALIZED_FILE}"
+    fi
+
+    if [ -f "${OCF_RESKEY_state}" ]; then
+	ptpstatus_update
+        # Multiple monitor levels are defined to support various tests
+        case "$OCF_CHECK_LEVEL" in
+            10)
+            # monitor level with delay, useful for testing timeouts
+            sleep 30
+            ;;
+
+            20)
+            # monitor level that fails intermittently
+            n=$(expr "$(dd if=/dev/urandom bs=1 count=1 2>/dev/null | od | head -1 | cut -f2 -d' ')" % 5)
+            if [ $n -eq 1 ]; then
+                ocf_exit_reason "smoke detected near CPU fan"
+                return $OCF_ERR_GENERIC
+            fi
+            ;;
+
+            30)
+            # monitor level that always fails
+            ocf_exit_reason "hyperdrive quota reached"
+            return $OCF_ERR_GENERIC
+            ;;
+
+            40)
+            # monitor level that returns error code from state file
+            rc=$(cat ${OCF_RESKEY_state})
+            [ -n "$rc" ] && ocf_exit_reason "CPU ejected. Observed leaving the Kronosnet galaxy at $rc times the speed of light." && return $rc
+            ;;
+
+            *)
+            ;;
+        esac
+        return $OCF_SUCCESS
+    fi
+    return $OCF_NOT_RUNNING
+}
+
+ptpstatus_validate() {
+    # Is the state directory writable?
+    state_dir=$(dirname "$OCF_RESKEY_state")
+    [ -d "$state_dir" ] && [ -w "$state_dir" ] && [ -x "$state_dir" ]
+    if [ $? -ne 0 ]; then
+        return $OCF_ERR_ARGS
+    fi
+    return $OCF_SUCCESS
+}
+
+: ${OCF_RESKEY_op_sleep:=0}
+: ${OCF_RESKEY_CRM_meta_interval:=0}
+: ${OCF_RESKEY_CRM_meta_globally_unique:="false"}
+: ${OCF_RESKEY_ptpstatus:="ptpstatus"}
+: ${OCF_RESKEY_dampen:=75}
+: ${OCF_RESKEY_multiplier:=1000}
+
+if [ -z "$OCF_RESKEY_state" ]; then
+    OCF_RESKEY_state="${HA_VARRUN%%/}/ptpstatus-${OCF_RESOURCE_INSTANCE}.state"
+
+    if [ "${OCF_RESKEY_CRM_meta_globally_unique}" = "false" ]; then
+        # Strip off the trailing clone marker (note + is not portable in sed)
+        OCF_RESKEY_state=$(echo $OCF_RESKEY_state | sed s/:[0-9][0-9]*\.state/.state/)
+    fi
+fi
+VERIFY_SERIALIZED_FILE="${OCF_RESKEY_state}.serialized"
+
+dump_env
+
+case "$__OCF_ACTION" in
+meta-data)      meta_data
+                exit $OCF_SUCCESS
+                ;;
+start)          ptpstatus_start;;
+stop)           ptpstatus_stop;;
+monitor)        ptpstatus_monitor;;
+migrate_to)     ocf_log info "Migrating ${OCF_RESOURCE_INSTANCE} to ${OCF_RESKEY_CRM_meta_migrate_target}."
+                ptpstatus_stop
+                ;;
+migrate_from)   ocf_log info "Migrating ${OCF_RESOURCE_INSTANCE} from ${OCF_RESKEY_CRM_meta_migrate_source}."
+                ptpstatus_start
+                ;;
+reload)         ocf_log err "Reloading..."
+                ptpstatus_start
+                ;;
+validate-all)   ptpstatus_validate;;
+usage|help)     ptpstatus_usage
+                exit $OCF_SUCCESS
+                ;;
+*)              ptpstatus_usage
+                exit $OCF_ERR_UNIMPLEMENTED
+                ;;
+esac
+rc=$?
+ocf_log debug "${OCF_RESOURCE_INSTANCE} $__OCF_ACTION : $rc"
+exit $rc
+
+# vim: set filetype=sh expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=80:

--- a/roles/oraclelinux_physical_machine/handlers/main.yml
+++ b/roles/oraclelinux_physical_machine/handlers/main.yml
@@ -1,0 +1,16 @@
+# Copyright (C) 2025 RTE
+# SPDX-License-Identifier: Apache-2.0
+
+- name: Trigger daemon-reload
+  ansible.builtin.service:
+    daemon_reload: yes
+
+- name: Restart systemd-sysctl
+  ansible.builtin.systemd:
+    name: systemd-sysctl.service
+    state: restarted
+
+- name: Rebuild initramfs if necessary
+  command:
+    cmd: /usr/sbin/update-initramfs -u
+  changed_when: true

--- a/roles/oraclelinux_physical_machine/initramfs-tools/conf.d/rebooter.conf.j2
+++ b/roles/oraclelinux_physical_machine/initramfs-tools/conf.d/rebooter.conf.j2
@@ -1,0 +1,5 @@
+# Device for /var/log storage
+REBOOTER_LOG_DEVICE={{ lvm_rebooter_log_device }}
+
+# Relative path from device root for /var/log
+REBOOTER_LOG_PATH={{ lvm_rebooter_log_path }}

--- a/roles/oraclelinux_physical_machine/initramfs-tools/scripts/init-bottom/rebooter
+++ b/roles/oraclelinux_physical_machine/initramfs-tools/scripts/init-bottom/rebooter
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+PREREQ="lvm"
+
+prereqs()
+{
+   echo "$PREREQ"
+}
+
+case $1 in
+prereqs)
+   prereqs
+   exit 0
+   ;;
+esac
+
+. /scripts/functions
+
+# Get REBOOTER_LOG_DEVICE and REBOOTER_LOG_PATH from config
+# Default to SEAPATH default (a dedicated LV called vg1-varlog)
+REBOOTER_LOG_DEVICE=/dev/mapper/vg1-varlog
+REBOOTER_LOG_PATH=.
+if [ -e /conf/conf.d/rebooter.conf ]; then
+	. /conf/conf.d/rebooter.conf
+fi
+
+log_begin_msg "Rebooter starting"
+if [ -e /run/initramfs/do_reboot ]; then
+	_log_msg "Rebooting...\n"
+	MOUNT_POINT="/run/mnt"
+	mkdir -p $MOUNT_POINT
+	mount -o sync,rw $REBOOTER_LOG_DEVICE $MOUNT_POINT
+	LOG_PATH="$MOUNT_POINT/$REBOOTER_LOG_PATH/initramfs.log"
+	echo "== $(date) ==" >> $LOG_PATH
+	dmesg >> $LOG_PATH
+	echo >> $LOG_PATH
+	umount $MOUNT_POINT
+	reboot -f -d 1 # No init to handle reboot => -f
+else
+	_log_msg "(no reboot needed) "
+fi
+log_end_msg
+
+exit 0

--- a/roles/oraclelinux_physical_machine/initramfs-tools/scripts/init-premount/lvm_snapshot_rebooter
+++ b/roles/oraclelinux_physical_machine/initramfs-tools/scripts/init-premount/lvm_snapshot_rebooter
@@ -1,0 +1,49 @@
+#!/bin/sh
+# LVM snapshot rebooter : wait for any merging LV and reboot once done
+# Use this it to workaround GRUB limitation : it does not handle LV with merging snapshot
+
+PREREQ="lvm"
+prereqs()
+{
+   echo "$PREREQ"
+}
+
+case $1 in
+prereqs)
+   prereqs
+   exit 0
+   ;;
+esac
+
+. /scripts/functions
+
+if [ ! -x "/sbin/lvm" ]; then
+   panic "lvs executable not found"
+fi
+
+get_lv_snapshot_merging() {
+	# This will print a list of "vg/lv" marked for merging
+	/sbin/lvm lvs --select 'lv_merging!=0' --noheadings --separator '/' -o vg_name,lv_name
+}
+
+log_begin_msg "Starting LVM Snapshot rebooter"
+
+# Wait for LVM elements to appear and be activated by udev
+wait_for_udev 10
+
+lv_merging=$(get_lv_snapshot_merging)
+if [ -n "$lv_merging" ] ; then
+	log_end_msg
+	for lv in $lv_merging; do
+		log_begin_msg "  Merging $lv"
+		/sbin/lvm lvchange --sysinit -ay "$lv" # lvmpolld/dmeventd no yet available
+		/sbin/lvm lvpoll --polloperation merge --interval 1 --config activation/monitoring=0 "$lv"
+		log_end_msg
+	done
+	log_success_msg "Snapshot merging complete, will reboot..."
+	touch /run/initramfs/do_reboot
+else
+	log_success_msg "Done. (No LVM snapshot need merging)"
+fi
+
+exit 0

--- a/roles/oraclelinux_physical_machine/initramfs-tools/scripts/init-top/init_log
+++ b/roles/oraclelinux_physical_machine/initramfs-tools/scripts/init-top/init_log
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+prereqs()
+{
+   echo "$PREREQ"
+}
+
+case $1 in
+prereqs)
+   prereqs
+   exit 0
+   ;;
+esac
+
+. /scripts/functions
+
+cat >> /conf/param.conf <<EOF
+if [ -z "\$INIT_LOG_DONE" ]; then
+	mkdir -p /run/initramfs
+	mkfifo "/run/initramfs/tempfifo"
+	awk '{print "<4>init: " \$0}' > /dev/kmsg </run/initramfs/tempfifo &
+	exec > /run/initramfs/tempfifo 2>&1
+	rm /run/initramfs/tempfifo
+
+	INIT_LOG_DONE=done
+fi
+EOF
+exit 0

--- a/roles/oraclelinux_physical_machine/meta/main.yml
+++ b/roles/oraclelinux_physical_machine/meta/main.yml
@@ -1,0 +1,14 @@
+# Copyright (C) 2024 RTE
+# SPDX-License-Identifier: Apache-2.0
+---
+galaxy_info:
+  author: "Seapath"
+  description: Debian prerequisites for a physical machine
+  license: Apache-2.0
+  min_ansible_version: 2.9.10
+  platforms:
+  - name: Debian
+    versions:
+    - all
+dependencies: []
+

--- a/roles/oraclelinux_physical_machine/tasks/main.yml
+++ b/roles/oraclelinux_physical_machine/tasks/main.yml
@@ -1,0 +1,207 @@
+# Copyright (C) 2024 RTE
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Populate service facts
+  service_facts:
+
+- name: Copy sysctl rules
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: /etc/sysctl.d/{{ item }}
+    mode: '0644'
+  with_items:
+    - 00-bridge_nf_call.conf
+  notify: Restart systemd-sysctl
+
+- name: Add sysctl conf from inventory (extra_sysctl_physical_machines)
+  ansible.builtin.copy:
+    dest: /etc/sysctl.d/00-seapathextra_physicalmachines.conf
+    mode: '0644'
+    content: "{{ extra_sysctl_physical_machines }}"
+  when: extra_sysctl_physical_machines is defined
+  notify: Restart systemd-sysctl
+
+- name: Create src folder on hosts
+  file:
+    path: /tmp/src
+    state: directory
+    mode: '0755'
+
+- name: Temp fix for synchronize to force evaluate variables
+  set_fact:
+    ansible_host: "{{ ansible_host }}"
+
+- name: Deploy vm_manager
+  include_role:
+    name: deploy_vm_manager
+
+- name: Deploy python3-setup-ovs
+  include_role:
+    name: deploy_python3_setup_ovs
+
+- name: Create /usr/lib/ocf/resource.d/seapath on hosts
+  file:
+    path: /usr/lib/ocf/resource.d/seapath
+    state: directory
+    mode: '0755'
+
+- name: Copy Pacemaker Seapath Resource-Agent files
+  ansible.posix.synchronize:
+    src: pacemaker_ra/
+    dest: /usr/lib/ocf/resource.d/seapath/
+    rsync_opts:
+    - "--chmod=F755"
+    - "--chown=root:root"
+  when:
+    - "'cluster_machines' in group_names"
+
+- name: Copy chrony-wait.service
+  template:
+    src: chrony-wait.service.j2
+    dest: /etc/systemd/system/chrony-wait.service
+    owner: root
+    group: root
+    mode: '0644'
+  register: chronywait
+  notify: Trigger daemon-reload
+- name: Enable chrony-wait.service
+  ansible.builtin.systemd:
+    name: chrony-wait.service
+    enabled: yes
+
+- when:
+    - services['pacemaker.service'] is defined
+  block:
+    - name: Create pacemaker.service.d directory
+      file:
+        path: /etc/systemd/system/pacemaker.service.d/
+        state: directory
+        owner: root
+        group: root
+        mode: 0755
+    - name: Copy pacemaker.service drop-in
+      template:
+        src: pacemaker_override.conf.j2
+        dest: /etc/systemd/system/pacemaker.service.d/override.conf
+        owner: root
+        group: root
+        mode: 0644
+      notify: Trigger daemon-reload
+      register: pacemaker_corosync
+    - name: Get Pacemaker service Status
+      ansible.builtin.systemd:
+        name: "pacemaker.service"
+      register: pacemaker_service_status
+    - name: Disable pacemaker (reinstall step 1/2)
+      ansible.builtin.systemd:
+        name: pacemaker.service
+        enabled: no
+      when: pacemaker_corosync.changed and pacemaker_service_status.status.UnitFileState == "enabled"
+    - name: Enable pacemaker (reinstall step 2/2)
+      ansible.builtin.systemd:
+        name: pacemaker.service
+        enabled: yes
+      when: pacemaker_corosync.changed and pacemaker_service_status.status.UnitFileState == "enabled"
+
+- name: Add extra modules to the kernel
+  lineinfile:
+    dest: /etc/modules
+    state: present
+    regexp: "^{{ item }}$"
+    line: "{{ item }}"
+  with_items: "{{ extra_kernel_modules | default([]) }}"
+
+- name: Add admin user to libvirt group
+  user:
+    name: "{{ admin_user }}"
+    groups: libvirt
+    append: yes
+
+- name: Creating libvirt user with libvirtd permissions
+  user:
+    name: libvirt
+    group: libvirt
+    shell: /bin/false
+
+- name: Add br_netfilter to /etc/modules-load.d
+  ansible.builtin.copy:
+    src: modules/netfilter.conf
+    dest: /etc/modules-load.d/netfilter.conf
+    owner: root
+    group: root
+    mode: 0751
+- name: Add raid6_pq to /etc/modules-load.d
+  ansible.builtin.copy:
+    src: modules/raid6_pq.conf
+    dest: /etc/modules-load.d/raid6_pq.conf
+    owner: root
+    group: root
+    mode: 0751
+
+- name: Lineinfile in hosts file for logstash-seapath
+  lineinfile:
+    dest: /etc/hosts
+    regexp: '.* logstash-seapath$'
+    line: "{{ logstash_server_ip }} logstash-seapath"
+    state: present
+  when: logstash_server_ip is defined
+
+- name: Make libvirt use the "machine-id" way to determine host UUID
+  lineinfile:
+    dest: /etc/libvirt/libvirtd.conf
+    regexp: "^#?host_uuid_source ="
+    line: "host_uuid_source = \"machine-id\""
+    state: present
+- name: Restart libvirtd
+  ansible.builtin.systemd:
+    name: libvirtd.service
+    state: restarted
+
+- name: Add rbd type to lvm.conf
+  ansible.builtin.lineinfile:
+    path: /etc/lvm/lvm.conf
+    insertafter: 'devices {'
+    line: "        types = [ \"rbd\", 1024 ]"
+    state: present
+- name: disable lvm use_devicesfile
+  ansible.builtin.lineinfile:
+    path: /etc/lvm/lvm.conf
+    regexp: "^\\s*#?\\s*use_devicesfile\\s*=\\s*"
+    line: "        use_devicesfile = 0"
+    state: present
+
+- name: Create a symbolic link for qemu-kvm/x86-64
+  ansible.builtin.file:
+    src: /usr/libexec/qemu-kvm
+    dest: /usr/bin/qemu-system-x86_64
+    state: link
+
+- name: Enable and start virtsecretd.socket
+  ansible.builtin.systemd:
+    name: virtsecretd.socket
+    state: started
+    enabled: true
+- name: Enable and start virtqemud.socket
+  ansible.builtin.systemd:
+    name: virtqemud.socket
+    state: started
+    enabled: true
+- name: Enable and start virtstoraged.socket
+  ansible.builtin.systemd:
+    name: virtstoraged.socket
+    state: started
+    enabled: true
+
+- name: Ensure group www-data exists with GID 1033
+  group:
+    name: www-data
+    gid: 1033
+    state: present
+
+- name: Ensure user www-data exists with UID 1033 and GID 1033
+  user:
+    name: www-data
+    uid: 1033
+    group: www-data
+    shell: /bin/bash

--- a/roles/oraclelinux_physical_machine/templates/chrony-wait.service.j2
+++ b/roles/oraclelinux_physical_machine/templates/chrony-wait.service.j2
@@ -1,0 +1,46 @@
+[Unit]
+Description=Wait for chrony to synchronize system clock
+Documentation=man:chronyc(1)
+After=timemaster.service
+Requires=timemaster.service
+Before=time-sync.target
+Wants=time-sync.target
+
+[Service]
+Type=oneshot
+# Wait for chronyd to update the clock and the remaining
+# correction to be less than 0.1 seconds
+ExecStart=/usr/bin/chronyc -h 127.0.0.1,::1 waitsync 0 0.1 0.0 1
+# Wait for at most chrony_wait_timeout_sec seconds
+TimeoutStartSec={{ chrony_wait_timeout_sec | default(180) }}
+RemainAfterExit=yes
+StandardOutput=null
+
+CapabilityBoundingSet=
+DevicePolicy=closed
+DynamicUser=yes
+IPAddressAllow=localhost
+IPAddressDeny=any
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+PrivateDevices=yes
+PrivateUsers=yes
+ProtectClock=yes
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectProc=invisible
+ProtectSystem=strict
+RestrictAddressFamilies=AF_INET AF_INET6
+RestrictNamespaces=yes
+RestrictRealtime=yes
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources
+UMask=0777
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/oraclelinux_physical_machine/templates/pacemaker_override.conf.j2
+++ b/roles/oraclelinux_physical_machine/templates/pacemaker_override.conf.j2
@@ -1,0 +1,13 @@
+[Unit]
+Wants=libvirtd.service
+After=libvirtd.service
+Wants=virtqemud.service
+After=virtqemud.service
+
+[Install]
+WantedBy=corosync.service
+
+[Service]
+ExecStartPre=/usr/bin/virsh list
+TimeoutStopSec={{ pacemaker_shutdown_timeout | default("2min") }}
+TimeoutStartSec=60s

--- a/roles/oraclelinux_tests/README.md
+++ b/roles/oraclelinux_tests/README.md
@@ -1,0 +1,17 @@
+# Oracle Linux cukinia tests
+
+This role the tests specific to OracleLinux machines
+
+## Requirements
+
+No requirement.
+
+## Role Variables
+
+## Example Playbook
+
+```yaml
+- hosts: cluster_machines
+  roles:
+    - { role: seapath_ansible.oraclelinux_tests }
+```

--- a/roles/oraclelinux_tests/files/cukinia-cluster.conf
+++ b/roles/oraclelinux_tests/files/cukinia-cluster.conf
@@ -1,0 +1,107 @@
+# Copyright (C) 2025 RTE
+# SPDX-License-Identifier: Apache-2.0
+
+logging class "${MACHINENAME:-$(hostname)}"
+logging suite "common cluster"
+
+# --- vm manager pacemaker tests ---
+cukinia_log "$(_colorize yellow "--- Test vm_manager module Pacemaker part ---")"
+
+# locate vm_manager directory
+VM_MANAGER_DIR=$(/usr/bin/python3 -c 'import vm_manager as m; print(m.__path__[0])')
+
+id "SEAPATH-00071" as "Test add VM" cukinia_cmd python3 $VM_MANAGER_DIR/helpers/tests/pacemaker/add_vm.py
+
+id "SEAPATH-00072" as "Test stop VM" cukinia_cmd python3 $VM_MANAGER_DIR/helpers/tests/pacemaker/stop_vm.py
+
+id "SEAPATH-00073" as "Test start VM" cukinia_cmd python3 $VM_MANAGER_DIR/helpers/tests/pacemaker/start_vm.py
+
+id "SEAPATH-00074" as "Test remove VM" cukinia_cmd python3 $VM_MANAGER_DIR/helpers/tests/pacemaker/remove_vm.py
+
+# --- vn manager pacemaker tests ---
+
+cukinia_log "$(_colorize yellow "--- Test vm_manager module Ceph RBD part ---")"
+
+id "SEAPATH-00306" as "Test clone disk" cukinia_cmd timeout -k 30s 30s python3 $VM_MANAGER_DIR/helpers/tests/rbd_manager/clone_rbd.py
+
+id "SEAPATH-00307" as "Test groups" cukinia_cmd timeout -k 30s 30s python3 $VM_MANAGER_DIR/helpers/tests/rbd_manager/create_rbd_group.py
+
+id "SEAPATH-00308" as "Test namespaces" cukinia_cmd timeout -k 30s 30s python3 $VM_MANAGER_DIR/helpers/tests/rbd_manager/create_rbd_namespace.py
+
+id "SEAPATH-00309" as "Test metadata" cukinia_cmd timeout -k 30s 30s python3 $VM_MANAGER_DIR/helpers/tests/rbd_manager/metadata_rbd.py
+
+id "SEAPATH-00060" as "Test snapshots" cukinia_cmd timeout -k 60s 60s python3 $VM_MANAGER_DIR/helpers/tests/rbd_manager/purge_rbd.py
+
+id "SEAPATH-00061" as "Test snapshots rollback" cukinia_cmd timeout -k 40s 40s python3 $VM_MANAGER_DIR/helpers/tests/rbd_manager/rollback_rbd.py
+
+id "SEAPATH-00062" as "Test write rbd" cukinia_cmd timeout -k 30s 30s python3 $VM_MANAGER_DIR/helpers/tests/rbd_manager/write_rbd.py
+
+# --- Ceph tests ---
+cukinia_log "$(_colorize yellow "--- check Ceph status ---")"
+
+_ceph_status=$(timeout 10s ceph status 2>/dev/null)
+# If cluster is not set up properly, ceph commands will never return anything.
+# A timeout is necessary to catch a cluster failure
+
+function get_ceph_status_field() {
+    local field="$1"
+
+    if test -z "${_ceph_status}"; then
+        return 254
+    fi
+    grep "${field}:" <<< "${_ceph_status}" | cut -d":" -f2- | xargs
+}
+
+get_ceph_status_field health | grep -Pq "HEALTH_(OK|WARN)"
+id "SEAPATH-00051" as "health is not error" cukinia_test $? -eq 0
+
+get_ceph_status_field mon | grep -q "3 daemons"
+id "SEAPATH-00052" as "3 monitors are configured" cukinia_test $? -eq 0
+
+quorum_out="$(get_ceph_status_field 'out of quorum' || echo fail)"
+id "SEAPATH-00053" as "3 monitors are up" cukinia_test -z "${quorum_out}"
+
+get_ceph_status_field osd | \
+    grep -qE "([2-9][0-9]*|1[0-9]+) osds: ([2-9][0-9]*|1[0-9]+) up"
+id "SEAPATH-00054" as "at least 2 osds are configured and up" cukinia_test $? -eq 0
+
+get_ceph_status_field mgr | grep -q "active"
+id "SEAPATH-00055" as "a manager is active" cukinia_test $? -eq 0
+
+# --- corosync tests ---
+cukinia_log "$(_colorize yellow "--- check corosync service ---")"
+
+
+id "SEAPATH-00119" as "corosync service is running" cukinia_cmd systemctl is-active corosync.service
+
+# --- pacemaker tests ---
+cukinia_log "$(_colorize yellow "--- check Pacemaker status ---")"
+
+id "SEAPATH-00122" as "pacemaker service is running" cukinia_cmd systemctl is-active pacemaker.service
+
+
+crm_output="$(crm status 2>/dev/null)"
+crm_retval=$?
+
+[ ${crm_retval} -eq 0 ] && ! grep -q "OFFLINE:" <<< "${crm_output}"
+echo "${crm_output}" | id "SEAPATH-00063" as "no OFFLINE node" cukinia_test $? -eq 0
+
+[ ${crm_retval} -eq 0 ] && grep -q "3 nodes configured" <<< "${crm_output}"
+echo "${crm_output}" | id "SEAPATH-00064" as "3 nodes are configured" cukinia_test $? -eq 0
+
+
+# --- libvirt tests ---
+cukinia_log "$(_colorize yellow "--- Test vm_manager module libvirt part ---")"
+
+clean_vm()
+{
+    if virsh list |grep -q 'test0' ; then
+        virsh undefine "test0"
+    fi
+    rm -f /tmp/test_config.xml
+}
+
+clean_vm
+
+id "SEAPATH-00065" as "list secrets" cukinia_test `/usr/local/bin/libvirt_cmd secrets \
+    |grep -c client.libvirt` -gt 0

--- a/roles/oraclelinux_tests/files/cukinia.conf
+++ b/roles/oraclelinux_tests/files/cukinia.conf
@@ -1,0 +1,40 @@
+# Copyright (C) 2025 Red Hat, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+logging class "${MACHINENAME:-$(hostname)}"
+logging suite "common"
+
+VM_MANAGER_DIR=$(/usr/bin/python3 -c 'import vm_manager as m; print(m.__path__[0])')
+
+# --- libvirt tests ---
+cukinia_log "$(_colorize yellow "--- Test vm_manager module libvirt part ---")"
+
+clean_vm()
+{
+    if virsh list |grep -q 'test0' ; then
+        virsh undefine "test0"
+    fi
+    rm -f /tmp/test_config.xml
+}
+
+clean_vm
+
+id "SEAPATH-00066" as "define VM from a valid configuration" cukinia_cmd \
+    /usr/local/bin/libvirt_cmd define $VM_MANAGER_DIR/testdata/vm.xml
+
+
+/usr/local/bin/libvirt_cmd \
+    define \
+    $VM_MANAGER_DIR/testdata/wrong_vm_config.xml 1>/dev/null 2>&1
+id "SEAPATH-00067" as "define VM from a valid configuration" \
+cukinia_test $? -ne 0
+
+id "SEAPATH-00068" as "list VM" cukinia_test `/usr/local/bin/libvirt_cmd list \
+    |grep -c "test0"` -gt 0
+
+id "SEAPATH-00069" as "export VM configuration" cukinia_cmd /usr/local/bin/libvirt_cmd \
+    export "test0" /tmp/test_config.xml
+
+id "SEAPATH-00070" as "VM configuration has been export" cukinia_test -f /tmp/test_config.xml
+
+clean_vm

--- a/roles/oraclelinux_tests/meta/main.yml
+++ b/roles/oraclelinux_tests/meta/main.yml
@@ -1,0 +1,14 @@
+# Copyright (C) 2024 RTE
+# SPDX-License-Identifier: Apache-2.0
+---
+galaxy_info:
+  author: "Seapath"
+  description: Cukinia tests for OracleLinux
+  min_ansible_version: 2.9.10
+  license: Apache-2.0
+  platforms:
+  - name: Debian
+    versions:
+    - all
+dependencies: []
+

--- a/roles/oraclelinux_tests/tasks/main.yml
+++ b/roles/oraclelinux_tests/tasks/main.yml
@@ -1,0 +1,20 @@
+# Copyright (C) 2024 RTE
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Create /etc/cukinia folder
+  file:
+    path: "/etc/cukinia"
+    state: directory
+    mode: '0755'
+
+- name: Copy OracleLinux cukinia tests
+  ansible.builtin.copy:
+    src: cukinia.conf
+    dest: /etc/cukinia/cukinia.conf
+    mode: '0644'
+- name: Copy OracleLinux cukinia cluster tests
+  ansible.builtin.copy:
+    src: cukinia-cluster.conf
+    dest: /etc/cukinia/cukinia-cluster.conf
+    mode: '0644'

--- a/roles/snmp/vars/OracleLinux.yml
+++ b/roles/snmp/vars/OracleLinux.yml
@@ -1,0 +1,5 @@
+# Copyright (C) 2024 RTE
+# SPDX-License-Identifier: Apache-2.0
+
+---
+snmp_user_name: "oraclelinux-snmp"

--- a/roles/timemaster/vars/OracleLinux.yml
+++ b/roles/timemaster/vars/OracleLinux.yml
@@ -1,0 +1,7 @@
+# Copyright (C) 2024 RTE
+# SPDX-License-Identifier: Apache-2.0
+
+---
+timemaster_path_timemaster_conf: "/etc/timemaster.conf"
+timemaster_path_chrony_conf: "/etc/chrony.conf"
+timemaster_service_name_chrony: "chronyd"

--- a/vars/OracleLinux_paths.yml
+++ b/vars/OracleLinux_paths.yml
@@ -1,0 +1,5 @@
+# Copyright (C) 2024, Red Hat
+# SPDX-License-Identifier: Apache-2.0
+
+---
+cukinia_command_path: "/usr/local/bin/cukinia"


### PR DESCRIPTION
This PR makes Seapath able to deploy on OracleLinux Servers. It includes:
- a kickstart file for building the iso
- a cephadm role so that we do not really on distro-specific ceph packages
- ceph 19
- minimal cukinia tests in a specific oraclelinux_tests role
- an operational CI infrastructure, that deploys a cluster + a standalone + 3 VMs and tests everything

It does not include:
- port of the "hypervisor" role, since OracleLinux does not come with an RT kernel. Using the centos RT kernel is an option but not in the scope of this PR.