### PR TITLE
Debian: remove latency testing

### DIFF
--- a/.github/workflows/ci-debian.yml
+++ b/.github/workflows/ci-debian.yml
@@ -48,11 +48,6 @@ jobs:
         run: cd ${{ env.WORK_DIR }};
              ci/launch.sh vm;
 
-      - name: Launch latency tests
-        if: ${{ always() && steps.conf.conclusion == 'success' }}
-        run: cd ${{ env.WORK_DIR }};
-             ci/launch.sh latency;
-
       - name: Upload test report
         if: ${{ always() && steps.conf.conclusion == 'success' }}
         run: cd ${{ env.WORK_DIR }};


### PR DESCRIPTION
These tests are obsolete and will be replaced by the newest svtrace approach