### PR TITLE
templates/vm: add secure boot feature

### DIFF
--- a/inventories/examples/seapath-vm-deployement.yaml
+++ b/inventories/examples/seapath-vm-deployement.yaml
@@ -23,7 +23,7 @@ VMs:
       wait_for_connection: true
 
       # Configuration part. These variables only work with the guest.xml.j2 template
-      vm_features: ["rt", "isolated"] # features for real time VM
+      vm_features: ["rt", "isolated"] # features for real time VM with secure boot disabled
       cpuset: [4, 5] # TODO : Replace by the hypervisor cpu you want to pin your VM on.
       bridges:
         - name: "br0"
@@ -39,7 +39,7 @@ VMs:
       wait_for_connection: true
 
       # Configuration part. These variables only work with the guest.xml.j2 template
-      vm_features: [] # features for non real-time VM
+      vm_features: ["secure-boot"] # features for non real-time VM with secure boot enabled
       nb_cpu: 1 # TODO : Number of vCPU of your VM
       bridges:
         - name: "br0"

--- a/templates/vm/guest.xml.j2
+++ b/templates/vm/guest.xml.j2
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright (C) 2023, RTE (http://www.rte-france.com) -->
+<!--  Copyright (C) 2025 Savoir-faire Linux, Inc-->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <!--
@@ -45,6 +46,9 @@
         <bootmenu enable="no" />
         <bios useserial="yes" rebootTimeout="0" />
         <smbios mode="emulate" />
+        <firmware>
+            <feature enabled="{{ 'yes' if 'secure-boot' is in vm.vm_features else 'no' }}" name="secure-boot"/>
+        </firmware>
     </os>
     <features>
         <acpi />

--- a/templates/vm/seapath_guest_nort.xml.j2
+++ b/templates/vm/seapath_guest_nort.xml.j2
@@ -15,6 +15,9 @@
       <boot dev="hd" />
       <bios useserial="yes" rebootTimeout="0" />
       <smbios mode="emulate" />
+      <firmware>
+          <feature enabled="{{ 'yes' if 'secure-boot' is in vm.vm_features else 'no' }}" name="secure-boot"/>
+      </firmware>
     </os>
     <features>
         <acpi/>

--- a/templates/vm/seapath_guest_rt.xml.j2
+++ b/templates/vm/seapath_guest_rt.xml.j2
@@ -15,6 +15,9 @@
       <boot dev="hd" />
       <bios useserial="yes" rebootTimeout="0" />
       <smbios mode="emulate" />
+      <firmware>
+          <feature enabled="{{ 'yes' if 'secure-boot' is in vm.vm_features else 'no' }}" name="secure-boot"/>
+      </firmware>
     </os>
     <features>
         <acpi/>

--- a/templates/vm/ssc600.xml.j2
+++ b/templates/vm/ssc600.xml.j2
@@ -32,6 +32,9 @@
     <os>
         <type arch="x86_64" machine="q35">hvm</type>
         <boot dev="hd"/>
+        <firmware>
+            <feature enabled="{{ 'yes' if 'secure-boot' is in vm.vm_features else 'no' }}" name="secure-boot"/>
+        </firmware>
     </os>
     <features>
         <acpi/>


### PR DESCRIPTION
Add the "vm_features" secure-boot in VM's configurations templates to explicitly enable or disable the secure boot.

Without this feature, the secure boot enabling differs between hypervisor machines and can lead to unexpected behaviors.