### PR TITLE
inventories/examples: add two require variables

### DIFF
--- a/inventories/examples/seapath-cluster.yaml
+++ b/inventories/examples/seapath-cluster.yaml
@@ -95,7 +95,10 @@ cluster_machines:
     ntp_servers:
       - "185.254.101.25" # public ntp server
       - "51.145.123.29"  # public ntp serve
-
+    # Hardening (Debian only)
+    # TODO : Put the password hash for the grub password
+    # It can be generated with the following command: grub-mkpasswd-pbkdf2
+    grub_password: grub.pbkdf2.sha512.10000.666FF16D5587509B2B3340B2388CB798BEF9553A9666CECA6282E0D822C1529F94AF693CC6738C1F757B868D8090F24FD48D8F56486C70C545D559CB4BAAAA3E.9718E767036BDB71CC1B82BCFC906610F8772DD4757F6F075D82A23E70DA46FBED372A3E5143E5C2D40AA888C6B884E4AA437488D82008383C54ED79D68A42CF
 
 # ------------------------------------------------------------------------------
 # ------------------- Ceph configuration part ----------------------------------

--- a/inventories/examples/seapath-standalone.yaml
+++ b/inventories/examples/seapath-standalone.yaml
@@ -39,6 +39,9 @@ standalone_machine:
     dns_servers: "192.168.200.1" # TODO : Put your dns address
     ip_addr: "{{ ansible_host }}"
     apply_network_config: true
+    # List of interfaces to wait for before considering the network as up.
+    # With the default network configuration, it should be "br0"
+    interfaces_to_wait_for: "br0"
     # systemd-networkd is used by default to configure the network
     # netplan can also be used to sum up complex network in one yaml file
     # See the wiki for more informations : TODO put link
@@ -46,7 +49,12 @@ standalone_machine:
     # NTP time synchronisation
     ntp_servers:
       - "185.254.101.25" # public ntp server
-      - "51.145.123.29"  # public ntp serve
+      - "51.145.123.29"  # public ntp server
+
+    # Hardening (Debian only)
+    # TODO : Put the password hash for the grub password
+    # It can be generated with the following command: grub-mkpasswd-pbkdf2
+    grub_password: grub.pbkdf2.sha512.10000.666FF16D5587509B2B3340B2388CB798BEF9553A9666CECA6282E0D822C1529F94AF693CC6738C1F757B868D8090F24FD48D8F56486C70C545D559CB4BAAAA3E.9718E767036BDB71CC1B82BCFC906610F8772DD4757F6F075D82A23E70DA46FBED372A3E5143E5C2D40AA888C6B884E4AA437488D82008383C54ED79D68A42CF
 
 # ------------------------------------------------------------------------------
 # ----------------------- Empty groups, prevent warnings -----------------------


### PR DESCRIPTION
grub_password is needed by the Debian hardening role and will fail if not set.

If interfaces_to_wait_for is not set, all the interfaces will be waited for before considering the network as up on standalone.