### PR TITLE
test_deploy_cukinia_tests: add deploy_cukinia role to the playbook

### DIFF
--- a/playbooks/ci_test.yaml
+++ b/playbooks/ci_test.yaml
@@ -6,15 +6,6 @@
 
 ---
 
-- name: Deploy cukinia
-  hosts:
-    - cluster_machines
-    - standalone_machine
-    - VMs
-  become: true
-  roles:
-    - deploy_cukinia
-
 - name: Import test_deploy_cukinia_tests playbook
   import_playbook: ./test_deploy_cukinia_tests.yaml
 - name: Import test_run_cukinia playbook

--- a/playbooks/test_deploy_cukinia_tests.yaml
+++ b/playbooks/test_deploy_cukinia_tests.yaml
@@ -10,4 +10,5 @@
   become: true
   gather_facts: True
   roles:
+    - deploy_cukinia
     - deploy_cukinia_tests


### PR DESCRIPTION
Call the deploy_cukinia role in the test_deploy_cukinia_tests playbook. Remove the deploy_cukinia role from the ci_test playbook.