### PR TITLE
ci-yocto: add seapath benchmark execution

### DIFF
--- a/.github/workflows/ci-yocto-weekly.yml
+++ b/.github/workflows/ci-yocto-weekly.yml
@@ -21,3 +21,4 @@ jobs:
     uses: ./.github/workflows/ci-yocto.yml
     with:
       pcap_loop: 900 # 15 min
+      weekly: true

--- a/.github/workflows/ci-yocto.yml
+++ b/.github/workflows/ci-yocto.yml
@@ -16,6 +16,10 @@ on:
         default: 60
         required: false
         type: number
+      weekly:
+        default: false
+        required: false
+        type: boolean
   workflow_dispatch:
 
 permissions:
@@ -56,6 +60,11 @@ jobs:
         if: ${{ always() && steps.conf.conclusion == 'success' }}
         run: cd ${{ env.WORK_DIR }};
             ci/launch-yocto.sh deploy_vms;
+
+      - name: Run seapath-benchmark
+        if: ${{ inputs.weekly == 'true' && steps.conf.conclusion == 'success' }}
+        run: cd ${{ env.WORK_DIR }};
+            ci/launch-yocto.sh run_benchmark_weekly;
 
       - name: Launch VMs tests
         if: ${{ always() && steps.conf.conclusion == 'success' }}


### PR DESCRIPTION
Add the execution of seapath-benchmark in Yocto weekly CI.