### PR TITLE
remove backup-restore and adapt vmmgrapi on standalone

### DIFF
--- a/playbooks/seapath_setup_main.yaml
+++ b/playbooks/seapath_setup_main.yaml
@@ -46,6 +46,8 @@
   import_playbook: cluster_setup_users.yaml
 - name: Import cluster_setup_ha playbook
   import_playbook: cluster_setup_ha.yaml
+- name: Import seapath_setup_vmmgrapi playbook
+  import_playbook: seapath_setup_vmmgrapi.yaml
 
 - name: Restart all hosts
   hosts:

--- a/playbooks/seapath_setup_prerequisdebian.yaml
+++ b/playbooks/seapath_setup_prerequisdebian.yaml
@@ -17,7 +17,6 @@
   become: true
   roles:
     - debian_physical_machine
-    - vmmgrapi
 - name: Backup_restore on cluster machines
   hosts:
     - cluster_machines

--- a/playbooks/seapath_setup_prerequisdebian.yaml
+++ b/playbooks/seapath_setup_prerequisdebian.yaml
@@ -17,8 +17,13 @@
   become: true
   roles:
     - debian_physical_machine
-    - backup_restore
     - vmmgrapi
+- name: Backup_restore on cluster machines
+  hosts:
+    - cluster_machines
+  become: true
+  roles:
+    - backup_restore
 - name: Prerequis hypervisor debian
   hosts:
     - hypervisors

--- a/playbooks/seapath_setup_vmmgrapi.yaml
+++ b/playbooks/seapath_setup_vmmgrapi.yaml
@@ -1,0 +1,13 @@
+# Copyright (C) 2022, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+# Ansible playbook that configures the vm-manager REST API
+
+---
+- name: Configure vm-manager rest api
+  hosts:
+    - cluster_machines
+    - standalone
+  become: true
+  roles:
+    - vmmgrapi

--- a/roles/configure_ha/README.md
+++ b/roles/configure_ha/README.md
@@ -14,7 +14,6 @@ No requirement.
 | corosync_node_list                   | yes      | String list |         | List of all corosync nodes. Usually `{{ groups['cluster_machines'] \| list }}` |
 | configure_ha_tmpdir                  | no       | String      | /tmp    | Temporary directory path to use                                                |
 | enable_vmmgr_http_api   | no       | Bool        | false   | Set to true to enable SEAPATH vm-manager REST API                              |
-| admin_cluster_ip                     | no       | String      |         | IP of the REST API. If not set the m-manager REST API will be disabled even if `enable_vmmgr_http_api is set to true` |
 | extra_crm_cmd_to_run                 | no       | String      |         | List of `crm configure` commands to run separate by a new line.                |
 
 ## Example Playbook

--- a/roles/configure_ha/tasks/main.yml
+++ b/roles/configure_ha/tasks/main.yml
@@ -143,23 +143,6 @@
     enabled: yes
 
 # run extra CRM commands
-- name: Run extra CRM configuration commands for vm-mgr http api
-  command:
-    cmd: crm -d config load update -
-    stdin: "{{ vmmgrapi_cmd_list }}"
-  when:
-    - enable_vmmgr_http_api is defined
-    - enable_vmmgr_http_api is true
-    - admin_cluster_ip is defined
-  run_once: true
-  register: vmmgrapi_cmd_list_task
-  changed_when: "'CIB commit successful' in vmmgrapi_cmd_list_task.stdout"
-  vars:
-    vmmgrapi_cmd_list: |
-      primitive ClusterIP IPaddr2 params ip={{ admin_cluster_ip }} cidr_netmask=32 op monitor interval=30s meta target-role=Started
-      primitive vmmgrapi systemd:nginx.service  op monitor interval=30s
-      colocation vmmgrapi_colocation inf: ClusterIP vmmgrapi
-      order order_ClusterIP_vmmgrapi ClusterIP vmmgrapi
 - name: Run extra CRM configuration commands
   command:
     cmd: crm -d config load update -

--- a/roles/vmmgrapi/README.md
+++ b/roles/vmmgrapi/README.md
@@ -14,9 +14,9 @@ No requirement.
 | vmmgr_http_tls_key_path    | No       | String  | Path in the Ansible machine to the TLS private key. If not set, it will be generated       |
 | vmmgr_http_local_auth_file | No       | String  | Optional path in the target to an existing basic HTTP auth file                            |
 | vmmgr_http_port            | No       | Integer | Port to listen                                                                             |
-| admin_cluster_ip           | No       | String  | IP address where connections will be listened                                              |
 | vmmgr_http_api_acl         | No       | String  | Extra Nginx "server" configuration                                                         |
 | enable_vmmgr_http_api      | No       | Bool    | Set to true to enable vm-manager REST API. Default is disable and the role will do nothing |
+| vmmgrapi_ipaddress         | No       | String  | IP address where connections will be listened                                              |
 
 ## Example Playbook
 

--- a/roles/vmmgrapi/defaults/main.yml
+++ b/roles/vmmgrapi/defaults/main.yml
@@ -1,0 +1,5 @@
+# Copyright (C) 2025 RTE
+# SPDX-License-Identifier: Apache-2.0
+
+---
+vmmgrapi_ipaddress: "{{ ansible_host }}"

--- a/roles/vmmgrapi/tasks/main.yml
+++ b/roles/vmmgrapi/tasks/main.yml
@@ -136,3 +136,21 @@
     enabled: no
   when:
     - services['gunicorn.service'] is defined
+
+- name: Run extra CRM configuration commands for vm-mgr http api
+  command:
+    cmd: crm -d config load update -
+    stdin: "{{ vmmgrapi_cmd_list }}"
+  when:
+    - enable_vmmgr_http_api is defined
+    - enable_vmmgr_http_api is true
+    - "'cluster_machines' in group_names"
+  run_once: true
+  register: vmmgrapi_cmd_list_task
+  changed_when: "'CIB commit successful' in vmmgrapi_cmd_list_task.stdout"
+  vars:
+    vmmgrapi_cmd_list: |
+      primitive ClusterIP IPaddr2 params ip={{ vmmgrapi_ipaddress }} cidr_netmask=32 op monitor interval=30s meta target-role=Started
+      primitive vmmgrapi systemd:nginx.service  op monitor interval=30s
+      colocation vmmgrapi_colocation inf: ClusterIP vmmgrapi
+      order order_ClusterIP_vmmgrapi ClusterIP vmmgrapi

--- a/roles/vmmgrapi/templates/nginx.conf.j2
+++ b/roles/vmmgrapi/templates/nginx.conf.j2
@@ -11,7 +11,7 @@ http {
     server unix:/run/gunicorn.sock fail_timeout=0;
   }
   server {
-    listen {{ admin_cluster_ip }}:{{ vmmgr_http_port }} ssl;
+    listen {{ vmmgrapi_ipaddress }}:{{ vmmgr_http_port }} ssl;
     ssl_certificate {{ vmmgrapi_certs_dir }}/seapath.crt;
     ssl_certificate_key {{ vmmgrapi_certs_dir }}/seapath.key;
 


### PR DESCRIPTION
Remove backup-restore on standalone
On standalone backup-restore does not make sense.

----
vmmgrapi: refactor to make it work on standalone
- admin_cluster_ip is replaced by a role variable vmmgrapi_ipaddress, specific to the vmmgrapi role
- deployment of this role is delayed to after configure_ha
- the vmmgrapi role now includes the logic to change the pacemaker configuration, instead of configure_ha