### PR TITLE
ci-yocto: fix incorrect condition

### DIFF
--- a/.github/workflows/ci-yocto.yml
+++ b/.github/workflows/ci-yocto.yml
@@ -62,7 +62,7 @@ jobs:
             ci/launch-yocto.sh deploy_vms;
 
       - name: Run seapath-benchmark
-        if: ${{ inputs.weekly == 'true' && steps.conf.conclusion == 'success' }}
+        if: ${{ inputs.weekly && steps.conf.conclusion == 'success' }}
         run: cd ${{ env.WORK_DIR }};
             ci/launch-yocto.sh run_benchmark_weekly;
 


### PR DESCRIPTION
The seapath-benchmark task run condition was incorrect, causing it to not be run in the weekly CI run.