### PR TITLE
cluster_setup_ceph: set ceph_uid variable for Yocto

### DIFF
--- a/playbooks/cluster_setup_ceph.yaml
+++ b/playbooks/cluster_setup_ceph.yaml
@@ -10,7 +10,18 @@
   become: true
   gather_facts: yes
   roles:
+    - detect_seapath_distro
     - ceph_prepare_installation
+  tasks:
+    - name: Set ceph UID/GID fact
+      when: seapath_distro == "Yocto"
+      block:
+        - name: Get GID of ceph group
+          register: ceoh_gid_result
+          shell: grep '^ceph' /etc/passwd | cut -d':' -f3
+        - name: Set ceph_uid
+          set_fact:
+            ceph_uid: "{{ ceoh_gid_result.stdout }}"
 
 - name: Ceph Expansion VG
   hosts:


### PR DESCRIPTION
By default, the ceph_uid variable is used by ceph-ansible to set user and group ownerships of files created on the target. For example, this is the case for the Ceph keys in /etc/ceph.

Until now, its value was provided by the ceph-defaults role of ceph-ansible. It works correctly with Debian, but sets the value to 167 by default for Yocto. This creates files on the system that do not belong to any user / group.

Fix this by setting ceph_uid to the actual UID of the ceph user.

Fixes partially https://github.com/seapath/ansible/issues/695