### PR TITLE
inventories/providers/abb/README: fix markdown syntax

### DIFF
--- a/inventories/providers/abb/README.md
+++ b/inventories/providers/abb/README.md
@@ -12,6 +12,7 @@ The VM deployment has been tested on a Yocto and a Debian hypervisor using the v
 ## Files needed
 
 Some files provided by ABB are needed to use these inventories:
+
 - ssc600\_disk.img.gz
 - qemu.hook
 
@@ -20,6 +21,7 @@ To use them, they can be copied in the `files` directory at the root of ansible.
 > The raw image disk ssc600\_disk.img.gz has to be converted to qcow2 format to work on SEAPATH.
 
 This can be done with the following commands:
+
 - `gunzip ssc600sw_disk.img.gz`
 - `qemu-img convert -f raw -O qcow2 ssc600_disk.img ssc600_disk.qcow2`
 
@@ -28,11 +30,13 @@ This can be done with the following commands:
 ## Prerequisite
 
 The VM need at least 30GB of free space. Ansible deploy it in the /var/lib/libvirt/images directory.
+
 > Make sure to have free 30GB on /var/lib directory
 
 ## Example architecture
 
 The example inventories have been created to run the SSC600 VM using 2 interfaces (on the figure):
+
 - enp0s20f0u7: Ansible management, VM HMI, PTP
 - enp88s0: SVs
 
@@ -50,5 +54,6 @@ Once the VM has booted, the only access referenced in ABB Documentation is throu
 In order for this HMI to be accessible outside of the hypervisor, the br0 bridge must have an IP on this subnet (for example 192.168.2.11).
 
 This can be done either :
+
 - directly in the inventory by setting the IP of your hypervisor `ansible_host: 192.168.2.11`
 - by logging into the hypervisor and typing `sudo ip addr add 192.168.2.11/24 dev br0`


### PR DESCRIPTION
On strict markdown parsers, the README file was not correctly rendered. This commit fixes the syntax to have a better rendering.