### PR TITLE
snmp agent: reload after 1h

### DIFF
--- a/roles/snmp/templates/snmpd.conf.j2
+++ b/roles/snmp/templates/snmpd.conf.j2
@@ -18,5 +18,5 @@ syscontact Root <root@localhost> (configure /etc/snmp/snmpd.local.conf)
 {% if extra_snmpd_directives is defined %}
 {{ extra_snmpd_directives -}}
 {% endif %}
-pass_persist    .2.25.1936023920.1635018752     /usr/local/bin/exposeseapathsnmp.pl
+pass_persist    .2.25.1936023920.1635018752     timeout 3600s /usr/local/bin/exposeseapathsnmp.pl
 agentAddress udp:{{ snmp_admin_ip_addr }}:161


### PR DESCRIPTION
The perl snmp agent seems unstable after a few fays of running time. It still runs but does not update the snmp tree anymore. We fix this by forcing snmpd to reload it after 1h, so that it stays fresh.