### PR TITLE
expose snmp data: have a different interval than the cron job

### DIFF
--- a/roles/snmp/files/exposeseapathsnmp.pl
+++ b/roles/snmp/files/exposeseapathsnmp.pl
@@ -4,7 +4,7 @@ use SNMP::Extension::PassPersist;
 
 my $extsnmp = SNMP::Extension::PassPersist->new(
     backend_collect => \&update_tree,
-    refresh         => 300
+    refresh         => 240
 );
 $extsnmp->run;
 


### PR DESCRIPTION
If the cron job that get the snmp data and the expose script have the same interval (currently 300s = 5min), we encounter the risk that the generation of the snmp data file and the reading of that file always happen at the same time...
This commit set the interval of the expose script to 4min, so that we are sure those scripts don't run at the same time.