### PR TITLE
snmp: include the get snmp data logic directly into the expose script

### DIFF
--- a/roles/snmp/files/exposeseapathsnmp.pl
+++ b/roles/snmp/files/exposeseapathsnmp.pl
@@ -4,12 +4,14 @@ use SNMP::Extension::PassPersist;
 
 my $extsnmp = SNMP::Extension::PassPersist->new(
     backend_collect => \&update_tree,
-    refresh         => 240
+    refresh         => 300
 );
 $extsnmp->run;
 
 sub update_tree {
     my ($self) = @_;
+    system('/usr/bin/sudo /usr/bin/systemd-cat -t seapathsnmp-expose /usr/local/sbin/snmp_getdata.py') == 0
+        or die "Failed to execute command: $!";
     my $file_path = "/tmp/snmpdata.txt";
     open(my $file, '<', $file_path) or die "Could not open file '$file_path' $!";
     while (my $line = <$file>) {

--- a/roles/snmp/files/seapathsnmp.cron
+++ b/roles/snmp/files/seapathsnmp.cron
@@ -1,2 +1,0 @@
-# generate data to be exposed by snmp
-*/5 * * * * root /usr/bin/systemd-cat -t "seapathsnmp-cron" /usr/local/sbin/snmp_getdata.py

--- a/roles/snmp/files/snmp_getdata.py
+++ b/roles/snmp/files/snmp_getdata.py
@@ -302,7 +302,7 @@ done
         command = f"""
 /usr/sbin/smartctl --scan | {grep} -E "^/dev/(sd|nvme)" | {awk} '{{ print $1 }}' | while read i; do
   {echo} $i
-  j=$({echo} $i | {sed} "s/\/dev\///")
+  j=$({echo} $i | {sed} "s|/dev/||")
   k=$(/usr/bin/udevadm info -q symlink --path=/sys/block/$j | {tr} " " "\n" | {sort} | {grep} 'disk/by-path' | {head} -n 1 | {awk} '{{ print "/dev/" $1 }}')
   {echo} $k
   /usr/sbin/smartctl --attributes -H $i | {sed} '0,/^=== START OF READ SMART DATA SECTION ===$/d'

--- a/roles/snmp/tasks/main.yml
+++ b/roles/snmp/tasks/main.yml
@@ -68,11 +68,10 @@
       src: snmp_getdata.py
       dest: "/usr/local/sbin/snmp_getdata.py"
       mode: '0755'
-  - name: Cron job to generate snmp data
-    copy:
-      src: seapathsnmp.cron
-      dest: "/etc/cron.d/seapathsnmp"
-      mode: '0644'
+  - name: Remove old cron job to generate data
+    file:
+      path: "/etc/cron.d/seapathsnmp"
+      state: absent
   - name: Wait for DHCP for SNMP
     lineinfile:
       dest: /lib/systemd/system/snmpd.service

--- a/roles/snmp/templates/snmpd.conf.j2
+++ b/roles/snmp/templates/snmpd.conf.j2
@@ -18,5 +18,5 @@ syscontact Root <root@localhost> (configure /etc/snmp/snmpd.local.conf)
 {% if extra_snmpd_directives is defined %}
 {{ extra_snmpd_directives -}}
 {% endif %}
-pass_persist    .2.25.1936023920.1635018752     timeout 3600s /usr/local/bin/exposeseapathsnmp.pl
+pass_persist .2.25.1936023920.1635018752 /usr/bin/timeout 3610s /usr/local/bin/exposeseapathsnmp.pl
 agentAddress udp:{{ snmp_admin_ip_addr }}:161

--- a/roles/snmp/templates/sudoers_snmp.j2
+++ b/roles/snmp/templates/sudoers_snmp.j2
@@ -1,4 +1,5 @@
 Defaults:{{ snmp_user_name }} !requiretty
+{{ snmp_user_name }}     ALL = (root) NOPASSWD:EXEC: /usr/bin/systemd-cat -t seapathsnmp-expose /usr/local/sbin/snmp_getdata.py
 {% if extra_usersnmp_sudoers is defined %}
 {{ extra_usersnmp_sudoers -}}
 {% endif %}


### PR DESCRIPTION
We have a "get snmp data" script and an "expose snmp data" script. Both needs a "refresh" interval.
If both logics use the same interval, there is the risk they interfere with each other. If we set a different interval, sometime the expose script will run just after the getting of the data (and the exposed data will be fresh) or just before, in which case the data will be fresh again after 4+5min (9min). 
For the data to be always fresh, it seems best to run the get_data script just before the expose refresh, so to include it in the script. 
This makes the cron job useless, however since the expose script is run by snmp, we have to give the permission to the snmp user via sudo.