### PR TITLE
playbooks/seapath_update_yocto: add playbooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ playbooks/*
 !playbooks/deploy_*.yaml
 !playbooks/seapath_setup_*.yaml
 !playbooks/purge_ceph.yaml
-!playbooks/seapath_update_debian.yaml
+!playbooks/seapath_update_*.yaml
 inventories/*
 !inventories/README.adoc
 !inventories/examples

--- a/ansible-lint.conf
+++ b/ansible-lint.conf
@@ -47,3 +47,6 @@ warn_list:
 #
 # load-failure is needed because we use roles in the playbook directory and in
 # the roles directory. This should be fixed by using roles globally.
+
+extra_vars:
+  machine_to_update: node1 # variable used in update playbooks

--- a/playbooks/seapath_update_yocto_cluster.yaml
+++ b/playbooks/seapath_update_yocto_cluster.yaml
@@ -1,0 +1,46 @@
+# Copyright (C) 2023 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# This playbook demonstrate how to update an hypervisor.
+
+---
+
+- name: Prepare machine for update
+  hosts: "{{ machine_to_update }}"
+  tasks:
+    - name: Set hypervisor in maintenance mode
+      command: crm node standby "{{ machine_to_update }}"
+    - name: Wait for all VMs to be migrated
+      shell:
+        cmd: crm status|grep "Migrating"|wc -l
+      register: check_migration
+      until: check_migration.stdout == '0'
+      retries: 10
+    - name: Copy SWU file on machine
+      copy:
+        src: "../swu_images/{{ swu_image }}"
+        dest: "/tmp/update.swu"
+    - name: Apply update
+      command: swupdate -i /tmp/update.swu
+    - name: Reboot host
+      reboot:
+        msg: "Reboot initiated by Ansible"
+        connect_timeout: 5
+        reboot_timeout: 600
+        pre_reboot_delay: 0
+        post_reboot_delay: 30
+        test_command: whoami
+    - name: Wait systemd has finished to boot
+      command: systemctl is-system-running --wait
+      register: system_status
+      failed_when: system_status.rc != 0 and system_status.rc != 1
+      tags:
+        - skip_ansible_lint
+    - name: unset maintenance mode for hypervisor
+      command: crm node online "{{ machine_to_update }}"
+      when: {{ machine_to_update }} in group['cluster_machines']
+    - name: Check if update has succeed
+      shell:
+        cmd: journalctl -u swupdate_check.service -b |grep "Update have failed"|wc -l
+      register: update_status
+      failed_when: update_status.stdout != '0'

--- a/playbooks/seapath_update_yocto_cluster.yaml
+++ b/playbooks/seapath_update_yocto_cluster.yaml
@@ -10,9 +10,11 @@
   tasks:
     - name: Set hypervisor in maintenance mode
       command: crm node standby "{{ machine_to_update }}"
+      changed_when: true
     - name: Wait for all VMs to be migrated
       shell:
         cmd: crm status|grep "Migrating"|wc -l
+      changed_when: false
       register: check_migration
       until: check_migration.stdout == '0'
       retries: 10
@@ -22,6 +24,7 @@
         dest: "/tmp/update.swu"
     - name: Apply update
       command: swupdate -i /tmp/update.swu
+      changed_when: true
     - name: Reboot host
       reboot:
         msg: "Reboot initiated by Ansible"
@@ -38,9 +41,10 @@
         - skip_ansible_lint
     - name: unset maintenance mode for hypervisor
       command: crm node online "{{ machine_to_update }}"
-      when: {{ machine_to_update }} in group['cluster_machines']
+      changed_when: true
     - name: Check if update has succeed
       shell:
         cmd: journalctl -u swupdate_check.service -b |grep "Update have failed"|wc -l
       register: update_status
       failed_when: update_status.stdout != '0'
+      changed_when: false

--- a/playbooks/seapath_update_yocto_standalone.yaml
+++ b/playbooks/seapath_update_yocto_standalone.yaml
@@ -15,6 +15,7 @@
         dest: "/tmp/update.swu"
     - name: Apply update
       command: swupdate -i /tmp/update.swu
+      changed_when: true
     - name: Reboot host
       reboot:
         msg: "Reboot initiated by Ansible"
@@ -27,6 +28,7 @@
       command: systemctl is-system-running --wait
       register: system_status
       failed_when: system_status.rc != 0 and system_status.rc != 1
+      changed_when: false
       tags:
         - skip_ansible_lint
     - name: Check if update has succeed
@@ -34,3 +36,4 @@
         cmd: journalctl -u swupdate_check.service -b |grep "Update have failed"|wc -l
       register: update_status
       failed_when: update_status.stdout != '0'
+      changed_when: false

--- a/playbooks/seapath_update_yocto_standalone.yaml
+++ b/playbooks/seapath_update_yocto_standalone.yaml
@@ -1,0 +1,36 @@
+# Copyright (C) 2023-2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# This playbook updates a standalone machine .
+# The variables machine_to_update and swu_image must be provided on the
+# command line
+
+---
+- name: Update machine
+  hosts: "{{ machine_to_update }}"
+  tasks:
+    - name: Copy SWU file on machine
+      copy:
+        src: "../swu_images/{{ swu_image }}"
+        dest: "/tmp/update.swu"
+    - name: Apply update
+      command: swupdate -i /tmp/update.swu
+    - name: Reboot host
+      reboot:
+        msg: "Reboot initiated by Ansible"
+        connect_timeout: 5
+        reboot_timeout: 600
+        pre_reboot_delay: 0
+        post_reboot_delay: 30
+        test_command: whoami
+    - name: Wait systemd has finished to boot
+      command: systemctl is-system-running --wait
+      register: system_status
+      failed_when: system_status.rc != 0 and system_status.rc != 1
+      tags:
+        - skip_ansible_lint
+    - name: Check if update has succeed
+      shell:
+        cmd: journalctl -u swupdate_check.service -b |grep "Update have failed"|wc -l
+      register: update_status
+      failed_when: update_status.stdout != '0'


### PR DESCRIPTION
Add playbooks to update Yocto machines in standalone or cluster. These playbook are backported from the yocto_legacy branch. They were forgotten while merging yocto and debian branches together.