### PR TITLE
Fixes on Cephadm

### DIFF
--- a/playbooks/replace_machine_remove_machine_cephadm.yaml
+++ b/playbooks/replace_machine_remove_machine_cephadm.yaml
@@ -16,19 +16,18 @@
     - name: Set fact with hostname of machine_to_remove
       set_fact:
         machine_to_remove_hostname: "{{ hostvars[machine_to_remove]['hostname'] }}"
-      run_once: true
     - name: Define first_node excluding machine_to_remove
       set_fact:
         first_node: "{{ (groups['cluster_machines'] | difference([machine_to_remove]))[0] }}"
 
-    - name: Remove machine from pacemaker-corosync cluster
+    - name: Remove machine from pacemaker-corosync cluster # noqa: run-once[task]
       command: "crm_node -R {{ machine_to_remove }} --force"
       delegate_to: "{{ first_node }}"
       run_once: true
       changed_when: true
       run_once: true
 
-    - name: Remove machine from ceph cluster
+    - name: Remove machine from ceph cluster # noqa: run-once[task]
       command: "ceph orch host rm {{ machine_to_remove_hostname }} --force --offline"
       delegate_to: "{{ first_node }}"
       run_once: true

--- a/playbooks/seapath_setup_prerequisdebian.yaml
+++ b/playbooks/seapath_setup_prerequisdebian.yaml
@@ -107,13 +107,9 @@
         name:
           - ceph
           - ceph-base
-          - ceph-common
           - ceph-mgr
           - ceph-mon
           - ceph-osd
-          - libcephfs2
-          - python3-ceph-argparse
-          - python3-cephfs
         state: absent
         purge: yes
         autoremove: yes

--- a/roles/cephadm/README.md
+++ b/roles/cephadm/README.md
@@ -8,7 +8,10 @@ no requirement.
 
 ## Role Variables
 
-no variable.
+| Variable                         | Required | Type    | Default | Comments                                                                                                                               |
+|----------------------------------|----------|---------|----------|----------------------------------------------------------------------------------|
+| cephadm_install                  | no       | String  | false    | Whether the role will download and install the cephadm binary (true or false)    |
+| cephadm_release                  | no       | String  | "19.2.2" | Version of the cephadm binary to install                                         |
 
 ## Example Playbook
 

--- a/roles/cephadm/defaults/main.yml
+++ b/roles/cephadm/defaults/main.yml
@@ -1,0 +1,6 @@
+# Copyright (C) 2025 RTE
+# SPDX-License-Identifier: Apache-2.0
+
+---
+cephadm_install: false
+cephadm_release: "19.2.2"

--- a/roles/cephadm/tasks/main.yml
+++ b/roles/cephadm/tasks/main.yml
@@ -12,18 +12,28 @@
         url: "https://download.ceph.com/rpm-{{ cephadm_release }}/el9/noarch/cephadm"
         dest: "/usr/local/bin/cephadm"
         mode: '0755'
-    - name: Add Ceph repository
-      command: /usr/local/bin/cephadm add-repo --release squid
-      changed_when: true
-    - name: Install ceph-common package
-      command: /usr/local/bin/cephadm install ceph-common ceph-volume
-      changed_when: true
+#    - name: Add Ceph repository
+#      command: /usr/local/bin/cephadm add-repo --release squid
+#      changed_when: true
+#    - name: Install ceph-common package
+#      command: /usr/local/bin/cephadm install ceph-common ceph-volume
+#      changed_when: true
 
-- name: Disable ceph-crash non-containerized service
-  ansible.builtin.systemd:
-    name: ceph-crash.service
-    enabled: false
-    state: stopped
+#- name: Disable ceph-crash non-containerized service
+#  ansible.builtin.systemd:
+#    name: ceph-crash.service
+#    enabled: false
+#    state: stopped
+
+- name: Create /usr/local/bin/ceph with 755 permissions
+  copy:
+    dest: /usr/local/bin/ceph
+    content: |
+      #!/bin/bash
+      exec /usr/local/bin/cephadm shell -- ceph "$@"
+    mode: '0755'
+    owner: root
+    group: root
 
 - name: Ensure group "cephadm" exists
   group:
@@ -61,7 +71,7 @@
 
 
 - name: Check if host is part of a Ceph cluster
-  command: "ceph -s"
+  command: "/usr/local/bin/ceph -s"
   register: ceph_status
   ignore_errors: true
   changed_when: false
@@ -171,7 +181,7 @@
   when: mon_nodes_to_add | length > 0
 
 - name: Add hosts to Ceph orchestrator with _admin label
-  command: "ceph orch host add {{ hostvars[item]['hostname'] }} --labels _admin"
+  command: "/usr/local/bin/ceph orch host add {{ hostvars[item]['hostname'] }} --labels _admin"
   loop: "{{ mon_nodes_to_add }}"
   changed_when: true
   failed_when: false
@@ -180,7 +190,7 @@
   when: mon_nodes_to_add | length > 0
 
 - name: Confirm monitors are in monmap
-  command: ceph mon dump
+  command: /usr/local/bin/ceph mon dump
   register: mon_dump
   retries: 30
   delay: 5
@@ -194,7 +204,7 @@
 # === Managers now ===
 - name: Get current number of MGR daemons
   shell:
-    cmd: set -o pipefail && ceph orch ls --service-name=mgr | grep -o "count:.*" | cut -d":" -f2
+    cmd: set -o pipefail && /usr/local/bin/ceph orch ls --service-name=mgr | grep -o "count:.*" | cut -d":" -f2
     executable: /bin/bash
   register: mgr_count_raw
   changed_when: false
@@ -207,8 +217,8 @@
   run_once: true
   delegate_to: "{{ first_node }}"
 
-- name: "RUN ceph orch apply mgr {{ groups['cluster_machines'] | length }}"
-  command: "ceph orch apply mgr {{ groups['cluster_machines'] | length }}"
+- name: "RUN /usr/local/bin/ceph orch apply mgr {{ groups['cluster_machines'] | length }}"
+  command: "/usr/local/bin/ceph orch apply mgr {{ groups['cluster_machines'] | length }}"
   run_once: true
   delegate_to: "{{ first_node }}"
   when: mgr_count | int != groups['cluster_machines'] | length
@@ -216,7 +226,7 @@
 
 # === OSDs now ===
 - name: Get list of current OSD daemons and their hosts
-  command: ceph orch ps --service-name=osd --format json
+  command: /usr/local/bin/ceph orch ps --service-name=osd --format json
   register: osd_ps
   delegate_to: "{{ first_node }}"
   run_once: true
@@ -239,7 +249,7 @@
   run_once: true
 
 - name: Zap the volume on nodes that need OSDs
-  command: "ceph-volume lvm zap vg_ceph/lv_ceph"
+  command: "/usr/local/bin/cephadm ceph-volume lvm zap vg_ceph/lv_ceph"
   delegate_to: "{{ item }}"
   run_once: true
   when: hostvars[item]['hostname'] in nodes_needing_osds
@@ -247,7 +257,7 @@
   changed_when: true
 
 - name: Add OSD daemon on nodes that need OSDs
-  command: "ceph orch daemon add osd {{ hostvars[item]['hostname'] }}:/dev/vg_ceph/lv_ceph"
+  command: "/usr/local/bin/ceph orch daemon add osd {{ hostvars[item]['hostname'] }}:/dev/vg_ceph/lv_ceph"
   delegate_to: "{{ first_node }}"
   run_once: true
   when: hostvars[item]['hostname'] in nodes_needing_osds
@@ -257,35 +267,35 @@
 
 - name: Check if RBD pool exists
   shell:
-    cmd: set -o pipefail && ceph osd lspools | grep -w rbd
+    cmd: set -o pipefail && /usr/local/bin/ceph osd lspools | grep -w rbd
     executable: /bin/bash
   register: rbd_pool_check
   changed_when: false
   failed_when: false
 
 - name: Create RBD pool if it doesn't exist
-  command: ceph osd pool create rbd
+  command: /usr/local/bin/ceph osd pool create rbd
   when: rbd_pool_check.rc != 0
   changed_when: true
   run_once: true
   delegate_to: "{{ first_node }}"
 
 - name: Enable RBD application on the pool
-  command: ceph osd pool application enable rbd rbd
+  command: /usr/local/bin/ceph osd pool application enable rbd rbd
   when: rbd_pool_check.rc != 0
   changed_when: true
   run_once: true
   delegate_to: "{{ first_node }}"
 
 - name: Check if CephX user client.libvirt exists
-  command: ceph auth get client.libvirt
+  command: /usr/local/bin/ceph auth get client.libvirt
   register: cephx_user_check
   changed_when: false
   failed_when: false
 
 - name: Create CephX user client.libvirt if it does not exist
   command:
-    ceph auth add client.libvirt
+    /usr/local/bin/ceph auth add client.libvirt
     mon 'profile rbd, allow command "osd blacklist"'
     osd 'allow class-read object_prefix rbd_children, profile rbd pool=rbd'
   when: cephx_user_check.rc != 0
@@ -293,14 +303,14 @@
 
 - name: Update CephX user client.libvirt permissions if it exists
   shell: >
-    ceph auth caps client.libvirt
+    /usr/local/bin/ceph auth caps client.libvirt
     mon 'profile rbd, allow command "osd blacklist"'
     osd 'allow class-read object_prefix rbd_children, profile rbd pool=rbd'
   when: cephx_user_check.rc == 0
   changed_when: true
 
-- name: Update logrotate configuration for Ceph
-  replace:
-    path: "{{ cephadm_logrorateceph_path }}"
-    regexp: '^/var/log/ceph/\*.log'
-    replace: '/var/log/ceph/!(cephadm).log'
+#- name: Update logrotate configuration for Ceph
+#  replace:
+#    path: "{{ cephadm_logrorateceph_path }}"
+#    regexp: '^/var/log/ceph/\*.log'
+#    replace: '/var/log/ceph/!(cephadm).log'

--- a/roles/cephadm/tasks/main.yml
+++ b/roles/cephadm/tasks/main.yml
@@ -4,23 +4,20 @@
 ---
 - include_vars: "{{ seapath_distro }}.yml"
 
-#- name: Define CEPH_RELEASE variable
-#  set_fact:
-#    CEPH_RELEASE: "19.2.1"
-#
-#- name: Download cephadm
-#  get_url:
-#    url: "https://download.ceph.com/rpm-{{ CEPH_RELEASE }}/el9/noarch/cephadm"
-#    dest: "/usr/local/bin/cephadm"
-#    mode: '0755'
-#
-#- name: Add Ceph repository
-#  command: /usr/local/bin/cephadm add-repo --release squid
-#  changed_when: true
-#
-#- name: Install ceph-common package
-#  command: /usr/local/bin/cephadm install ceph-common ceph-volume
-#  changed_when: true
+- name: Install cephadm binaries
+  when: cephadm_install is true
+  block:
+    - name: Download cephadm
+      get_url:
+        url: "https://download.ceph.com/rpm-{{ cephadm_release }}/el9/noarch/cephadm"
+        dest: "/usr/local/bin/cephadm"
+        mode: '0755'
+    - name: Add Ceph repository
+      command: /usr/local/bin/cephadm add-repo --release squid
+      changed_when: true
+    - name: Install ceph-common package
+      command: /usr/local/bin/cephadm install ceph-common ceph-volume
+      changed_when: true
 
 - name: Disable ceph-crash non-containerized service
   ansible.builtin.systemd:

--- a/roles/cephadm/tasks/main.yml
+++ b/roles/cephadm/tasks/main.yml
@@ -62,54 +62,125 @@
     src: cephadm_sudoers
     dest: /etc/sudoers.d/cephadm
 
-- name: Define first_node
+
+- name: Check if host is part of a Ceph cluster
+  command: "ceph -s"
+  register: ceph_status
+  ignore_errors: true
+  changed_when: false
+
+- name: Mark host as ceph or nonceph
   set_fact:
-    first_node: "{{ groups['cluster_machines'][0] }}"
+    is_ceph_node: "{{ ceph_status.rc == 0 }}"
+
+- name: Add host to ceph_nodes group
+  add_host:
+    name: "{{ item }}"
+    groups: ceph_nodes
+  run_once: true
+  loop: "{{ groups['cluster_machines'] }}"
+  when: hostvars[item].is_ceph_node
+
+- name: Add host to nonceph_nodes group
+  add_host:
+    name: "{{ item }}"
+    groups: nonceph_nodes
+  run_once: true
+  loop: "{{ groups['cluster_machines'] }}"
+  when: not hostvars[item].is_ceph_node
+
+- name: Set first_node and bootstrap condition
+  set_fact:
+    first_node: >-
+      {{ (groups['ceph_nodes'][0] if (groups['ceph_nodes'] is defined and groups['ceph_nodes'] | length > 0)
+         else groups['cluster_machines'][0]) | trim }}
+    do_bootstrap: "{{ (groups['ceph_nodes'] | default([])) | length == 0 }}"
   run_once: true
 
-- name: Upload file ceph.conf needed for boostrapping
+- name: Compute list of nodes to add as monitors
+  set_fact:
+    mon_nodes_to_add: "{{ (groups['nonceph_nodes'] | default([]) | difference([first_node])) if do_bootstrap else groups['nonceph_nodes'] | default([]) }}"
+  run_once: true
+
+- name: Debug situation
+  debug:
+    msg: |
+      first_node = {{ first_node }}
+      do_bootstrap = {{ do_bootstrap }}
+      mon_nodes_to_add = {{ mon_nodes_to_add | default([]) }}
+      ceph_nodes = {{ groups['ceph_nodes'] | default([]) }}
+      nonceph_nodes = {{ groups['nonceph_nodes'] | default([]) }}
+  run_once: true
+
+# === Bootstrap if currently no ceph nodes ===
+- name: Upload file ceph.conf needed for bootstrapping
   template:
-    src: ceph.conf.j2
-    dest: /tmp/ceph.conf
+      src: ceph.conf.j2
+      dest: /tmp/ceph.conf
   run_once: true
   delegate_to: "{{ first_node }}"
+  when: do_bootstrap | bool
 
 - name: Bootstrap Ceph cluster
-  command: "/usr/local/bin/cephadm bootstrap --skip-monitoring-stack --skip-dashboard --config /tmp/ceph.conf --ssh-user cephadm --mon-ip {{ hostvars[first_node]['cluster_ip_addr'] }}"
+  command: >
+      /usr/local/bin/cephadm bootstrap
+      --skip-monitoring-stack
+      --skip-dashboard
+      --config /tmp/ceph.conf
+      --ssh-user cephadm
+      --mon-ip {{ hostvars[first_node]['cluster_ip_addr'] }}
   changed_when: true
   failed_when: false
   run_once: true
   delegate_to: "{{ first_node }}"
   register: ceph_bootstrap_result
+  when: do_bootstrap | bool
 
-- name: Set ceph_already_installed fact if bootstrap failed
-  set_fact:
-    ceph_already_installed: true
-  when: ceph_bootstrap_result.rc != 0
-
-- name: Fetch the ceph keyfile
-  fetch:
-    src: "/etc/ceph/ceph.pub"
-    dest: "/tmp/ceph.pub"
-    flat: true
+# === adding monitor on other nodes ===
+- name: Check if /etc/ceph/ceph.pub exists on first_node
+  stat:
+    path: /etc/ceph/ceph.pub
+  register: ceph_pub_stat
   run_once: true
   delegate_to: "{{ first_node }}"
-- name: Copy the key to the other nodes
+  when: mon_nodes_to_add | length > 0
+
+- name: Fetch the ceph keyfile if it exists, otherwise fetch authorized_keys
+  fetch:
+    src: "{{ ceph_pub_stat.stat.exists | ternary('/etc/ceph/ceph.pub', '/home/cephadm/.ssh/authorized_keys') }}"
+    dest: "/tmp/ceph.pub"
+    flat: true
+  delegate_to: "{{ first_node }}"
+  run_once: true
+  when: mon_nodes_to_add | length > 0
+
+- name: Read the key from the local file
+  set_fact:
+    ceph_pubkey: "{{ lookup('file', '/tmp/ceph.pub') }}"
+  delegate_to: localhost
+  run_once: true
+  when: mon_nodes_to_add | length > 0
+
+- name: Add the ceph pubkey to each target node
   ansible.posix.authorized_key:
     user: cephadm
     state: present
-    key: "{{ lookup('file', '/tmp/ceph.pub') }}"
+    key: "{{ ceph_pubkey }}"
+  with_items: "{{ mon_nodes_to_add }}"
+  loop_control:
+    loop_var: target_node
+  delegate_to: "{{ target_node }}"
   run_once: true
-  delegate_to: "{{ item }}"
-  loop: "{{ groups['cluster_machines'] | difference([first_node]) }}"
+  when: mon_nodes_to_add | length > 0
 
-- name: "RUN ceph orch host add nodeX --labels _admin"
+- name: Add hosts to Ceph orchestrator with _admin label
   command: "ceph orch host add {{ hostvars[item]['hostname'] }} --labels _admin"
+  loop: "{{ mon_nodes_to_add }}"
   changed_when: true
   failed_when: false
   run_once: true
   delegate_to: "{{ first_node }}"
-  loop: "{{ groups['cluster_machines'] | difference([first_node]) }}"
+  when: mon_nodes_to_add | length > 0
 
 - name: Confirm monitors are in monmap
   command: ceph mon dump
@@ -120,8 +191,10 @@
   run_once: true
   delegate_to: "{{ first_node }}"
   until: "hostvars[item]['hostname'] in mon_dump.stdout"
-  loop: "{{ groups['cluster_machines'] | difference([first_node]) }}"
+  loop: "{{ mon_nodes_to_add }}"
+  when: mon_nodes_to_add | length > 0
 
+# === Managers now ===
 - name: Get current number of MGR daemons
   shell:
     cmd: set -o pipefail && ceph orch ls --service-name=mgr | grep -o "count:.*" | cut -d":" -f2
@@ -144,6 +217,7 @@
   when: mgr_count | int != groups['cluster_machines'] | length
   changed_when: true
 
+# === OSDs now ===
 - name: Get list of current OSD daemons and their hosts
   command: ceph orch ps --service-name=osd --format json
   register: osd_ps

--- a/roles/debian_hypervisor/tasks/main.yml
+++ b/roles/debian_hypervisor/tasks/main.yml
@@ -2,17 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-- name: Enable docker.service
-  ansible.builtin.systemd:
-    name: docker.service
-    enabled: yes
-    state: started
-- name: Enable docker.socket
-  ansible.builtin.systemd:
-    name: docker.socket
-    enabled: yes
-    state: started
-
 - name: Add vhost_vsock to /etc/modules
   lineinfile:
     path: /etc/modules

--- a/roles/debian_tests/cukinia-tests/cukinia/common_security_tests.d/apt.conf.j2
+++ b/roles/debian_tests/cukinia-tests/cukinia/common_security_tests.d/apt.conf.j2
@@ -41,6 +41,7 @@ audispd-plugins|\
 auditd|\
 bridge-utils|\
 ca-certificates|\
+catatonit|\
 ceph-base|\
 ceph-common|\
 ceph-mgr-diskprediction-local|\
@@ -94,6 +95,7 @@ openvswitch-switch|\
 ovmf|\
 pacemaker|\
 patch|\
+podman|\
 python3-apt|\
 python3-ceph-argparse|\
 python3-cephfs|\

--- a/roles/debian_tests/cukinia-tests/cukinia/common_security_tests.d/apt.conf.j2
+++ b/roles/debian_tests/cukinia-tests/cukinia/common_security_tests.d/apt.conf.j2
@@ -51,6 +51,7 @@ ceph-osd|\
 ceph|\
 chrony|\
 conntrackd|\
+containernetworking-plugins|\
 corosync|\
 cpuset|\
 crmsh|\

--- a/roles/debian_tests/cukinia-tests/cukinia/common_security_tests.d/files.conf
+++ b/roles/debian_tests/cukinia-tests/cukinia/common_security_tests.d/files.conf
@@ -24,7 +24,7 @@ id "SEAPATH-00090" as "Check /etc/ssh/ssh_host_rsa_key permissions" cukinia_test
     "$(stat -c "%a %U %G" /etc/ssh/ssh_host_rsa_key)" == "600 root root"
 
 id "SEAPATH-00192" as "All files have a known owner and group" \
-    cukinia_test "$(find / -type f,d,l \( -nouser -o -nogroup \) -not -path '/sys/*' -not -path '/proc/*' -not -path '/var/lib/docker/*' 2>/dev/null || true)" = ""
+    cukinia_test "$(find / -type f,d,l \( -nouser -o -nogroup \) -not -path '/sys/*' -not -path '/proc/*' -not -path '/var/lib/docker/*' -not -path '/var/lib/containers/*' 2>/dev/null || true)" = ""
 
 id "SEAPATH-00193" as "All directories writable by all users have the sticky bit" \
     cukinia_test "$(find / -type d \( -perm -0002 -a \! -perm -1000 \) 2>/dev/null || true)" = ""
@@ -47,6 +47,8 @@ SETUID_ALLOWLIST="(\
 /usr/bin/ksu|\
 /usr/bin/mount|\
 /usr/bin/newgrp|\
+/usr/bin/newuidmap|\
+/usr/bin/newgidmap|\
 /usr/bin/ntfs-3g|\
 /usr/bin/passwd|\
 /usr/bin/pkexec|\
@@ -63,4 +65,4 @@ SETUID_ALLOWLIST="(\
 /usr/sbin/unix_chkpwd\
 )"
 id "SEAPATH-00196" as "No unexpected file has setuid/setgid enabled" \
-    cukinia_test "$(find / -type f -perm /6000 -not -path '/var/lib/docker/*' 2>/dev/null | grep -Ev ${SETUID_ALLOWLIST})" = ""
+    cukinia_test "$(find / -type f -perm /6000 -not -path '/var/lib/docker/*' -not -path '/var/lib/containers/*' 2>/dev/null | grep -Ev ${SETUID_ALLOWLIST})" = ""

--- a/roles/debian_tests/cukinia-tests/cukinia/common_security_tests.d/systemd.conf
+++ b/roles/debian_tests/cukinia-tests/cukinia/common_security_tests.d/systemd.conf
@@ -40,6 +40,7 @@ ovs-record-hostname|\
 ovs-vswitchd|\
 ovsdb-server|\
 pacemaker|\
+podman-restart|\
 polkit|\
 ptp_vsock|\
 ptpstatus|\

--- a/roles/debian_tests/cukinia-tests/cukinia/hypervisor_security_tests.d/groups.conf.j2
+++ b/roles/debian_tests/cukinia-tests/cukinia/hypervisor_security_tests.d/groups.conf.j2
@@ -7,7 +7,7 @@ groups=" \
     ceph \
     haclient \
 {% endif %}
-{% if force_cephadm is defined and force_cephadm is true %}
+{% if inventory_hostname in groups.get('cluster_machines', []) and force_cephadm is defined and force_cephadm is true %}
     containerized-ceph \
     cephadm \
 {% endif %}

--- a/roles/debian_tests/cukinia-tests/cukinia/hypervisor_security_tests.d/passwd.conf.j2
+++ b/roles/debian_tests/cukinia-tests/cukinia/hypervisor_security_tests.d/passwd.conf.j2
@@ -18,7 +18,7 @@ passwd=" \
     ceph \
     hacluster \
 {% endif %}
-{% if force_cephadm is defined and force_cephadm is true %}
+{% if inventory_hostname in groups.get('cluster_machines', []) and force_cephadm is defined and force_cephadm is true %}
     containerized-ceph \
     cephadm \
 {% endif %}


### PR DESCRIPTION
cephadm: fix on replacing first node
The current code did not work when the node to be replaced was the first one.
This commit makes it possible to replace any node.

----
cephadm: introducing cephadm_install
This is a variable to make the playbook install the cephadm binary (not compatible with offline install mode, obviously).

----
cephadm: stop depending on local ceph packages
Local ceph packages were still necessary for tools like rbd or ceph-volume.
This commit makes the maximum to use the tools provided inside the containers (ceph-volume, ceph, etc.). We will still need ceph-volume (for rbd, used by vm-manager) though.

----
cephadm: adapt debian tests for podman

----
cephadm: fix cephadm test on standalone

----
remove docker forced start
This commit removes old code from when the ptp_vsock service was an apache docker container.
And with cephadm, we are moving to podman anyway.

----
podman: fix debian tests