### PR TITLE
cephadm: more fixes

### DIFF
--- a/roles/cephadm/tasks/main.yml
+++ b/roles/cephadm/tasks/main.yml
@@ -30,7 +30,11 @@
     dest: /usr/local/bin/ceph
     content: |
       #!/bin/bash
-      exec /usr/local/bin/cephadm shell -- ceph "$@"
+      if [ $# -eq 0 ]; then
+        exec /usr/local/bin/cephadm shell
+      else
+        exec /usr/local/bin/cephadm shell -- ceph "$@"
+      fi
     mode: '0755'
     owner: root
     group: root

--- a/roles/debian_tests/cukinia-tests/cukinia/cluster_tests.d/ceph.conf
+++ b/roles/debian_tests/cukinia-tests/cukinia/cluster_tests.d/ceph.conf
@@ -3,7 +3,7 @@
 
 cukinia_log "$(_colorize yellow "--- check Ceph status ---")"
 
-_ceph_status=$(timeout 10s ceph status 2>/dev/null)
+_ceph_status=$(timeout --foreground 10s ceph status 2>/dev/null)
 # If cluster is not set up properly, ceph commands will never return anything.
 # A timeout is necessary to catch a cluster failure
 


### PR DESCRIPTION
**cephadm: adapt test for containerized ceph**
The timeout executed in a subshell will make the cephadm command choke because of how signal management is interfering.
This is solved with "--foreground" in the timeout command.
man timeout:
```
--foreground
when not running timeout directly from a shell prompt,
allow COMMAND to read from the TTY and get TTY signals; in this mode, children of COMMAND will not be timed out

```
----
**cephadm: adapt ceph wrapper for case with no argument**
When no argument is passed to the "ceph" command we want to launch a cephadm shell.