### PR TITLE
cephadm: add cephadm user to privileged group

### DIFF
--- a/roles/debian_hardening_physical_machine/tasks/main.yml
+++ b/roles/debian_hardening_physical_machine/tasks/main.yml
@@ -34,12 +34,23 @@
 
 - name: Adding ceph user to group privileged
   user:
-    name: "ceph"
+    name: ceph
     groups: privileged
     append: yes
   when:
     - not revert
     - cluster_ip_addr is defined
+
+- name: Adding cephadm user to group privileged
+  user:
+    name: cephadm
+    groups: privileged
+    append: yes
+  when:
+    - not revert
+    - cluster_ip_addr is defined
+    - force_cephadm is defined
+    - force_cephadm is true
 
 - name: Adding Debian-snmp user to group privileged
   user:


### PR DESCRIPTION
Necessary for the cephadm user to be able to run sudo, with the hardening setup