### PR TITLE
changes for cephadm and cluster network

### DIFF
--- a/inventories/examples/seapath-cluster.yaml
+++ b/inventories/examples/seapath-cluster.yaml
@@ -110,6 +110,7 @@ cluster_machines:
     force_cephadm: false # by default seapath uses ceph-ansible, but we can use cephadm instead
     ceph_origin: distro
     cluster_network: "192.168.55.0/24" # TODO : Replace by the IP range of your cluster
+    #no_cluster_network: true # if this variable is defined, whatever its value, seapath won't configure the cluster network (neither with RSTP nor HSR)
     public_network: "{{ cluster_network }}"
     monitor_address: "{{ cluster_ip_addr }}"
     configure_firewall: false

--- a/playbooks/cluster_setup_cephadm.yaml
+++ b/playbooks/cluster_setup_cephadm.yaml
@@ -4,6 +4,33 @@
 # This playbook configures and sets up Ceph with cephadm.
 
 ---
+
+- name: Prepare Ceph installation
+  hosts:
+      osds
+  become: true
+  gather_facts: yes
+  roles:
+    - detect_seapath_distro
+    - ceph_prepare_installation
+
+- name: Ceph Expansion VG
+  hosts:
+      osds
+  become: true
+  gather_facts: yes
+  roles:
+    - ceph_expansion_vg
+
+- name: Ceph Expansion LV
+  hosts:
+      osds
+  become: true
+  gather_facts: yes
+  serial: 1
+  roles:
+    - ceph_expansion_lv
+
 - name: Cephadm
   hosts:
       cluster_machines

--- a/playbooks/seapath_setup_main.yaml
+++ b/playbooks/seapath_setup_main.yaml
@@ -44,11 +44,11 @@
 
 - name: Import cluster_setup_ceph playbook
   import_playbook: cluster_setup_ceph.yaml
-  when: seapath_distro != "OracleLinux" and (force_cephadm is not defined or force_cephadm is false)
+  when: not is_using_cephadm | bool
 
 - name: Import cluster_setup_cephdm playbook
   import_playbook: cluster_setup_cephadm.yaml
-  when: seapath_distro == "OracleLinux" or (force_cephadm is defined and force_cephadm is true)
+  when: is_using_cephadm | bool
 
 - name: Import cluster_setup_libvirt playbook
   import_playbook: cluster_setup_libvirt.yaml

--- a/playbooks/seapath_setup_network.yaml
+++ b/playbooks/seapath_setup_network.yaml
@@ -30,7 +30,8 @@
   hosts: cluster_machines
   become: true
   roles:
-    - network_clusternetwork
+    - role: network_clusternetwork
+      when: no_cluster_network is not defined
 
 - name: Configure OVS, hosts and hostname, then DNS with resolved, then systemd-networkd-wait-online.service
   hosts:

--- a/playbooks/seapath_setup_prerequisdebian.yaml
+++ b/playbooks/seapath_setup_prerequisdebian.yaml
@@ -113,7 +113,7 @@
         state: absent
         purge: yes
         autoremove: yes
-      when: force_cephadm is defined and force_cephadm is true
+      when: force_cephadm | default(false)
     - name: Uninstall apt packages not required after installation (all debian version)
       apt:
         name:

--- a/roles/ceph_expansion_lv/tasks/main.yml
+++ b/roles/ceph_expansion_lv/tasks/main.yml
@@ -2,9 +2,22 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
+- name: Refresh LVM facts
+  ansible.builtin.setup:
+    filter: "ansible_lvm"
+- debug:
+    msg: "{{ lvm_volumes[0].data_size }}"
+- debug:
+    msg: "{{ ansible_lvm }}"
+- debug:
+    msg: "{{ ansible_lvm['lvs'][lvm_volumes[0].data] }}"
+- debug:
+    msg: "{{ ansible_lvm['lvs'][lvm_volumes[0].data]['size_g'] }}"
+- debug:
+    msg: "{{ (ansible_lvm['lvs'][lvm_volumes[0].data]['size_g'] | float * 1024) | round(2) }}"
 - name: Check if lv_ceph has to be expanded
   set_fact:
-    expand_lv: "{{ (lvm_volumes[0].data_size | regex_replace('[A-Za-z]*', '') | int) > ansible_lvm['lvs'][lvm_volumes[0].data]['size_g'] | int }}"
+    expand_lv: "{{ (lvm_volumes[0].data_size | int) > ((ansible_lvm['lvs'][lvm_volumes[0].data]['size_g'] | float * 1024) | round(2)) }}"
   when: ansible_lvm is defined and lvm_volumes is defined
 - name: Increase ceph LV and OSD
   when: expand_lv is defined and expand_lv

--- a/roles/ceph_expansion_vg/tasks/main.yml
+++ b/roles/ceph_expansion_vg/tasks/main.yml
@@ -7,7 +7,6 @@
   block:
     - name: Set fact unit, new_pv_size, list_pvs
       set_fact:
-        unit: "{{ lvm_volumes[0].device_size | regex_replace('[0-9.]*', '') }}"
         new_pv_size: "{{ (lvm_volumes[0].device_size | regex_replace('[A-Za-z]*', '') | int) }}"
         list_pvs: "{{ ansible_lvm['pvs'] | dict2items | community.general.json_query(query) }}"
       vars:
@@ -16,7 +15,6 @@
       community.general.parted:
         # Get the name of the device by escaping the partition number
         device: "{{ item | regex_replace('(p?\\d+)$', '') }}"
-        unit: "{{ unit }}"
       loop: "{{ list_pvs }}"
       register: parted_info
     - name: Set fact part_info

--- a/roles/ceph_prepare_installation/tasks/main.yml
+++ b/roles/ceph_prepare_installation/tasks/main.yml
@@ -30,7 +30,7 @@
       when:
         - lvm_volumes is defined
         - ansible_lvm['lvs'][lvm_volumes[0].data] is defined
-        - force_cephadm is not defined or force_cephadm is false
+        - not (is_using_cephadm | default(false))
       block:
         - name: Cleanup Ceph LV with ceph-volume
           command: "ceph-volume lvm zap /dev/{{ lvm_volumes[0].data_vg }}/{{ lvm_volumes[0].data }}"

--- a/roles/ceph_prepare_installation/tasks/main.yml
+++ b/roles/ceph_prepare_installation/tasks/main.yml
@@ -30,6 +30,7 @@
       when:
         - lvm_volumes is defined
         - ansible_lvm['lvs'][lvm_volumes[0].data] is defined
+        - force_cephadm is not defined or force_cephadm is false
       block:
         - name: Cleanup Ceph LV with ceph-volume
           command: "ceph-volume lvm zap /dev/{{ lvm_volumes[0].data_vg }}/{{ lvm_volumes[0].data }}"
@@ -54,14 +55,63 @@
           when:
             - lvm_volumes is defined
           block:
-            - name: Create partition on OSD disks with parted
+            - name: Get partition info
+              community.general.parted:
+                device: "{{ ceph_osd_realdisk.stdout }}"
+                unit: MiB
+                state: info
+              register: parted_info
+        
+            - name: Check if current partition exists
+              set_fact:
+                current_exists: >-
+                  {{ parted_info.partitions
+                     | selectattr('num', 'equalto', lvm_volumes[0].device_number)
+                     | list | length > 0 }}
+        
+            - name: Check if previous partition exists
+              set_fact:
+                previous_exists: >-
+                  {{ parted_info.partitions
+                     | selectattr('num', 'equalto', lvm_volumes[0].device_number - 1)
+                     | list | length > 0 }}
+        
+            - name: Get end of previous partition
+              set_fact:
+                prev_end: >-
+                  {{ (parted_info.partitions
+                       | selectattr('num', 'equalto', lvm_volumes[0].device_number - 1)
+                       | map(attribute='end')
+                       | first) | float }}
+              when: previous_exists
+        
+            - debug:
+                var: prev_end
+            - debug:
+                var: lvm_volumes[0].device_size
+            - debug:
+                msg: "{{ ((prev_end | float) + (lvm_volumes[0].device_size | float)) | round(2) }}"
+
+            - name: Calculate partition boundaries
+              set_fact:
+                part_start: "{{ (prev_end | float) | round(2) }}MiB"
+                part_end: "{{ ((prev_end | float) + (lvm_volumes[0].device_size | float) | float) | round(2) }}MiB"
+              when: previous_exists
+        
+            - name: Create partition using parted module
               community.general.parted:
                 device: "{{ ceph_osd_realdisk.stdout }}"
                 number: "{{ lvm_volumes[0].device_number }}"
-                label: gpt # Must be the same type as the partition table of the disk used
+                label: gpt
+                name: ""
+                part_start: "{{ part_start }}"
+                part_end: "{{ part_end }}"
+                flags:
+                  - lvm
                 state: present
-                unit: MB
-                part_start: "-{{ lvm_volumes[0].device_size }}" # Negative numbers specifie the distance from the end of the disk
+              when:
+                - not current_exists
+                - previous_exists
               register: ceph_osd_result
             - name: Get disk/by-path of OSD disk
               command: "/usr/bin/find -L /dev/disk/by-path -samefile {{ ceph_osd_result.disk.dev }} -print -quit"

--- a/roles/debian_hardening_physical_machine/tasks/main.yml
+++ b/roles/debian_hardening_physical_machine/tasks/main.yml
@@ -49,8 +49,7 @@
   when:
     - not revert
     - cluster_ip_addr is defined
-    - force_cephadm is defined
-    - force_cephadm is true
+    - force_cephadm | default(false)
 
 - name: Adding Debian-snmp user to group privileged
   user:

--- a/roles/detect_seapath_distro/tasks/main.yaml
+++ b/roles/detect_seapath_distro/tasks/main.yaml
@@ -38,4 +38,9 @@
   fail:
     msg: "The Seapath distribution could not be determined"
   when: seapath_distro is not defined
+
+- name: Set is_using_cephadm depending on distro and option
+  set_fact:
+    is_using_cephadm: "{{ seapath_distro == 'OracleLinux' or (force_cephadm | default(false)) }}"
+
 ...

--- a/vars/network_defaults.yml
+++ b/vars/network_defaults.yml
@@ -66,5 +66,5 @@ systemd_networkd_netdev_nocluster: "{{ wired_systemd_networkd_netdev | combine(s
 systemd_networkd_network_nocluster: "{{ wired_systemd_networkd_network | combine(systemd_networkd_network_custom) }}"
 
 systemd_networkd_network: "{{ systemd_networkd_network_nocluster | combine(team0_systemd_networkd_network) if
- cluster_ip_addr is defined else systemd_networkd_network_nocluster }}"
+ cluster_ip_addr is defined and no_cluster_network is not defined else systemd_networkd_network_nocluster }}"
 systemd_networkd_netdev: "{{ systemd_networkd_netdev_nocluster }}"


### PR DESCRIPTION
improve ceph lv creation
This is less buggy.

----
introducing is_using_cephadm variable
Instead of checking for the seapath_distro and cephadm_force variables, we set is_using_cephadm in the detect_seapath_distro role and use this variable instead, to know whether we deploy with ceph-ansible or cephadm.

----
network: allows no having a cluster network
It's useful for some test setups to not have to create a fully resilient cluster_network.
This commit allows the cluster network to use only the team0 interface instead of a team0 bridge with 2 interfaces.
For that purpose we introduce the "no_cluster_network" variable.