### PR TITLE
cephadm - new fixes

### DIFF
--- a/playbooks/seapath_setup_prerequisdebian.yaml
+++ b/playbooks/seapath_setup_prerequisdebian.yaml
@@ -110,6 +110,7 @@
           - ceph-mgr
           - ceph-mon
           - ceph-osd
+          - ceph-volume
         state: absent
         purge: yes
         autoremove: yes

--- a/roles/ceph_prepare_installation/tasks/main.yml
+++ b/roles/ceph_prepare_installation/tasks/main.yml
@@ -97,32 +97,34 @@
                 part_start: "{{ (prev_end | float) | round(2) }}MiB"
                 part_end: "{{ ((prev_end | float) + (lvm_volumes[0].device_size | float) | float) | round(2) }}MiB"
               when: previous_exists
-        
-            - name: Create partition using parted module
-              community.general.parted:
-                device: "{{ ceph_osd_realdisk.stdout }}"
-                number: "{{ lvm_volumes[0].device_number }}"
-                label: gpt
-                name: ""
-                part_start: "{{ part_start }}"
-                part_end: "{{ part_end }}"
-                flags:
-                  - lvm
-                state: present
+
+            - name: Create partition, VG and LV
               when:
                 - not current_exists
                 - previous_exists
-              register: ceph_osd_result
-            - name: Get disk/by-path of OSD disk
-              command: "/usr/bin/find -L /dev/disk/by-path -samefile {{ ceph_osd_result.disk.dev }} -print -quit"
-              register: ceph_osd_finddisk
-              changed_when: false
-            - name: Create volume group on the partition
-              community.general.lvg:
-                vg: "{{ lvm_volumes[0].data_vg }}"
-                pvs: "{{ ceph_osd_finddisk.stdout }}-part{{ lvm_volumes[0].device_number }}"
-            - name: Create logical volume in the VG
-              community.general.lvol:
-                vg: "{{ lvm_volumes[0].data_vg }}"
-                lv: "{{ lvm_volumes[0].data }}"
-                size: "{{ lvm_volumes[0].data_size }}"
+              block:
+                - name: Create partition using parted module
+                  community.general.parted:
+                    device: "{{ ceph_osd_realdisk.stdout }}"
+                    number: "{{ lvm_volumes[0].device_number }}"
+                    label: gpt
+                    name: ""
+                    part_start: "{{ part_start }}"
+                    part_end: "{{ part_end }}"
+                    flags:
+                      - lvm
+                    state: present
+                  register: ceph_osd_result
+                - name: Get disk/by-path of OSD disk
+                  command: "/usr/bin/find -L /dev/disk/by-path -samefile {{ ceph_osd_result.disk.dev }} -print -quit"
+                  register: ceph_osd_finddisk
+                  changed_when: false
+                - name: Create volume group on the partition
+                  community.general.lvg:
+                    vg: "{{ lvm_volumes[0].data_vg }}"
+                    pvs: "{{ ceph_osd_finddisk.stdout }}-part{{ lvm_volumes[0].device_number }}"
+                - name: Create logical volume in the VG
+                  community.general.lvol:
+                    vg: "{{ lvm_volumes[0].data_vg }}"
+                    lv: "{{ lvm_volumes[0].data }}"
+                    size: "{{ lvm_volumes[0].data_size }}"

--- a/roles/ceph_prepare_installation/tasks/main.yml
+++ b/roles/ceph_prepare_installation/tasks/main.yml
@@ -2,25 +2,28 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-- name: Create Ceph log directory
-  file:
-      path: /var/log/ceph
-      owner: ceph
-      group: ceph
-      mode: "0770"
-      state: directory
-- name: Create Ceph crash directory
-  file:
-      path: /var/lib/ceph/crash/posted
-      owner: ceph
-      group: ceph
-      mode: "0770"
-      state: directory
-  register: new_ceph_installation
+- name: Check for existing installation (ceph-ansible only)
+  when: not (is_using_cephadm | default(false))
+  block:
+  - name: Create Ceph log directory
+    file:
+        path: /var/log/ceph
+        owner: ceph
+        group: ceph
+        mode: "0770"
+        state: directory
+  - name: Create Ceph crash directory
+    file:
+        path: /var/lib/ceph/crash/posted
+        owner: ceph
+        group: ceph
+        mode: "0770"
+        state: directory
+    register: new_ceph_installation
 
 - name: Prepare OSD disk # noqa: no-handler
   when:
-    - new_ceph_installation.changed
+    - new_ceph_installation.changed | default(false) or is_using_cephadm | default(false)
   block:
     - name: Refresh LVM VG
       command:
@@ -45,11 +48,15 @@
           changed_when: false
         - name: Cleanup Ceph OSD disks with ceph-volume
           command: "ceph-volume lvm zap {{ ceph_osd_realdisk.stdout }} --destroy" # Zapping the disk and destroying any vgs or lvs present
-          when: lvm_volumes is not defined or lvm_volumes[0].device_number == 1 # The disk must not be zapped in the case of a single disk for linux and ceph
+          when:
+            - lvm_volumes is not defined or lvm_volumes[0].device_number == 1 # The disk must not be zapped in the case of a single disk for linux and ceph
+            - not (is_using_cephadm | default(false))
           changed_when: true
         - name: Cleanup Ceph lvm's partition with ceph-volume
           command: "ceph-volume lvm zap /dev/{{ lvm_volumes[0].data_vg }}" # In the case of a single-disk installation, only the Ceph partition is zapped
-          when: lvm_volumes is defined and ansible_lvm['lvs'][lvm_volumes[0].data] is defined
+          when:
+            - lvm_volumes is defined and ansible_lvm['lvs'][lvm_volumes[0].data] is defined
+            - not (is_using_cephadm | default(false))
           changed_when: true
         - name: Create volumes for OSD disk
           when:

--- a/roles/ceph_prepare_installation/tasks/main.yml
+++ b/roles/ceph_prepare_installation/tasks/main.yml
@@ -72,18 +72,20 @@
             - name: Check if previous partition exists
               set_fact:
                 previous_exists: >-
-                  {{ parted_info.partitions
-                     | selectattr('num', 'equalto', lvm_volumes[0].device_number - 1)
-                     | list | length > 0 }}
-        
-            - name: Get end of previous partition
+                  {{ lvm_volumes[0].device_number > 1 and (
+                       parted_info.partitions
+                       | selectattr('num', 'equalto', lvm_volumes[0].device_number - 1)
+                       | list | length > 0 ) }}
+
+            - name: Set prev_end based on previous partition or zero
               set_fact:
                 prev_end: >-
-                  {{ (parted_info.partitions
-                       | selectattr('num', 'equalto', lvm_volumes[0].device_number - 1)
-                       | map(attribute='end')
-                       | first) | float }}
-              when: previous_exists
+                  {{ (
+                        parted_info.partitions
+                        | selectattr('num', 'equalto', lvm_volumes[0].device_number - 1)
+                        | map(attribute='end')
+                        | first
+                      ) | float if previous_exists else 0.0 }}
         
             - debug:
                 var: prev_end
@@ -94,14 +96,14 @@
 
             - name: Calculate partition boundaries
               set_fact:
-                part_start: "{{ (prev_end | float) | round(2) }}MiB"
+                part_start: "{{ '0%' if (prev_end | float) == 0 else (prev_end | float | round(2)) ~ 'MiB' }}"
                 part_end: "{{ ((prev_end | float) + (lvm_volumes[0].device_size | float) | float) | round(2) }}MiB"
-              when: previous_exists
+              when: previous_exists or lvm_volumes[0].device_number == 1
 
             - name: Create partition, VG and LV
               when:
                 - not current_exists
-                - previous_exists
+                - previous_exists or lvm_volumes[0].device_number == 1
               block:
                 - name: Create partition using parted module
                   community.general.parted:

--- a/roles/cephadm/defaults/main.yml
+++ b/roles/cephadm/defaults/main.yml
@@ -4,3 +4,5 @@
 ---
 cephadm_install: false
 cephadm_release: "19.2.2"
+cephadm_installcommon: false
+cephadm_installrepo: false

--- a/roles/cephadm/tasks/main.yml
+++ b/roles/cephadm/tasks/main.yml
@@ -38,7 +38,7 @@
     src: cephadm_sudoers
     dest: /etc/sudoers.d/cephadm
 
-- name: Install cephadm binaries
+- name: Install cephadm binary
   when: cephadm_install is true
   block:
     - name: Download cephadm
@@ -49,12 +49,16 @@
     - name: Install cephadm
       command: /tmp/cephadm install
       changed_when: true
-#    - name: Add Ceph repository
-#      command: /usr/local/bin/cephadm add-repo --release squid
-#      changed_when: true
+
+- name: Install cephadm repository
+  command: cephadm add-repo --release squid
+  changed_when: true
+  when: cephadm_installrepo is true
+
 - name: Install ceph-common package
   command: cephadm install ceph-common
   changed_when: true
+  when: cephadm_installcommon is true
 
 #- name: Disable ceph-crash non-containerized service
 #  ansible.builtin.systemd:
@@ -77,7 +81,7 @@
 #    group: root
 
 - name: Check if host is part of a Ceph cluster
-  command: "/usr/local/bin/ceph -s"
+  command: "ceph -s"
   register: ceph_status
   ignore_errors: true
   changed_when: false
@@ -294,7 +298,7 @@
   failed_when: false
 
 - name: Create CephX user client.libvirt if it does not exist
-  command:
+  command: >
     ceph auth add client.libvirt
     mon 'profile rbd, allow command "osd blacklist"'
     osd 'allow class-read object_prefix rbd_children, profile rbd pool=rbd'
@@ -302,7 +306,7 @@
   changed_when: true
 
 - name: Update CephX user client.libvirt permissions if it exists
-  shell: >
+  command: >
     ceph auth caps client.libvirt
     mon 'profile rbd, allow command "osd blacklist"'
     osd 'allow class-read object_prefix rbd_children, profile rbd pool=rbd'

--- a/roles/cephadm/tasks/main.yml
+++ b/roles/cephadm/tasks/main.yml
@@ -15,9 +15,9 @@
 #    - name: Add Ceph repository
 #      command: /usr/local/bin/cephadm add-repo --release squid
 #      changed_when: true
-#    - name: Install ceph-common package
-#      command: /usr/local/bin/cephadm install ceph-common ceph-volume
-#      changed_when: true
+- name: Install ceph-common package
+  command: /usr/local/bin/cephadm install ceph-common
+  changed_when: true
 
 #- name: Disable ceph-crash non-containerized service
 #  ansible.builtin.systemd:

--- a/roles/cephadm/tasks/main.yml
+++ b/roles/cephadm/tasks/main.yml
@@ -10,13 +10,16 @@
     - name: Download cephadm
       get_url:
         url: "https://download.ceph.com/rpm-{{ cephadm_release }}/el9/noarch/cephadm"
-        dest: "/usr/local/bin/cephadm"
+        dest: "/tmp/cephadm"
         mode: '0755'
+    - name: Install cephadm
+      command: /tmp/cephadm install
+      changed_when: true
 #    - name: Add Ceph repository
 #      command: /usr/local/bin/cephadm add-repo --release squid
 #      changed_when: true
 - name: Install ceph-common package
-  command: /usr/local/bin/cephadm install ceph-common
+  command: cephadm install ceph-common
   changed_when: true
 
 #- name: Disable ceph-crash non-containerized service
@@ -25,19 +28,19 @@
 #    enabled: false
 #    state: stopped
 
-- name: Create /usr/local/bin/ceph with 755 permissions
-  copy:
-    dest: /usr/local/bin/ceph
-    content: |
-      #!/bin/bash
-      if [ $# -eq 0 ]; then
-        exec /usr/local/bin/cephadm shell
-      else
-        exec /usr/local/bin/cephadm shell -- ceph "$@"
-      fi
-    mode: '0755'
-    owner: root
-    group: root
+#- name: Create /usr/local/bin/ceph with 755 permissions
+#  copy:
+#    dest: /usr/local/bin/ceph
+#    content: |
+#      #!/bin/bash
+#      if [ $# -eq 0 ]; then
+#        exec cephadm shell
+#      else
+#        exec cephadm shell -- ceph "$@"
+#      fi
+#    mode: '0755'
+#    owner: root
+#    group: root
 
 - name: Ensure group "cephadm" exists
   group:
@@ -134,7 +137,7 @@
 
 - name: Bootstrap Ceph cluster
   command: >
-      /usr/local/bin/cephadm bootstrap
+      cephadm bootstrap
       --skip-monitoring-stack
       --skip-dashboard
       --config /tmp/ceph.conf
@@ -186,7 +189,7 @@
 
 # === adding monitor on other nodes ===
 - name: Add hosts to Ceph orchestrator with _admin label
-  command: "/usr/local/bin/ceph orch host add {{ hostvars[item]['hostname'] }} --labels _admin"
+  command: "ceph orch host add {{ hostvars[item]['hostname'] }} --labels _admin"
   loop: "{{ mon_nodes_to_add }}"
   changed_when: true
   failed_when: false
@@ -195,7 +198,7 @@
   when: mon_nodes_to_add | length > 0
 
 - name: Confirm monitors are in monmap
-  command: /usr/local/bin/ceph mon dump
+  command: ceph mon dump
   register: mon_dump
   retries: 30
   delay: 5
@@ -231,7 +234,7 @@
   run_once: true
 
 - name: Zap the volume on nodes that need OSDs
-  command: "/usr/local/bin/cephadm ceph-volume lvm zap vg_ceph/lv_ceph"
+  command: "cephadm ceph-volume lvm zap vg_ceph/lv_ceph"
   delegate_to: "{{ item }}"
   run_once: true
   when: hostvars[item]['hostname'] in nodes_needing_osds
@@ -247,14 +250,14 @@
   delegate_to: "{{ first_node }}"
 
 - name: Add OSD daemon on nodes that need OSDs
-  command: /usr/local/bin/cephadm shell -v /tmp/t.yaml:/tmp/t.yaml:ro -- ceph orch apply -i /tmp/t.yaml
+  command: cephadm shell -v /tmp/t.yaml:/tmp/t.yaml:ro -- ceph orch apply -i /tmp/t.yaml
   delegate_to: "{{ first_node }}"
   run_once: true
   changed_when: true
   failed_when: false
 
 - name: Confirm cluster is ok
-  command: /usr/local/bin/ceph status --format=json
+  command: ceph status --format=json
   register: cephs
   retries: 30
   delay: 5
@@ -265,35 +268,35 @@
 
 - name: Check if RBD pool exists
   shell:
-    cmd: set -o pipefail && /usr/local/bin/ceph osd lspools | grep -w rbd
+    cmd: set -o pipefail && ceph osd lspools | grep -w rbd
     executable: /bin/bash
   register: rbd_pool_check
   changed_when: false
   failed_when: false
 
 - name: Create RBD pool if it doesn't exist
-  command: /usr/local/bin/ceph osd pool create rbd
+  command: ceph osd pool create rbd
   when: rbd_pool_check.rc != 0
   changed_when: true
   run_once: true
   delegate_to: "{{ first_node }}"
 
 - name: Enable RBD application on the pool
-  command: /usr/local/bin/ceph osd pool application enable rbd rbd
+  command: ceph osd pool application enable rbd rbd
   when: rbd_pool_check.rc != 0
   changed_when: true
   run_once: true
   delegate_to: "{{ first_node }}"
 
 - name: Check if CephX user client.libvirt exists
-  command: /usr/local/bin/ceph auth get client.libvirt
+  command: ceph auth get client.libvirt
   register: cephx_user_check
   changed_when: false
   failed_when: false
 
 - name: Create CephX user client.libvirt if it does not exist
   command:
-    /usr/local/bin/ceph auth add client.libvirt
+    ceph auth add client.libvirt
     mon 'profile rbd, allow command "osd blacklist"'
     osd 'allow class-read object_prefix rbd_children, profile rbd pool=rbd'
   when: cephx_user_check.rc != 0
@@ -301,7 +304,7 @@
 
 - name: Update CephX user client.libvirt permissions if it exists
   shell: >
-    /usr/local/bin/ceph auth caps client.libvirt
+    ceph auth caps client.libvirt
     mon 'profile rbd, allow command "osd blacklist"'
     osd 'allow class-read object_prefix rbd_children, profile rbd pool=rbd'
   when: cephx_user_check.rc == 0

--- a/roles/cephadm/tasks/main.yml
+++ b/roles/cephadm/tasks/main.yml
@@ -147,7 +147,7 @@
   register: ceph_bootstrap_result
   when: do_bootstrap | bool
 
-# === adding monitor on other nodes ===
+# === adding cephadm key on other nodes ===
 - name: Check if /etc/ceph/ceph.pub exists on first_node
   stat:
     path: /etc/ceph/ceph.pub
@@ -184,6 +184,7 @@
   run_once: true
   when: mon_nodes_to_add | length > 0
 
+# === adding monitor on other nodes ===
 - name: Add hosts to Ceph orchestrator with _admin label
   command: "/usr/local/bin/ceph orch host add {{ hostvars[item]['hostname'] }} --labels _admin"
   loop: "{{ mon_nodes_to_add }}"
@@ -205,32 +206,9 @@
   loop: "{{ mon_nodes_to_add }}"
   when: mon_nodes_to_add | length > 0
 
-# === Managers now ===
-- name: Get current number of MGR daemons
-  shell:
-    cmd: set -o pipefail && /usr/local/bin/ceph orch ls --service-name=mgr | grep -o "count:.*" | cut -d":" -f2
-    executable: /bin/bash
-  register: mgr_count_raw
-  changed_when: false
-  run_once: true
-  delegate_to: "{{ first_node }}"
-
-- name: Set fact with MGR count
-  set_fact:
-    mgr_count: "{{ mgr_count_raw.stdout | trim }}"
-  run_once: true
-  delegate_to: "{{ first_node }}"
-
-- name: "RUN /usr/local/bin/ceph orch apply mgr {{ groups['cluster_machines'] | length }}"
-  command: "/usr/local/bin/ceph orch apply mgr {{ groups['cluster_machines'] | length }}"
-  run_once: true
-  delegate_to: "{{ first_node }}"
-  when: mgr_count | int != groups['cluster_machines'] | length
-  changed_when: true
-
 # === OSDs now ===
 - name: Get list of current OSD daemons and their hosts
-  command: /usr/local/bin/ceph orch ps --service-name=osd --format json
+  command: ceph orch ps --daemon-type=osd --format json
   register: osd_ps
   delegate_to: "{{ first_node }}"
   run_once: true
@@ -260,14 +238,30 @@
   loop: "{{ groups['cluster_machines'] }}"
   changed_when: true
 
+- name: Copy ceph orch spec file
+  template:
+    src: "{{ ceph_spec_path | default('spec.yaml.j2') }}"
+    dest: /tmp/t.yaml
+    mode: 0644
+  run_once: true
+  delegate_to: "{{ first_node }}"
+
 - name: Add OSD daemon on nodes that need OSDs
-  command: "/usr/local/bin/ceph orch daemon add osd {{ hostvars[item]['hostname'] }}:/dev/vg_ceph/lv_ceph"
+  command: /usr/local/bin/cephadm shell -v /tmp/t.yaml:/tmp/t.yaml:ro -- ceph orch apply -i /tmp/t.yaml
   delegate_to: "{{ first_node }}"
   run_once: true
-  when: hostvars[item]['hostname'] in nodes_needing_osds
-  loop: "{{ groups['cluster_machines'] }}"
   changed_when: true
   failed_when: false
+
+- name: Confirm cluster is ok
+  command: /usr/local/bin/ceph status --format=json
+  register: cephs
+  retries: 30
+  delay: 5
+  changed_when: false
+  run_once: true
+  delegate_to: "{{ first_node }}"
+  until: cephs.stdout | from_json | community.general.json_query('health.status') == "HEALTH_OK"
 
 - name: Check if RBD pool exists
   shell:

--- a/roles/cephadm/tasks/main.yml
+++ b/roles/cephadm/tasks/main.yml
@@ -4,6 +4,40 @@
 ---
 - include_vars: "{{ seapath_distro }}.yml"
 
+- name: Ensure group "cephadm" exists
+  group:
+    name: cephadm
+    gid: 1001
+    state: present
+
+- name: Ensure user "cephadm" exists
+  user:
+    name: cephadm
+    uid: 1001
+    group: cephadm
+    create_home: yes
+
+- name: Ensure group "containerized-ceph" exists
+  group:
+    name: containerized-ceph
+    gid: 167
+    state: present
+  when: seapath_distro == "Debian"
+
+- name: Ensure user "containerized-ceph" exists with nologin (already exists on centos/oraclelinux)
+  user:
+    name: containerized-ceph
+    uid: 167
+    group: containerized-ceph
+    create_home: no
+    shell: /sbin/nologin
+  when: seapath_distro == "Debian"
+
+- name: Set cephadm user sudo permissions
+  copy:
+    src: cephadm_sudoers
+    dest: /etc/sudoers.d/cephadm
+
 - name: Install cephadm binaries
   when: cephadm_install is true
   block:
@@ -41,41 +75,6 @@
 #    mode: '0755'
 #    owner: root
 #    group: root
-
-- name: Ensure group "cephadm" exists
-  group:
-    name: cephadm
-    gid: 1001
-    state: present
-
-- name: Ensure user "cephadm" exists
-  user:
-    name: cephadm
-    uid: 1001
-    group: cephadm
-    create_home: yes
-
-- name: Ensure group "containerized-ceph" exists
-  group:
-    name: containerized-ceph
-    gid: 167
-    state: present
-  when: seapath_distro == "Debian"
-
-- name: Ensure user "containerized-ceph" exists with nologin (already exists on centos/oraclelinux)
-  user:
-    name: containerized-ceph
-    uid: 167
-    group: containerized-ceph
-    create_home: no
-    shell: /sbin/nologin
-  when: seapath_distro == "Debian"
-
-- name: Set cephadm user sudo permissions
-  copy:
-    src: cephadm_sudoers
-    dest: /etc/sudoers.d/cephadm
-
 
 - name: Check if host is part of a Ceph cluster
   command: "/usr/local/bin/ceph -s"

--- a/roles/cephadm/tasks/main.yml
+++ b/roles/cephadm/tasks/main.yml
@@ -38,22 +38,22 @@
     src: cephadm_sudoers
     dest: /etc/sudoers.d/cephadm
 
-- name: Install cephadm binary
+- name: Download cephadm
+  get_url:
+    url: "https://download.ceph.com/rpm-{{ cephadm_release }}/el9/noarch/cephadm"
+    dest: "/tmp/cephadm"
+    mode: '0755'
   when: cephadm_install is true
-  block:
-    - name: Download cephadm
-      get_url:
-        url: "https://download.ceph.com/rpm-{{ cephadm_release }}/el9/noarch/cephadm"
-        dest: "/tmp/cephadm"
-        mode: '0755'
-    - name: Install cephadm
-      command: /tmp/cephadm install
-      changed_when: true
 
 - name: Install cephadm repository
-  command: cephadm add-repo --release squid
+  command: "{{ '/tmp/cephadm' if cephadm_install | default(false) else 'cephadm' }} add-repo --release squid"
   changed_when: true
   when: cephadm_installrepo is true
+
+- name: Install cephadm
+  command: /tmp/cephadm install
+  changed_when: true
+  when: cephadm_install is true
 
 - name: Install ceph-common package
   command: cephadm install ceph-common

--- a/roles/cephadm/tasks/main.yml
+++ b/roles/cephadm/tasks/main.yml
@@ -263,7 +263,7 @@
   command: ceph status --format=json
   register: cephs
   retries: 30
-  delay: 5
+  delay: 10
   changed_when: false
   run_once: true
   delegate_to: "{{ first_node }}"

--- a/roles/cephadm/templates/spec.yaml.j2
+++ b/roles/cephadm/templates/spec.yaml.j2
@@ -1,0 +1,29 @@
+service_type: crash
+service_name: crash
+placement:
+  host_pattern: '*'
+---
+service_type: mgr
+service_name: mgr
+placement:
+  host_pattern: '*'
+---
+service_type: mon
+service_name: mon
+placement:
+  host_pattern: '*'
+---
+{% for host in groups['osds'] %}
+service_type: osd
+service_id: {{ 'osd' ~ (groups['osds'].index(host) + 1) }}
+service_name: osd.{{ 'osd' ~ (groups['osds'].index(host) + 1) }}
+placement:
+  host_pattern: {{ hostvars[host]['hostname'] }}
+spec:
+  data_devices:
+    paths:
+    - /dev/vg_ceph/lv_ceph
+  filter_logic: AND
+  objectstore: bluestore
+---
+{% endfor %}

--- a/roles/configure_ha/tasks/main.yml
+++ b/roles/configure_ha/tasks/main.yml
@@ -136,6 +136,15 @@
       when: groups['valid_machine'] is undefined
       changed_when: true
 
+
+- name: Verify stonith is disabled
+  command: "{{ configure_ha_crm_command_path }} configure show"
+  register: stonith_check
+  run_once: true
+  until: "'stonith-enabled=false' in stonith_check.stdout"
+  retries: 5
+  delay: 3
+
 - name: Making sure that Corosync service is started
   ansible.builtin.systemd:
     name: corosync

--- a/roles/debian_tests/cukinia-tests/cukinia/common_security_tests.d/apt.conf.j2
+++ b/roles/debian_tests/cukinia-tests/cukinia/common_security_tests.d/apt.conf.j2
@@ -49,6 +49,7 @@ ceph-mgr|\
 ceph-mon|\
 ceph-osd|\
 ceph|\
+cephadm|\
 chrony|\
 conntrackd|\
 containernetworking-plugins|\

--- a/roles/network_networkdwait/templates/systemd-networkd-wait-online.service.j2
+++ b/roles/network_networkdwait/templates/systemd-networkd-wait-online.service.j2
@@ -1,3 +1,3 @@
 [Service]
 ExecStart=
-ExecStart=/lib/systemd/systemd-networkd-wait-online {% if interfaces_to_wait_for is defined %}{% for interface in interfaces_to_wait_for %}{{" -i " + interface}}{% endfor %}{% endif %}{% if cluster_protocol is defined and cluster_protocol == 'HSR' %} -i hsr0 {% elif cluster_ip_addr is defined %} -i team0 {% endif %}
+ExecStart=/lib/systemd/systemd-networkd-wait-online {% if interfaces_to_wait_for is defined %}{% for interface in interfaces_to_wait_for %}{{" -i " + interface}}{% endfor %}{% endif %}{% if cluster_protocol is defined and cluster_protocol == 'HSR' %} -i hsr0 {% elif cluster_ip_addr is defined and no_cluster_network is not defined %} -i team0 {% endif %}


### PR DESCRIPTION
ceph: fix LV creation
Without this commit, if the partition exists but the LV does not, the LV creation fails.
We need to make everystep independant (partition, PV, VG, LV...), but in the meantime we make everything in one unique block so that if nothing is done on the partition (first step) we don't do anything with the other steps.

----
use ceph orch spec to deploy osd
So that the OSDs are in a managed state

----
cephadm: install ceph-common package

----
cephadm: use ceph binary from distro package

----
cephadm: add cephadm package to test

----
cephadm: create the user/group before installing cephadm
Otherwise cephadm will create user and group with different UID/GID

----
cephadm: add variable for repo and ceph-command installation

----
cephadm: remove ceph-volume package

----
cephadm: increase delay to rebuild OSD

----
pacemaker: prevent race condition with stonith status

----
no_cluster_network: adapt systemd-networkd-wait-online

----
cephadm: fix repo installation

----
ceph lv: adapt for when we create the first partition

----
cephadm: adapt ceph preparation (no zap)
