### PR TITLE
ceph: fix installation on whole disk

### DIFF
--- a/playbooks/cluster_setup_ceph.yaml
+++ b/playbooks/cluster_setup_ceph.yaml
@@ -30,7 +30,9 @@
   become: true
   gather_facts: yes
   roles:
-    - ceph_expansion_vg
+    - role: ceph_expansion_vg
+      when: lvm_volumes is defined
+
 
 - name: Ceph Expansion LV
   hosts:
@@ -39,7 +41,8 @@
   gather_facts: yes
   serial: 1
   roles:
-    - ceph_expansion_lv
+    - role: ceph_expansion_lv
+      when: lvm_volumes is defined
 
 - name: Import ceph-ansible/site.yml playbook
   import_playbook: ../ceph-ansible/site.yml

--- a/playbooks/cluster_setup_cephadm.yaml
+++ b/playbooks/cluster_setup_cephadm.yaml
@@ -20,7 +20,8 @@
   become: true
   gather_facts: yes
   roles:
-    - ceph_expansion_vg
+    - role: ceph_expansion_vg
+      when: lvm_volumes is defined
 
 - name: Ceph Expansion LV
   hosts:
@@ -29,7 +30,8 @@
   gather_facts: yes
   serial: 1
   roles:
-    - ceph_expansion_lv
+    - role: ceph_expansion_lv
+      when: lvm_volumes is defined
 
 - name: Cephadm
   hosts:

--- a/roles/ceph_expansion_lv/README.md
+++ b/roles/ceph_expansion_lv/README.md
@@ -10,8 +10,7 @@ No requirement.
 
 | Variable    | Required | Type         | Comments                                                                                                                                      |
 |-------------|----------|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
-| lvm_volumes | No       | List of dict | LVM volumes used for Ceph OSD. Refer to Ceph Ansible documentation: https://docs.ceph.com/projects/ceph-ansible/en/latest/osds/scenarios.html |
-| ansible_lvm | No       | Dict         | TODO                                                                                                                                          |
+| lvm_volumes | Yes      | List of dict | LVM volumes used for Ceph OSD. Refer to Ceph Ansible documentation: https://docs.ceph.com/projects/ceph-ansible/en/latest/osds/scenarios.html |
 
 
 ## Example Playbook

--- a/roles/ceph_expansion_vg/README.md
+++ b/roles/ceph_expansion_vg/README.md
@@ -10,7 +10,7 @@ No requirement.
 
 | Variable    | Required | Type         | Comments                                                                                                                                      |
 |-------------|----------|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
-| lvm_volumes | No       | List of dict | LVM volumes used for Ceph OSD. Refer to Ceph Ansible documentation: https://docs.ceph.com/projects/ceph-ansible/en/latest/osds/scenarios.html |
+| lvm_volumes | Yes      | List of dict | LVM volumes used for Ceph OSD. Refer to Ceph Ansible documentation: https://docs.ceph.com/projects/ceph-ansible/en/latest/osds/scenarios.html |
 
 
 ## Example Playbook


### PR DESCRIPTION
Fixes the case where the user choose to give ceph the whole disk, in which case lvm_volumes is not defined.