### PR TITLE
pacemaker: adds ethmonitor resource agent override

### DIFF
--- a/roles/debian_physical_machine/files/ethmonitor_patch1
+++ b/roles/debian_physical_machine/files/ethmonitor_patch1
@@ -1,0 +1,14 @@
+@@ -269,10 +269,13 @@
+ 	else
+ 		case $__OCF_ACTION in
+ 			validate-all)
+ 				ocf_exit_reason "Interface $NIC does not exist"
+ 				exit $OCF_ERR_CONFIGURED;;
++			monitor)
++				ocf_log debug "Interface $NIC does not exist"
++				;;
+ 			*)	
+ 				## It might be a bond interface which is temporarily not available, therefore we want to continue here
+ 				ocf_log warn "Interface $NIC does not exist"
+ 				;;
+ 		esac

--- a/roles/debian_physical_machine/files/ethmonitor_patch2
+++ b/roles/debian_physical_machine/files/ethmonitor_patch2
@@ -1,0 +1,88 @@
+@@ -59,10 +59,11 @@
+ OCF_RESKEY_pktcnt_timeout_default="5"
+ OCF_RESKEY_arping_count_default="1"
+ OCF_RESKEY_arping_timeout_default="1"
+ OCF_RESKEY_arping_cache_entries_default="5"
+ OCF_RESKEY_link_status_only_default="false"
++OCF_RESKEY_dampen_default="10s"
+ 
+ : ${OCF_RESKEY_interface=${OCF_RESKEY_interface_default}}
+ : ${OCF_RESKEY_name=${OCF_RESKEY_name_default}}
+ : ${OCF_RESKEY_multiplier=${OCF_RESKEY_multiplier_default}}
+ : ${OCF_RESKEY_repeat_count=${OCF_RESKEY_repeat_count_default}}
+@@ -70,10 +71,11 @@
+ : ${OCF_RESKEY_pktcnt_timeout=${OCF_RESKEY_pktcnt_timeout_default}}
+ : ${OCF_RESKEY_arping_count=${OCF_RESKEY_arping_count_default}}
+ : ${OCF_RESKEY_arping_timeout=${OCF_RESKEY_arping_timeout_default}}
+ : ${OCF_RESKEY_arping_cache_entries=${OCF_RESKEY_arping_cache_entries_default}}
+ : ${OCF_RESKEY_link_status_only=${OCF_RESKEY_link_status_only_default}}
++: ${OCF_RESKEY_dampen=${OCF_RESKEY_dampen_default}}
+ 
+ #######################################################################
+ 
+ meta_data() {
+ 	cat <<END
+@@ -206,10 +208,18 @@
+ </longdesc>
+ <shortdesc lang="en">link status check only</shortdesc>
+ <content type="boolean" default="${OCF_RESKEY_link_status_only_default}" />
+ </parameter>
+ 
++<parameter name="dampen" reloadable="1">
++<longdesc lang="en">
++The time to wait (dampening) further changes occur
++</longdesc>
++<shortdesc lang="en">Dampening interval</shortdesc>
++<content type="integer" default="10s"/>
++</parameter>
++
+ </parameters>
+ <actions>
+ <action name="start" timeout="60s" />
+ <action name="stop" timeout="20s" />
+ <action name="status" depth="0" timeout="60s" interval="10s" />
+@@ -465,11 +475,15 @@
+ END
+ }
+ 
+ set_cib_value() {
+ 	local score=`expr $1 \* $OCF_RESKEY_multiplier`
+-	attrd_updater -n $ATTRNAME -v $score
++	if [ "$__OCF_ACTION" = "start" ] ; then
++	    attrd_updater -n $ATTRNAME -B $score -d "$OCF_RESKEY_dampen"
++        else
++	    attrd_updater -n $ATTRNAME -v $score -d "$OCF_RESKEY_dampen"
++	fi
+ 	local rc=$?
+ 	case $rc in
+ 		0) ocf_log debug "attrd_updater: Updated $ATTRNAME = $score" ;;
+ 		*) ocf_log warn "attrd_updater: Could not update $ATTRNAME = $score: rc=$rc";;
+ 	esac
+@@ -523,11 +537,11 @@
+ 	exit $attr_rc
+ }
+ 
+ if_stop()
+ {
+-	attrd_updater -D -n $ATTRNAME
++	attrd_updater -D -n $ATTRNAME -d "$OCF_RESKEY_dampen"
+ 	ha_pseudo_resource $OCF_RESOURCE_INSTANCE stop
+ }
+ 
+ if_start()
+ {
+@@ -545,11 +559,13 @@
+ }
+ 
+ 
+ if_validate() {
+ 	check_binary $IP2UTIL
+-	check_binary arping
++	if [ "OCF_RESKEY_link_status_only_default" = "false" ]; then
++	    check_binary arping
++	fi
+ 	check_binary bc
+ 	if_init
+ }
+ 
+ case $__OCF_ACTION in

--- a/roles/debian_physical_machine/tasks/main.yml
+++ b/roles/debian_physical_machine/tasks/main.yml
@@ -46,15 +46,39 @@
     state: directory
     mode: '0755'
 
-- name: Copy Pacemaker Seapath Resource-Agent files
-  ansible.posix.synchronize:
-    src: pacemaker_ra/
-    dest: /usr/lib/ocf/resource.d/seapath/
-    rsync_opts:
-    - "--chmod=F755"
-    - "--chown=root:root"
-  when:
-    - "'cluster_machines' in group_names"
+- name: Configure Pacemaker Seapath resources
+  when: "'cluster_machines' in group_names"
+  block:
+
+    - name: Copy Pacemaker Seapath Resource-Agent files
+      ansible.posix.synchronize:
+        src: pacemaker_ra/
+        dest: /usr/lib/ocf/resource.d/seapath/
+        rsync_opts:
+          - "--chmod=F755"
+          - "--chown=root:root"
+
+    - name: Copy ethmonitor from heartbeat to seapath
+      copy:
+        remote_src: yes
+        src: /usr/lib/ocf/resource.d/heartbeat/ethmonitor
+        dest: /usr/lib/ocf/resource.d/seapath/ethmonitor
+        owner: root
+        group: root
+        mode: '0755'
+        force: yes
+
+    - name: Apply patch1 to ethmonitor
+      ansible.builtin.patch:
+        src: ethmonitor_patch1
+        dest: /usr/lib/ocf/resource.d/seapath/ethmonitor
+        strip: 0
+
+    - name: Apply patch2 to ethmonitor
+      ansible.builtin.patch:
+        src: ethmonitor_patch2
+        dest: /usr/lib/ocf/resource.d/seapath/ethmonitor
+        strip: 0
 
 - name: Copy chrony-wait.service
   template:


### PR DESCRIPTION
The ethmonitor resource agent exists but has 2 limitations:
- no dampening feature
- needs arping installed even if not used by the configuation

This commit creates an ocf:seapath:ethmonitor overrides that deals with those two issues.

Example:
```
primitive ethmonitor-ADM ocf:seapath:ethmonitor \
        params interface=ADM repeat_count=1 repeat_interval=1 link_status_only=true dampen=10s \
        op monitor timeout=10 interval=10
```