### PR TITLE
conntrackd: variabilize interface name

### DIFF
--- a/roles/conntrackd/README.md
+++ b/roles/conntrackd/README.md
@@ -10,9 +10,10 @@ No requirement.
 
 - conntrackd_ignore_ip_list
 
-| Variable                   | Required | Type   | Comments                                    |
-|----------------------------|----------|--------|---------------------------------------------|
-| conntrackd_ignore_ip_list  | no       | Bool   | Enable contrackd if the variable is defined |
+| Variable                   | Required | Type   | Default | Comments                                                |
+|----------------------------|----------|--------|---------|---------------------------------------------------------|
+| conntrackd_ignore_ip_list  | no       | Bool   | none    | Enable contrackd if the variable is defined             |
+| conntrackd_interface       | no       | String | team0   | Set the network interface on which conntrackd will work |
 
 ## Example Playbook
 

--- a/roles/conntrackd/defaults/main.yml
+++ b/roles/conntrackd/defaults/main.yml
@@ -1,0 +1,5 @@
+# Copyright (C) 2025 RTE
+# SPDX-License-Identifier: Apache-2.0
+
+---
+conntrackd_interface: "team0"

--- a/roles/conntrackd/templates/conntrackd.conf.j2
+++ b/roles/conntrackd/templates/conntrackd.conf.j2
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 RTE
+# SPDX-License-Identifier: Apache-2.0
+
 Sync {
         Mode NOTRACK {
                 DisableInternalCache on
@@ -8,7 +11,7 @@ Sync {
                 IPv4_address 225.0.0.50
                 Group 3780
 		IPv4_interface {{ cluster_ip_addr }}
-                Interface team0
+                Interface {{ conntrackd_interface }}
                 SndSocketBuffer 1249280
                 RcvSocketBuffer 1249280
                 Checksum on


### PR DESCRIPTION
In case of "no cluster network", we can't use team0, so we need to give the option to the user to set a specific interface name.