### PR TITLE
Network interface aliases for Welotec RSAPCMK2

### DIFF
--- a/playbooks/seapath_setup_custom_hardware.yaml
+++ b/playbooks/seapath_setup_custom_hardware.yaml
@@ -1,0 +1,11 @@
+
+---
+- name: Welotec hardware customization
+  hosts:
+    - cluster_machines
+    - standalone_machine
+  become: true
+  gather_facts: true
+  roles:
+    - role: hardware_customization/welotec
+      when: welotec is defined and welotec | bool

--- a/roles/hardware_customization/welotec/README.md
+++ b/roles/hardware_customization/welotec/README.md
@@ -1,0 +1,27 @@
+# Welotec hardware customization role
+
+This role applies specific configuration for Welotec hardware:
+* Welotec RSAPCMK2:
+  * Creates .link files corresponding to Welotec OUI network interfaces.
+
+## Requirements
+
+No requirement.
+
+## Role Variables
+* `network_link.yaml`: a var file containing the mapping of network interfaces.
+
+
+## Example Playbook
+
+```yaml
+- name: Welotec hardware customization
+  hosts:
+    - cluster_machines
+    - standalone_machine
+  become: true
+  gather_facts: true
+  roles:
+    - role: hardware_customization/welotec
+      when: welotec is defined and welotec | bool
+```

--- a/roles/hardware_customization/welotec/meta/main.yaml
+++ b/roles/hardware_customization/welotec/meta/main.yaml
@@ -1,0 +1,9 @@
+# Copyright (C) 2025 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+---
+galaxy_info:
+  author: "Seapath"
+  description: Contains the hardware customization for Welotec RSAPCMK2 hypervisor
+  min_ansible_version: 2.9.10
+  license: Apache-2.0
+dependencies: []

--- a/roles/hardware_customization/welotec/tasks/main.yaml
+++ b/roles/hardware_customization/welotec/tasks/main.yaml
@@ -1,0 +1,36 @@
+# Copyright (C) 2025 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+---
+- include_vars: "network_link.yaml"
+
+- name: Gather interfaces MAC addresses
+  shell:
+    cmd: "cat /sys/class/net/*/address|grep 78:70|sort|uniq"
+  register: mac_addresses
+- name: Gather PRP-HSR interfaces MAC addresses
+  shell:
+    cmd: "cat /sys/class/net/*/address|grep 70:F8:E7*|sort|uniq"
+  register: mac_addresses_hsr_prp
+- name: Map MAC addresses to interfaces
+  set_fact:
+    mac_address_map: >-
+      {{
+        dict(
+          [
+                ('lan5', mac_addresses.stdout_lines[0]),
+                ('lan6', mac_addresses.stdout_lines[1]),
+                ('lan7', mac_addresses.stdout_lines[2]),
+                ('lan8', mac_addresses.stdout_lines[3]),
+                ('lan1', mac_addresses.stdout_lines[4]),
+                ('lan2', mac_addresses.stdout_lines[5]),
+                ('lan3', mac_addresses.stdout_lines[6]),
+                ('lan4', mac_addresses.stdout_lines[7]),
+                ('lan_hsr-prp', mac_addresses_hsr_prp.stdout_lines[0]),
+          ]
+        )
+      }}
+- name: Apply config
+  include_role:
+    name: systemd_networkd
+  vars:
+    systemd_networkd_apply_config: "{{ apply_network_config | default(false) }}"

--- a/roles/hardware_customization/welotec/vars/network_link.yaml
+++ b/roles/hardware_customization/welotec/vars/network_link.yaml
@@ -1,0 +1,87 @@
+# Copyright (C) 2025 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+---
+systemd_networkd_link:
+  20_lan1:
+    - Match:
+        - Name: "lan1"
+        - Driver: "igc"
+        - PermanentMACAddress: "{{ mac_address_map['lan1'] }}"
+    - Link:
+        - NamePolicy:
+        - AlternativeNamesPolicy:
+        - Name: "lan1"
+        - AlternativeName: "lan_mgmt"
+        - AlternativeName: "lan_ptp"
+  20_lan2:
+    - Match:
+        - Name: "lan2"
+        - Driver: "igc"
+        - PermanentMACAddress: "{{ mac_address_map['lan2'] }}"
+    - Link:
+        - NamePolicy:
+        - AlternativeNamesPolicy:
+        - Name: "lan2"
+  20_lan3:
+    - Match:
+        - Name: "lan3"
+        - Driver: "igc"
+        - PermanentMACAddress: "{{ mac_address_map['lan3'] }}"
+    - Link:
+        - NamePolicy:
+        - AlternativeNamesPolicy:
+        - Name: "lan3"
+  20_lan4:
+    - Match:
+        - Name: "lan4"
+        - Driver: "igc"
+        - PermanentMACAddress: "{{ mac_address_map['lan4'] }}"
+    - Link:
+        - NamePolicy:
+        - AlternativeNamesPolicy:
+        - Name: "lan4"
+  20_lan5:
+    - Match:
+        - Name: "lan5"
+        - Driver: "igc"
+        - PermanentMACAddress: "{{ mac_address_map['lan5'] }}"
+    - Link:
+        - NamePolicy:
+        - AlternativeNamesPolicy:
+        - Name: "lan5"
+  20_lan6:
+    - Match:
+        - Name: "lan6"
+        - Driver: "igc"
+        - PermanentMACAddress: "{{ mac_address_map['lan6'] }}"
+    - Link:
+        - NamePolicy:
+        - AlternativeNamesPolicy:
+        - Name: "lan6"
+  20_lan7:
+    - Match:
+        - Name: "lan7"
+        - Driver: "igc"
+        - PermanentMACAddress: "{{ mac_address_map['lan7'] }}"
+    - Link:
+        - NamePolicy:
+        - AlternativeNamesPolicy:
+        - Name: "lan7"
+  20_lan8:
+    - Match:
+        - Name: "lan8"
+        - Driver: "igc"
+        - PermanentMACAddress: "{{ mac_address_map['lan8'] }}"
+    - Link:
+        - NamePolicy:
+        - AlternativeNamesPolicy:
+        - Name: "lan8"
+  20_lan_prp:
+      - Match:
+          - Name: "lan_prp"
+          - Driver: "igc"
+          - PermanentMACAddress: "{{ mac_address_map['lan_hsr-prp'] }}"
+      - Link:
+          - NamePolicy:
+          - AlternativeNamesPolicy:
+          - Name: "lan_hsr-prp"


### PR DESCRIPTION
Hello,
This (draft) PR makes the needed changes for creating the needed network interface aliases for  Welotec RSAPCMK2 hypervisor. This work is based on [Welotec build_debian_iso fork], and reproduce the same behavior.
Currently, the implementation is voluntary made in a playbook, and can't be merged as it as these modification are for a specific hypervisor hardware, and we currently don't have any support for this in Ansible.

Feel free to give me your opinion!

[Welotec build_debian_iso fork]: https://github.com/welotec/seapath-build_debian_iso/blob/main/usercustomization/scripts/USERCUSTOMIZATION/90-welotec