### PR TITLE
ci_vms_standalone_ptp: remove become

### DIFF
--- a/playbooks/ci_vms_standalone_ptp.yaml
+++ b/playbooks/ci_vms_standalone_ptp.yaml
@@ -4,7 +4,6 @@
 # Ansible playbook that deploy and set-up ptp on vms for a standalone machine
 
 - name: Import deploy_vms_standalone
-  become: true
   import_playbook: deploy_vms_standalone.yaml
 
 - name: Synchronise VMs with PTP


### PR DESCRIPTION
This become is useless and has no effect.