### PR TITLE
inventories: add subnet variables

### DIFF
--- a/inventories/examples/seapath-cluster.yaml
+++ b/inventories/examples/seapath-cluster.yaml
@@ -86,6 +86,7 @@ cluster_machines:
     gateway_addr: "192.168.200.1" # TODO : Put your gatway address
     dns_servers: "192.168.200.1" # TODO : Put your dns address
     ip_addr: "{{ ansible_host }}"
+    subnet: 24 # TODO : Put your subnet mask in CIDR notation
     apply_network_config: true
     # systemd-networkd is used by default to configure the network
     # netplan can also be used to sum up complex network in one yaml file

--- a/inventories/examples/seapath-standalone.yaml
+++ b/inventories/examples/seapath-standalone.yaml
@@ -38,6 +38,7 @@ standalone_machine:
     gateway_addr: "192.168.200.1" # TODO : Put your gatway address
     dns_servers: "192.168.200.1" # TODO : Put your dns address
     ip_addr: "{{ ansible_host }}"
+    subnet: 24 # TODO : Put your subnet mask in CIDR notation
     apply_network_config: true
     # List of interfaces to wait for before considering the network as up.
     # With the default network configuration, it should be "br0"


### PR DESCRIPTION
Add in the examples inventories the subnet variable to allow the user to specify the subnet mask in CIDR notation.