### PR TITLE
Adds seapath provided generic qemu hook

### DIFF
--- a/inventories/providers/abb/ssc600sw_hypervisor_standalone_example.yaml
+++ b/inventories/providers/abb/ssc600sw_hypervisor_standalone_example.yaml
@@ -18,10 +18,6 @@ all:
       ptp_interface: "enp7s0" # Change to your PTP interface.
       ntp_servers: "192.168.216.1" # Change to your ntp server. Remove if not needed.
 
-      upload_files: # This file is given with the ssc600sw package
-        - src: "../files/qemu.hook"
-          dest: "/etc/libvirt/hooks/"
-          mode: "0744"
       nics_affinity:
         - enp88s0: 3 # Change to your NIC receiving Sampled Values
       # Change for the same core as VM's emulatorpin

--- a/roles/configure_libvirt/README.md
+++ b/roles/configure_libvirt/README.md
@@ -9,6 +9,11 @@ This is useful for the Libvirt administration user to
 - Provide live migration over the cluster
 - Allow VM console access over the cluster
 
+If `configure_libvirt_deploy_seapath_qemu_hook` is set to true, this role
+deploys Seapath qemu hook under `/etc/libvirt/hooks/qemu.d/`.
+This QEMU hook modify thread priorities and affinity related to bridges. It is
+necessary if the process bus is passed to the VM through a bridge (Linux or OvS)
+
 ## Requirements
 
 No requirement.
@@ -18,6 +23,7 @@ No requirement.
 | Variable                                               | Required | Type    | Default | Comments                                                                                   |
 |--------------------------------------------------------|----------|---------|---------|--------------------------------------------------------------------------------------------|
 | configure_libvirt_allow_non_root_libvirt_socket_access | no       | Boolean | true    | Allow non-root users in libvirt group to access libvirt socket                             |
+| configure_libvirt_deploy_seapath_qemu_hook             | no       | Boolean | false   | Deploy Seapath qemu hook under `/etc/libvirt/hooks/qemu.d/`                                |
 
 ## Example Playbook
 

--- a/roles/configure_libvirt/defaults/main.yml
+++ b/roles/configure_libvirt/defaults/main.yml
@@ -3,3 +3,4 @@
 
 ---
 configure_libvirt_allow_non_root_libvirt_socket_access: true
+configure_libvirt_deploy_seapath_qemu_hook: false

--- a/roles/configure_libvirt/files/qemu_hook.py
+++ b/roles/configure_libvirt/files/qemu_hook.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2025 Florent CARLI
+# SPDX-License-Identifier: GPL-3.0-only
+
+import sys
+import os
+import time
+import xml.etree.ElementTree as ET
+import subprocess
+from optparse import OptionParser
+
+XML_DIRS = ("/etc/pacemaker", "/etc/libvirt/qemu")
+
+def parse_args():
+    parser = OptionParser(
+        usage="%prog <vm_name> <vm_action>",
+        description=(
+            "vm_action values:\n"
+            "  started     - run commands for real\n"
+            "  started-dry - dry-run, print commands only\n"
+            "  other       - do nothing and exit"
+        ),
+    )
+    options, args = parser.parse_args()
+
+    if len(args) < 2:
+        parser.print_help()
+        sys.exit(0)
+
+    return options, args[0], args[1]
+
+def parse_xml(guest_name):
+    for xml_dir in XML_DIRS:
+        filename = f"{xml_dir}/{guest_name}.xml"
+        try:
+            tree = ET.parse(filename)
+            return tree.getroot()
+        except FileNotFoundError:
+            continue
+        except ET.ParseError as e:
+            print(f"Error reading XML for {guest_name}: {e}", file=sys.stderr)
+            sys.exit(0)
+
+    print(f"Error reading XML for {guest_name}: file not found", file=sys.stderr)
+    sys.exit(0)
+
+def run_ethtool_commands(root, dry_run):
+    for interface in root.findall(".//interface"):
+        target = interface.find("target")
+        if target is not None and "dev" in target.attrib:
+            dev = target.attrib["dev"]
+            cmd = ["/sbin/ethtool", "-s", dev, "autoneg", "off", "speed", "1000", "duplex", "full"]
+            if dry_run:
+                print(f"Dry run: {' '.join(cmd)}")
+            else:
+                print(f"Running: {' '.join(cmd)}")
+                subprocess.run(cmd, check=True)
+
+def is_realtime_guest(root):
+    return root.find(".//cputune/vcpusched") is not None
+
+def find_qemu_pid(guest_name):
+    try:
+        output = subprocess.check_output(["ps", "axo", "pid,command"], text=True)
+        for line in output.splitlines():
+            if "qemu-" in line and f"guest={guest_name}," in line:
+                return int(line.strip().split()[0])
+    except subprocess.CalledProcessError:
+        pass
+    return None
+
+def find_qemu_pid_with_retry(guest_name, retries=10, delay=1):
+    count = 0
+    while count < retries:
+        pid = find_qemu_pid(guest_name)
+        if pid:
+            return pid
+        time.sleep(delay)
+        count += 1
+    print("No qemu process found", file=sys.stderr)
+    sys.exit(0)
+
+
+def find_vhost_pids(qemu_pid, retries=10, delay=1):
+    """
+    Finds TIDs of vhost threads belonging to a given QEMU PID.
+    Works with the new kernel behavior where vhost threads are
+    shown as threads inside the QEMU process.
+    """
+    for _ in range(retries):
+        task_dir = f"/proc/{qemu_pid}/task"
+        if os.path.isdir(task_dir):
+            vhost_tids = []
+            for tid in os.listdir(task_dir):
+                try:
+                    with open(f"{task_dir}/{tid}/comm") as f:
+                        if f.read().strip() == f"vhost-{qemu_pid}":
+                            vhost_tids.append(int(tid))
+                except FileNotFoundError:
+                    # Thread might have exited between listing and reading
+                    continue
+            if vhost_tids:
+                return vhost_tids
+        time.sleep(delay)
+    return []
+
+def get_affinity(pid):
+    try:
+        output = subprocess.check_output(["taskset", "-p", str(pid)], text=True)
+        return output.strip().split(":")[1].strip()
+    except subprocess.CalledProcessError:
+        return None
+
+def apply_realtime_settings(pid_list, affinity, dry_run):
+    for pid in pid_list:
+        print(f"{'Dry run' if dry_run else 'Running'}: taskset -p {affinity} {pid}")
+        print(f"{'Dry run' if dry_run else 'Running'}: chrt -p 1 {pid}")
+        if dry_run:
+            continue
+        subprocess.run(["taskset", "-p", affinity, str(pid)], check=True)
+        subprocess.run(["chrt", "-p", "1", str(pid)], check=True)
+
+def handle_kvm_pit(qemu_pid, affinity, dry_run):
+    try:
+        output = subprocess.check_output(["pgrep", f"kvm-pit/{qemu_pid}"], text=True)
+        for line in output.splitlines():
+            pid = int(line.strip())
+            print(f"{'Dry run' if dry_run else 'Running'}: taskset -p {affinity} {pid}")
+            print(f"{'Dry run' if dry_run else 'Running'}: chrt -p 1 {pid}")
+            if dry_run:
+                continue
+            subprocess.run(["taskset", "-p", affinity, str(pid)], check=True)
+            subprocess.run(["chrt", "-p", "1", str(pid)], check=True)
+    except subprocess.CalledProcessError:
+        pass
+
+def main():
+    print(f"Script called with: {' '.join(sys.argv)}")
+    _, guest_name, vm_action = parse_args()
+
+    if vm_action == "started":
+        dry_run = False
+    elif vm_action == "started-dry":
+        dry_run = True
+    else:
+        # For other actions do nothing
+        sys.exit(0)
+
+    root = parse_xml(guest_name)
+
+    if is_realtime_guest(root):
+        print(f"\nGuest {guest_name} is marked as realtime.")
+        qemu_pid = find_qemu_pid_with_retry(guest_name)
+        print(f"QEMU PID: {qemu_pid}")
+
+        vhost_pids = find_vhost_pids(qemu_pid)
+        if not vhost_pids:
+            print("No vhost-* threads found for QEMU.")
+            sys.exit(1)
+
+        affinity = get_affinity(qemu_pid)
+        if not affinity:
+            print("Could not get CPU affinity.", file=sys.stderr)
+            sys.exit(1)
+
+        apply_realtime_settings(vhost_pids, affinity, dry_run)
+        handle_kvm_pit(qemu_pid, affinity, dry_run)
+    else:
+        print(f"\nGuest {guest_name} is not realtime. Skipping vhost thread tuning.")
+
+    run_ethtool_commands(root, dry_run)
+
+if __name__ == "__main__":
+    main()

--- a/roles/configure_libvirt/handlers/main.yml
+++ b/roles/configure_libvirt/handlers/main.yml
@@ -1,0 +1,9 @@
+# Copyright (C) 2024-2025 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+
+- name: Restart libvirtd
+  ansible.builtin.systemd:
+    name: libvirtd
+    state: restarted

--- a/roles/configure_libvirt/molecule/default/converge.yml
+++ b/roles/configure_libvirt/molecule/default/converge.yml
@@ -1,0 +1,13 @@
+---
+- name: Converge default configuration
+  hosts: all
+  become: true
+  gather_facts: false
+
+  roles:
+    - role: configure_libvirt
+
+  handlers:
+    - name: Restart libvirtd
+      ansible.builtin.command: /usr/bin/true
+      changed_when: false

--- a/roles/configure_libvirt/molecule/default/molecule.yml
+++ b/roles/configure_libvirt/molecule/default/molecule.yml
@@ -1,0 +1,28 @@
+---
+dependency:
+  name: galaxy
+
+driver:
+  name: podman
+
+platforms:
+  - name: instance
+    image: docker.io/geerlingguy/docker-debian13-ansible:latest
+    privileged: true
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      roles_path: "${MOLECULE_PROJECT_DIRECTORY}/.."
+  playbooks:
+    prepare: prepare.yml
+    converge: converge.yml
+    verify: verify.yml
+  inventory:
+    host_vars:
+      instance:
+        seapath_distro: Debian
+
+verifier:
+  name: ansible

--- a/roles/configure_libvirt/molecule/default/prepare.yml
+++ b/roles/configure_libvirt/molecule/default/prepare.yml
@@ -1,0 +1,24 @@
+---
+- name: Prepare libvirt test environment
+  hosts: all
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Create libvirt configuration directory
+      ansible.builtin.file:
+        path: /etc/libvirt
+        state: directory
+        mode: "0755"
+
+    - name: Create qemu hook directory
+      ansible.builtin.file:
+        path: /etc/libvirt/hooks/qemu.d
+        state: directory
+        mode: "0755"
+
+    - name: Create qemu hook that disabled role configuration must remove
+      ansible.builtin.copy:
+        dest: /etc/libvirt/hooks/qemu.d/seapath_qemu_hook.py
+        content: stale hook\n
+        mode: "0755"

--- a/roles/configure_libvirt/molecule/default/verify.yml
+++ b/roles/configure_libvirt/molecule/default/verify.yml
@@ -1,0 +1,45 @@
+---
+- name: Verify default libvirt configuration
+  hosts: all
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Check libvirtd configuration
+      ansible.builtin.stat:
+        path: /etc/libvirt/libvirtd.conf
+      register: configure_libvirt_conf_stat
+
+    - name: Assert libvirtd configuration ownership and permissions
+      ansible.builtin.assert:
+        that:
+          - configure_libvirt_conf_stat.stat.exists
+          - configure_libvirt_conf_stat.stat.isreg
+          - configure_libvirt_conf_stat.stat.mode == "0644"
+          - configure_libvirt_conf_stat.stat.pw_name == "root"
+          - configure_libvirt_conf_stat.stat.gr_name == "root"
+
+    - name: Read libvirtd configuration
+      ansible.builtin.slurp:
+        path: /etc/libvirt/libvirtd.conf
+      register: configure_libvirt_conf
+
+    - name: Assert libvirtd configuration grants libvirt group access
+      ansible.builtin.assert:
+        that:
+          - "'listen_tls = 0' in (configure_libvirt_conf.content | b64decode)"
+          - "'listen_tcp = 0' in (configure_libvirt_conf.content | b64decode)"
+          - "'unix_sock_ro_perms = \"0770\"' in (configure_libvirt_conf.content | b64decode)"
+          - "'unix_sock_rw_perms = \"0770\"' in (configure_libvirt_conf.content | b64decode)"
+          - "'unix_sock_group = \"libvirt\"' in (configure_libvirt_conf.content | b64decode)"
+          - "'host_uuid = \"' ~ (inventory_hostname | to_uuid) ~ '\"' in (configure_libvirt_conf.content | b64decode)"
+
+    - name: Check disabled qemu hook is absent
+      ansible.builtin.stat:
+        path: /etc/libvirt/hooks/qemu.d/seapath_qemu_hook.py
+      register: configure_libvirt_qemu_hook
+
+    - name: Assert disabled qemu hook is absent
+      ansible.builtin.assert:
+        that:
+          - not configure_libvirt_qemu_hook.stat.exists

--- a/roles/configure_libvirt/molecule/qemu_hook/converge.yml
+++ b/roles/configure_libvirt/molecule/qemu_hook/converge.yml
@@ -1,0 +1,15 @@
+---
+- name: Converge qemu hook configuration
+  hosts: all
+  become: true
+  gather_facts: false
+
+  roles:
+    - role: configure_libvirt
+      vars:
+        configure_libvirt_deploy_seapath_qemu_hook: true
+
+  handlers:
+    - name: Restart libvirtd
+      ansible.builtin.command: /usr/bin/true
+      changed_when: false

--- a/roles/configure_libvirt/molecule/qemu_hook/molecule.yml
+++ b/roles/configure_libvirt/molecule/qemu_hook/molecule.yml
@@ -1,0 +1,28 @@
+---
+dependency:
+  name: galaxy
+
+driver:
+  name: podman
+
+platforms:
+  - name: instance
+    image: docker.io/geerlingguy/docker-debian13-ansible:latest
+    privileged: true
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      roles_path: "${MOLECULE_PROJECT_DIRECTORY}/.."
+  playbooks:
+    prepare: prepare.yml
+    converge: converge.yml
+    verify: verify.yml
+  inventory:
+    host_vars:
+      instance:
+        seapath_distro: Debian
+
+verifier:
+  name: ansible

--- a/roles/configure_libvirt/molecule/qemu_hook/prepare.yml
+++ b/roles/configure_libvirt/molecule/qemu_hook/prepare.yml
@@ -1,0 +1,12 @@
+---
+- name: Prepare libvirt test environment
+  hosts: all
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Create libvirt configuration directory
+      ansible.builtin.file:
+        path: /etc/libvirt
+        state: directory
+        mode: "0755"

--- a/roles/configure_libvirt/molecule/qemu_hook/verify.yml
+++ b/roles/configure_libvirt/molecule/qemu_hook/verify.yml
@@ -1,0 +1,45 @@
+---
+- name: Verify qemu hook configuration
+  hosts: all
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Check qemu hook directory
+      ansible.builtin.stat:
+        path: /etc/libvirt/hooks/qemu.d
+      register: configure_libvirt_qemu_hook_dir
+
+    - name: Assert qemu hook directory ownership and permissions
+      ansible.builtin.assert:
+        that:
+          - configure_libvirt_qemu_hook_dir.stat.exists
+          - configure_libvirt_qemu_hook_dir.stat.isdir
+          - configure_libvirt_qemu_hook_dir.stat.mode == "0755"
+          - configure_libvirt_qemu_hook_dir.stat.pw_name == "root"
+          - configure_libvirt_qemu_hook_dir.stat.gr_name == "root"
+
+    - name: Check qemu hook file
+      ansible.builtin.stat:
+        path: /etc/libvirt/hooks/qemu.d/seapath_qemu_hook.py
+      register: configure_libvirt_qemu_hook
+
+    - name: Assert qemu hook ownership and permissions
+      ansible.builtin.assert:
+        that:
+          - configure_libvirt_qemu_hook.stat.exists
+          - configure_libvirt_qemu_hook.stat.isreg
+          - configure_libvirt_qemu_hook.stat.mode == "0755"
+          - configure_libvirt_qemu_hook.stat.pw_name == "root"
+          - configure_libvirt_qemu_hook.stat.gr_name == "root"
+
+    - name: Read qemu hook file
+      ansible.builtin.slurp:
+        path: /etc/libvirt/hooks/qemu.d/seapath_qemu_hook.py
+      register: configure_libvirt_qemu_hook_content
+
+    - name: Assert deployed qemu hook content
+      ansible.builtin.assert:
+        that:
+          - "(configure_libvirt_qemu_hook_content.content | b64decode).startswith('#!/usr/bin/env python3')"
+          - "'def main():' in (configure_libvirt_qemu_hook_content.content | b64decode)"

--- a/roles/configure_libvirt/tasks/main.yml
+++ b/roles/configure_libvirt/tasks/main.yml
@@ -41,6 +41,7 @@
     mode: '0755'
     owner: root
     group: root
+  when: configure_libvirt_deploy_seapath_qemu_hook
   notify: Restart libvirtd
 
 - name: Copy qemu_hook.py to libvirt qemu hook
@@ -50,4 +51,12 @@
     mode: '0755'
     owner: root
     group: root
+  when: configure_libvirt_deploy_seapath_qemu_hook
+  notify: Restart libvirtd
+
+- name: Remove seapath qemu hook when disabled
+  ansible.builtin.file:
+    path: /etc/libvirt/hooks/qemu.d/seapath_qemu_hook.py
+    state: absent
+  when: not configure_libvirt_deploy_seapath_qemu_hook
   notify: Restart libvirtd

--- a/roles/configure_libvirt/tasks/main.yml
+++ b/roles/configure_libvirt/tasks/main.yml
@@ -40,3 +40,21 @@
     state: started
     enabled: true
   when: seapath_distro == "OracleLinux"
+
+- name: Ensure libvirt hooks/qemu.d directory exists
+  ansible.builtin.file:
+    path: /etc/libvirt/hooks/qemu.d/
+    state: directory
+    mode: '0755'
+    owner: root
+    group: root
+  notify: Restart libvirtd
+
+- name: Copy qemu_hook.py to libvirt qemu hook
+  ansible.builtin.copy:
+    src: qemu_hook.py
+    dest: /etc/libvirt/hooks/qemu
+    mode: '0755'
+    owner: root
+    group: root
+  notify: Restart libvirtd

--- a/roles/configure_libvirt/tasks/main.yml
+++ b/roles/configure_libvirt/tasks/main.yml
@@ -12,14 +12,7 @@
     mode: "0644"
   when:
     - configure_libvirt_allow_non_root_libvirt_socket_access
-  register: configure_libvirt_libvirtd_conf
-
-# Restart libvirtd if configuration changed
-- name: Restart libvirtd
-  ansible.builtin.systemd:
-    name: libvirtd
-    state: restarted
-  when: configure_libvirt_libvirtd_conf.changed # noqa: no-handler
+  notify: Restart libvirtd
 
 # OracleLinux specific
 - name: Enable and start virtsecretd.socket
@@ -53,7 +46,7 @@
 - name: Copy qemu_hook.py to libvirt qemu hook
   ansible.builtin.copy:
     src: qemu_hook.py
-    dest: /etc/libvirt/hooks/qemu
+    dest: /etc/libvirt/hooks/qemu.d/seapath_qemu_hook.py
     mode: '0755'
     owner: root
     group: root


### PR DESCRIPTION
This hook will run tasks that needs to be run everytime a guest is started:
 - parse the guest xml
 - override the network speed of all declared network interfaces to 1Gb (instead of the default 10Mb that make all supervision software believe they use more than 100%)
 - set all vhost- threads to RR1 if guest is realtime (= use vcpusched)
 - set cpu affinity of those threads to the same as main qemu thread if guest is realtime