### PR TITLE
Align variables and documentation for sriov pool creation

### DIFF
--- a/roles/network_sriovpool/README.md
+++ b/roles/network_sriovpool/README.md
@@ -8,10 +8,10 @@ No requirement.
 
 ## Role Variables
 
-| Variable                | Required  | Type   | Comments                                  |
-|-------------------------|-----------|--------|-------------------------------------------|
-| sriov_network_pool_name | Yes       | String | Name of the libvirt SR-IOV pool           |
-| interface               | Yes       | String | Network interface to use for SR-IOV setup |
+| Variable                                  | Required  | Type   | Comments                                  |
+|-------------------------------------------|-----------|--------|-------------------------------------------|
+| network_sriovpool_sriov_network_pool_name | Yes       | String | Name of the libvirt SR-IOV pool           |
+| network_sriovpool_interface               | Yes       | String | Network interface to use for SR-IOV setup |
 
 ## Example Playbook
 

--- a/roles/network_sriovpool/tasks/main.yml
+++ b/roles/network_sriovpool/tasks/main.yml
@@ -3,10 +3,10 @@
 
 ---
 - debug:
-    msg: "the network pool name is {{ sriov_network_pool_name }}"
+    msg: "the network pool name is {{ network_sriovpool_sriov_network_pool_name }}"
 - name: Try to get sriov network pool
   shell:
-    cmd: set -o pipefail && virsh -q net-list --all | awk '{ print $1 }' | grep -q "{{ sriov_network_pool_name }}"
+    cmd: set -o pipefail && virsh -q net-list --all | awk '{ print $1 }' | grep -q "{{ network_sriovpool_sriov_network_pool_name }}"
     executable: /bin/bash
   register: pool_defined
   failed_when: pool_defined.rc > 1
@@ -21,10 +21,10 @@
       command: "virsh net-define /tmp/sriov_network_pool.xml"
       changed_when: true
     - name: AutoStart libvirt SRIOV network pool
-      command: "virsh net-autostart {{ sriov_network_pool_name }}"
+      command: "virsh net-autostart {{ network_sriovpool_sriov_network_pool_name }}"
       changed_when: true
     - name: Start libvirt SRIOV network pool
-      command: "virsh net-start {{ sriov_network_pool_name }}"
+      command: "virsh net-start {{ network_sriovpool_sriov_network_pool_name }}"
       changed_when: true
     - name: Remove temporary file
       file:


### PR DESCRIPTION
Variable names used in the tasks .yml file and the readme were misaligned with the variables actually supplied