### PR TITLE
Fix several issues for Welotec hardware customizations

### DIFF
--- a/roles/hardware_customization_welotec/tasks/main.yaml
+++ b/roles/hardware_customization_welotec/tasks/main.yaml
@@ -38,4 +38,5 @@
     name: systemd_networkd
   vars:
     systemd_networkd_link: "{{ hardware_customization_welotec_systemd_networkd_link }}"
+    systemd_networkd_network: "{{ hardware_customization_welotec_systemd_networkd_network }}"
     systemd_networkd_apply_config: "{{ apply_network_config | default(false) }}"

--- a/roles/hardware_customization_welotec/vars/network_link.yaml
+++ b/roles/hardware_customization_welotec/vars/network_link.yaml
@@ -78,10 +78,16 @@ hardware_customization_welotec_systemd_networkd_link:
         - Name: "lan8"
   20_lan_prp:
       - Match:
-          - Name: "lan_prp"
+          - Name: "lan_hsr-prp"
           - Driver: "igb"
           - PermanentMACAddress: "{{ mac_address_map['lan_hsr-prp'] }}"
       - Link:
           - NamePolicy:
           - AlternativeNamesPolicy:
           - Name: "lan_hsr-prp"
+hardware_customization_welotec_systemd_networkd_network:
+  20_lan_prp:
+      - Match:
+          - Name: "lan_hsr-prp"
+      - Network:
+          - KeepConfiguration: static


### PR DESCRIPTION
Hi,

During our tests there were several issues while running the `seapath_setup_custom_hardware.yaml` playbook:
* The `Gather PRP-HSR interfaces MAC addresses` failed because the MAC address is using lowercase letters and not uppercase letters as used with the `grep`.
* The `systemd_networkd_link` var was missing the double quotes and curly brackets around the `hardware_customization_welotec_networkd_link` variable in the `Apply config` task
* The driver used by the PRP-HSR interface is `igb` not `igc`