### PR TITLE
prepare: bump cockpit plugins to 1.2.0

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -64,6 +64,6 @@ find src/ceph-ansible-patches -type f -name "*.diff" -exec git -C ceph-ansible \
 echo "Fetch Cockpit plugins"
 mkdir -p roles/deploy_cockpit_plugins/files
 curl -L -o roles/deploy_cockpit_plugins/files/cockpit-cluster-dashboard.tar.gz \
-    https://github.com/seapath/cockpit-cluster-dashboard/releases/download/v1.1.0/cockpit-cluster-dashboard.tar.gz
+    https://github.com/seapath/cockpit-cluster-dashboard/releases/download/v1.2.0/cockpit-cluster-dashboard.tar.gz
 curl -L -o roles/deploy_cockpit_plugins/files/cockpit-cluster-vm-management.tar.gz \
-    https://github.com/seapath/cockpit-cluster-vm-management/releases/download/v1.1.0/cockpit-cluster-vm-management.tar.gz
+    https://github.com/seapath/cockpit-cluster-vm-management/releases/download/v1.2.0/cockpit-cluster-vm-management.tar.gz


### PR DESCRIPTION
Update the prepare.sh script to fetch version 1.2.0 of the cockpit-cluster-dashboard and cockpit-cluster-vm-management plugins.