### PR TITLE
roles/yocto: add SR-IOV configuration

### DIFF
--- a/README-ansible-galaxy.md
+++ b/README-ansible-galaxy.md
@@ -105,7 +105,7 @@ Note: For the Yocto based SEAPATH, this configuration is done at build time
 ## Utility roles
 
 - `update`: Update a SEAPATH machine (Yocto only)
-- `yocto`: Specify additional kernel parameters (Yocto only)
+- `yocto`: Specify additional kernel parameters and SR-IOV configuration (Yocto only)
 - `debian_grub_bootcount`: Setup a rollback system in GRUB (Debian only)
 - `deploy_cukinia`: Deploy the testing system on a Debian machine (Debian only)
 - `debian_tests`: Launch the system tests on a Debian machine (Debian only)

--- a/playbooks/seapath_setup_prerequisyocto.yaml
+++ b/playbooks/seapath_setup_prerequisyocto.yaml
@@ -1,5 +1,5 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
-# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# Copyright (C) 2024-2025 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # This Ansible playbook configures a SEAPATH machine.
@@ -18,6 +18,12 @@
   become: true
   roles:
     - yocto/hugepages
+
+- name: Configure SR-IOV
+  hosts: hypervisors
+  become: true
+  roles:
+    - yocto/sriov
 
 - name: Upload extra files
   hosts:
@@ -55,4 +61,3 @@
         - skip_ansible_lint
       loop: "{{ commands_to_run_after_upload }}"
       when: commands_to_run_after_upload is defined
-

--- a/roles/yocto/README.md
+++ b/roles/yocto/README.md
@@ -13,6 +13,8 @@ No requirement.
 | extra_kernel_parameters   | extra_kernel_parameters   | No       | String  |         | Extra kernel parameter to set             |
 | kernel_parameters_restart | kernel_parameters_restart | No       | Bool    | false   | Restart after the kernel parameter update |
 | yocto_hugepages           | hugepages                 | No       | Integer | 0       | One GB hugepages to allocate              |
+| sriov                     | List of dict | List of network interfaces to configure for SR-IOV use. Dictionary list: `{ interface_name: number_of_interface_to_create }`             |
+
 
 ## Example Playbook
 

--- a/roles/yocto/sriov/handlers/main.yaml
+++ b/roles/yocto/sriov/handlers/main.yaml
@@ -1,0 +1,8 @@
+# Copyright (C) 2025 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+- name: Restart sriov-configure.service
+  ansible.builtin.systemd:
+    name: sriov-configure.service
+    state: restarted
+    enabled: true

--- a/roles/yocto/sriov/tasks/main.yaml
+++ b/roles/yocto/sriov/tasks/main.yaml
@@ -1,0 +1,14 @@
+# Copyright (C) 2025 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# This role configures SR-IOV.
+
+
+---
+- name: Add sriov sysfs rules
+  template:
+    src: sriov-configure.service.j2
+    dest: /etc/systemd/system/sriov-configure.service
+    mode: '0644'
+  when: sriov is defined
+  notify: Restart sriov-configure.service

--- a/roles/yocto/sriov/templates/sriov-configure.service.j2
+++ b/roles/yocto/sriov/templates/sriov-configure.service.j2
@@ -1,0 +1,13 @@
+[Unit]
+Description=Configure SR-IOV Virtual Functions
+After=network-pre.target
+Wants=network-pre.target
+
+[Service]
+Type=oneshot
+{% for device in sriov | dict2items %}
+ExecStart=/bin/sh -c 'echo {{ device.value }} > /sys/class/net/{{ device.key }}/device/sriov_numvfs'
+{% endfor %}
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The SR-IOV configuration was missing on Yocto. This commit adds a new role to configure SR-IOV on hypervisors.

There is no /etc/sysfs.d directory on Yocto, and the tempdir.d approach use on CentOS does not work either, so we create a systemd service to configure SR-IOV on boot.