### PR TITLE
Removed duplicate task from role network_systemdnetworkd

### DIFF
--- a/roles/network_systemdnetworkd/tasks/main.yml
+++ b/roles/network_systemdnetworkd/tasks/main.yml
@@ -14,9 +14,6 @@
 - name: Gather service facts to detect udev service
   ansible.builtin.service_facts:
 
-- name: Gather service facts to detect udev service
-  ansible.builtin.service_facts:
-
 - name: Check if systemd-udev-trigger is present
   ansible.builtin.set_fact:
     network_systemdnetworkd_service_name_udev: systemd-udev-trigger


### PR DESCRIPTION
Removed duplicate invocation of ansible.builtin.service_facts in the tasks of role network_systemdnetworkd to fix https://github.com/seapath/ansible/issues/852

Best regards, 
Daniel