### PR TITLE
Fixed result type of "when" conditions.

### DIFF
--- a/roles/detect_seapath_distro/tasks/main.yaml
+++ b/roles/detect_seapath_distro/tasks/main.yaml
@@ -18,17 +18,17 @@
 - name: Detect Debian distribution
   set_fact:
     detect_seapath_distro_distro: Debian
-  when: ansible_distribution | regex_search("Debian")
+  when: ansible_distribution | regex_search("Debian") != None
 
 - name: Detect Centos distribution
   set_fact:
     detect_seapath_distro_distro: CentOS
-  when: ansible_distribution | regex_search("CentOS|RedHat")
+  when: ansible_distribution | regex_search("CentOS|RedHat") != None
 
 - name: Detect OracleLinux distribution
   set_fact:
     detect_seapath_distro_distro: OracleLinux
-  when: ansible_distribution | regex_search("Oracle")
+  when: ansible_distribution | regex_search("Oracle") != None
 
 - name: Show detect_seapath_distro_distro
   debug:

--- a/roles/network_systemdnetworkd/tasks/main.yml
+++ b/roles/network_systemdnetworkd/tasks/main.yml
@@ -22,10 +22,15 @@
 - import_tasks: profiles.yml
 
 - name: Enable systemd-networkd
-  service:
+  ansible.builtin.service:
     name: systemd-networkd
-    enabled: yes
-  when: network_systemdnetworkd_network or network_systemdnetworkd_link or network_systemdnetworkd_netdev
+    enabled: true
+  when: >
+    network_systemdnetworkd_network is defined and network_systemdnetworkd_network | length > 0
+    or
+    network_systemdnetworkd_link is defined and network_systemdnetworkd_link | length > 0
+    or
+    network_systemdnetworkd_netdev is defined and network_systemdnetworkd_netdev | length > 0
 
 - name: Start and enable systemd-resolved
   service:


### PR DESCRIPTION
The "when" condition in tasks of role network_systemdnetworkd and detect_seapath_distro returned values which could be evaluated to a boolean but were no real booleans and thus rejected by Ansible (2.19.4). 
OS: Debian Trixie (6.12.63-1 (2025-12-30) x86_64)

Best regards, 
Daniel