### PR TITLE
inventories/examples/seapath-cluster: disable rbd pg autoscaling

### DIFF
--- a/inventories/examples/seapath-cluster.yaml
+++ b/inventories/examples/seapath-cluster.yaml
@@ -142,8 +142,10 @@ clients:
     rbd:
       name: "rbd"
       application: "rbd"
-      pg_autoscale_mode: on
-      target_size_ratio: 1
+      pg_autoscale_mode: off
+      pg_num: 128
+      pgp_num: 128
+
     pools:
       - "{{ rbd }}"
     keys:


### PR DESCRIPTION
For an unclear reason, enabling pg autoscaling on the rbd pool causes the following error with Ceph 18 when creating the Ceph pool:

'pgp_num' must be greater than 0 and lower or equal than 'pg_num', which in this case is 1".

It seems that pg autoscaling failed to calcule the correct pg_num.

To avoid this issue, we disable pg autoscaling on the rbd pool and set pg_num and pgp_num to 128 (the default value).