### PR TITLE
feat: add registry role for disconnected deployment

### DIFF
--- a/.cqfdrc
+++ b/.cqfdrc
@@ -1,10 +1,15 @@
 [project]
 org='seapath'
 name='ansible'
-flavors='prepare manual module_documentation lint format export'
+flavors='prepare pull_ceph_container manual module_documentation lint format export'
 
 [build]
 command='check_yaml && ansible-lint -c ansible-lint.conf'
+
+[pull_ceph_container]
+command="mkdir -p files && \
+         podman pull quay.io/ceph/ceph:v20.2.0 && \
+         podman save -o files/ceph-v20.2.0.tar quay.io/ceph/ceph:v20.2.0"
 
 [prepare]
 command='./prepare.sh'

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ playbooks/*
 !playbooks/deploy_*.yaml
 !playbooks/seapath_setup_*.yaml
 !playbooks/purge_ceph.yaml
+!playbooks/purge_ceph_cephadm.yaml
 !playbooks/seapath_update_*.yaml
 !playbooks/molecule/
 inventories/*

--- a/inventories/examples/seapath-cluster.yaml
+++ b/inventories/examples/seapath-cluster.yaml
@@ -90,14 +90,21 @@ cluster_machines:
       br_rstp_priority: 12288 # Do not modify, used by RSTP
 
 # Ceph monitor. All machines in the cluster must be part of mons groups
-# Note : By default SEAPATH uses ceph-ansible to configure Ceph.
-# You can also switch to cephadm deployment by setting force_cephadm to true (Only available on Debian for now)
+# Note : By default SEAPATH uses cephadm to configure Ceph.
+# You can also switch to ceph-ansible deployment by setting force_cephadm to false
 mons:
   hosts:
     node1:
     node2:
     node3:
   vars:
+    # Registry for ceph container image on ansible machine
+    # You can remove thoses two variables if you are on Debian. It will fallback to ceph image embedded in SEAPATH Debian iso.
+    container_registry_url: "192.168.200.100" # IP address of the ansible machine. TODO
+    podman_registry_mirror_url: "{{ container_registry_url }}"
+
+    # Ceph configuration
+    force_cephadm: true
     ceph_origin: distro
     cluster_network: "192.168.55.0/24" # IP range of your cluster. TODO
     public_network: "{{ cluster_network }}"

--- a/inventories/examples/seapath-cluster.yaml
+++ b/inventories/examples/seapath-cluster.yaml
@@ -48,7 +48,6 @@ all:
     ansible_remote_tmp: /tmp/.ansible/tmp
     ansible_user: ansible
     ip_addr: "{{ ansible_host }}"
-    hostname: "{{ inventory_hostname }}"
     apply_network_config: true
 
 # Three hypervisors setup. All machines are part of the hypervisor group.
@@ -107,6 +106,9 @@ mons:
     force_cephadm: true
     ceph_origin: distro
     cluster_network: "192.168.55.0/24" # IP range of your cluster. TODO
+    cephadm_network: "{{ cluster_network }}"
+    cephadm_hostname: "{{ inventory_hostname }}"
+    cephadm_ip_addr: "{{ cluster_ip_addr }}"
     public_network: "{{ cluster_network }}"
     monitor_address: "{{ cluster_ip_addr }}"
     configure_firewall: false

--- a/playbooks/cluster_setup_cephadm.yaml
+++ b/playbooks/cluster_setup_cephadm.yaml
@@ -32,6 +32,8 @@
 - name: Cephadm
   hosts: cluster_machines
   become: true
+  vars:
+    cephadm_use_localhost_registry: "{{ container_registry_url is not defined or container_registry_url is none }}"
   roles:
     - detect_seapath_distro
     - cephadm

--- a/playbooks/purge_ceph_cephadm.yaml
+++ b/playbooks/purge_ceph_cephadm.yaml
@@ -1,0 +1,60 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Remove the Cephadm-managed Ceph configuration on the cluster
+
+# This playbook is intended to be used if Cephadm configuration fails during cluster setup
+# Using it on a fully configured cluster destroys all Ceph data
+
+---
+- name: Purge Cephadm cluster from all hosts
+  hosts: cluster_machines
+  become: true
+  tasks:
+    - name: Find cephadm location
+      ansible.builtin.command: which cephadm
+      register: cephadm_path
+      failed_when: false
+      changed_when: false
+      environment:
+        PATH: "{{ ansible_env.PATH }}:/usr/local/bin"
+
+    - name: Set cephadm binary path
+      ansible.builtin.set_fact:
+        cephadm_bin: "{{ cephadm_path.stdout if cephadm_path.rc == 0 else '/usr/local/bin/cephadm' }}"
+
+    - name: Get cluster FSID
+      ansible.builtin.command: ceph fsid
+      register: cephadm_purge_fsid
+      changed_when: false
+
+    - name: Store cluster FSID
+      ansible.builtin.set_fact:
+        cephadm_purge_cluster_fsid: "{{ cephadm_purge_fsid.stdout | trim }}"
+
+    - name: Disable cephadm manager module
+      ansible.builtin.command: ceph mgr module disable cephadm
+      changed_when: true
+
+    - name: Purge Cephadm cluster data
+      ansible.builtin.command: >-
+        {{ cephadm_bin }} rm-cluster --force --zap-osds
+        --fsid {{ cephadm_purge_cluster_fsid }}
+      changed_when: true
+
+- name: Re-create Ceph folders
+  hosts: cluster_machines
+  become: true
+  tasks:
+    - name: Re-create Ceph folders
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+      loop:
+        - /etc/ceph
+        - /var/lib/ceph
+        - /var/run/ceph
+        - /var/log/ceph

--- a/playbooks/seapath_setup_main.yaml
+++ b/playbooks/seapath_setup_main.yaml
@@ -1,6 +1,6 @@
 # Copyright (C) 2024 Red Hat, Inc.
 # Copyright (C) 2021-2024, RTE (http://www.rte-france.com)
-# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # This playbook setup SEAPATH on both debian and CentOS machines
@@ -50,11 +50,14 @@
 - name: Import seapath_setup_snmp playbook
   import_playbook: seapath_setup_snmp.yaml
 
+- name: Import seapath_setup_podman_registry_mirror playbook
+  import_playbook: seapath_setup_podman_registry_mirror.yaml
+
 - name: Import cluster_setup_ceph playbook
   import_playbook: cluster_setup_ceph.yaml
   when: not is_using_cephadm | bool
 
-- name: Import cluster_setup_cephdm playbook
+- name: Import cluster_setup_cephadm playbook
   import_playbook: cluster_setup_cephadm.yaml
   when: is_using_cephadm | bool
 

--- a/playbooks/seapath_setup_podman_registry_mirror.yaml
+++ b/playbooks/seapath_setup_podman_registry_mirror.yaml
@@ -1,0 +1,14 @@
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Setup registry mirroring on cluster machines
+  hosts:
+    - cluster_machines
+    - standalone_machine
+  become: true
+  roles:
+    - role: podman_registry_mirror
+      when:
+        - podman_registry_mirror_url is defined
+        - podman_registry_mirror_url is not none

--- a/roles/ceph_expansion_lv/tasks/main.yml
+++ b/roles/ceph_expansion_lv/tasks/main.yml
@@ -44,7 +44,7 @@
         ceph_expansion_lv_osdid: "{{ item.key | regex_search('@(osd\\.[0-9]+)\\.service', '\\1') | list | first }}"
         ceph_expansion_lv_osdid_number: "{{ ((item.key | regex_search('@(osd\\.[0-9]+)\\.service', '\\1') | list).0).split('.')[-1] }}"
       loop: "{{ ansible_facts.services | dict2items }}"
-      when: "'osd' in item.key"
+      when: "'@osd' in item.key"
       loop_control:
         label: "{{ item.key }}"
     - name: Show result

--- a/roles/cephadm/README.md
+++ b/roles/cephadm/README.md
@@ -22,13 +22,8 @@ no requirement.
 | cephadm_spec_path              | No       | String | spec.yaml.j2 | Path to the spec file of cephadm. Use it to override the default config               |
 | cephadm_network                | Yes      | String |              | Ceph network (e.g. "192.168.55.0/24")                                                 |
 | cephadm_use_localhost_registry | No       | Bool   | false        | When true, use localhost registry (`localhost:5000`) for ceph image pull.             |
-
-Note that for each node you want in the cluster, those host vars need to be defined:
-
-| Variable               | Required | Type   | Comments                                                                              |
-|------------------------|----------|--------|---------------------------------------------------------------------------------------|
-| hostname               | Yes      | String | The hostname of the machine. Can be fallback to "inventory_hostname" in the inventory |
-| cluster_ip_addr        | Yes      | String | IP address of the machine on the cluster network                                      |
+| cephadm_hostname               | Yes      | String |              | The hostname of the machine. Typically set to `"{{ hostname }}"` in the inventory     |
+| cephadm_ip_addr                | Yes      | String |              | IP address of the machine on the cluster network. Typically set to `"{{ cluster_ip_addr }}"` in the inventory |
 
 More information about ceph networks on [ceph documentation](https://docs.ceph.com/en/latest/rados/configuration/network-config-ref/).
 

--- a/roles/cephadm/README.md
+++ b/roles/cephadm/README.md
@@ -8,19 +8,20 @@ no requirement.
 
 ## Role Variables
 
-| Variable               | Required | Type   | Default      | Comments                                                                              |
-|------------------------|----------|--------|--------------|---------------------------------------------------------------------------------------|
-| seapath_distro         | No       | String | Not set      | SEAPATH distribution                                                                  |
-| cephadm_release        | No       | String | "20.2.0"     | Version of the cephadm binary to install                                              |
-| cephadm_release_name   | No       | String | "tentacle"   | Name of the ceph release, needed for repo installation                                |
-| cephadm_downloadbinary | No       | String | false        | whether we install the cephadm by downloading it to /tmp/cephadm                      |
-| cephadm_installbinary  | No       | String | false        | whether we install the cephadm binary by copying from /tmp/cephadm to /usr/local/bin  |
-| cephadm_installrepo    | No       | String | false        | whether we install the cephadm package with "cephadm add-repo"                        |
-| cephadm_installpackage | No       | String | false        | whether we install the cephadm package with "cephadm install"                         |
-| cephadm_installcommon  | No       | String | false        | whether we install the ceph-common package with "cephadm install ceph-common"         |
-| cephadm_pullimages     | No       | String | false        | whether we pull the needed container images                                           |
-| cephadm_spec_path      | No       | String | spec.yaml.j2 | Path to the spec file of cephadm. Use it to override the default config               |
-| cephadm_network        | Yes      | String |              | Ceph network (e.g. "192.168.55.0/24")                                                 |
+| Variable                       | Required | Type   | Default      | Comments                                                                              |
+|--------------------------------|----------|--------|--------------|---------------------------------------------------------------------------------------|
+| seapath_distro                 | No       | String | Not set      | SEAPATH distribution                                                                  |
+| cephadm_release                | No       | String | "20.2.0"     | Version of the cephadm binary to install                                              |
+| cephadm_release_name           | No       | String | "tentacle"   | Name of the ceph release, needed for repo installation                                |
+| cephadm_downloadbinary         | No       | String | false        | whether we install the cephadm by downloading it to /tmp/cephadm                      |
+| cephadm_installbinary          | No       | String | false        | whether we install the cephadm binary by copying from /tmp/cephadm to /usr/local/bin  |
+| cephadm_installrepo            | No       | String | false        | whether we install the cephadm package with "cephadm add-repo"                        |
+| cephadm_installpackage         | No       | String | false        | whether we install the cephadm package with "cephadm install"                         |
+| cephadm_installcommon          | No       | String | false        | whether we install the ceph-common package with "cephadm install ceph-common"         |
+| cephadm_pullimages             | No       | String | false        | whether we pull the needed container images                                           |
+| cephadm_spec_path              | No       | String | spec.yaml.j2 | Path to the spec file of cephadm. Use it to override the default config               |
+| cephadm_network                | Yes      | String |              | Ceph network (e.g. "192.168.55.0/24")                                                 |
+| cephadm_use_localhost_registry | No       | Bool   | false        | When true, use localhost registry (`localhost:5000`) for ceph image pull.             |
 
 Note that for each node you want in the cluster, those host vars need to be defined:
 

--- a/roles/cephadm/defaults/main.yml
+++ b/roles/cephadm/defaults/main.yml
@@ -1,4 +1,5 @@
 # Copyright (C) 2025 RTE
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 ---
@@ -9,3 +10,6 @@ cephadm_installbinary: false
 cephadm_installrepo: false
 cephadm_installcommon: false
 cephadm_pullimages: false
+
+# Registry configuration
+cephadm_use_localhost_registry: false

--- a/roles/cephadm/defaults/main.yml
+++ b/roles/cephadm/defaults/main.yml
@@ -10,6 +10,8 @@ cephadm_installbinary: false
 cephadm_installrepo: false
 cephadm_installcommon: false
 cephadm_pullimages: false
+cephadm_hostname:
+cephadm_ip_addr:
 
 # Registry configuration
 cephadm_use_localhost_registry: false

--- a/roles/cephadm/tasks/local_registry_mirroring.yml
+++ b/roles/cephadm/tasks/local_registry_mirroring.yml
@@ -1,0 +1,52 @@
+# Copyright (C) 2025 RTE
+# Copyright (C) 2026 Savoir-faire Linux Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Ensure insecure registry localhost:5000 is in /etc/containers/registries.conf
+  ansible.builtin.blockinfile:
+    path: /etc/containers/registries.conf
+    marker: "# {mark} ANSIBLE MANAGED BLOCK for insecure registries"
+    block: |
+      [[registry]]
+      insecure = true
+      location = "localhost"
+
+- name: Ensure /var/lib/registry exists
+  ansible.builtin.file:
+    path: /var/lib/registry
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Pull needed Docker images
+  containers.podman.podman_image:
+    name: "{{ item }}"
+  when: cephadm_pullimages
+  loop:
+    - "docker.io/library/registry:2"
+    - "quay.io/ceph/ceph:v{{ cephadm_release }}"
+
+- name: Run local container registry using Podman
+  containers.podman.podman_container:
+    name: registry
+    image: registry:2
+    state: started
+    detach: true
+    privileged: true
+    ports:
+      - "5000:5000"
+    volume:
+      - /var/lib/registry:/var/lib/registry
+    restart_policy: always
+
+- name: Tag ceph image for local registry
+  ansible.builtin.command: >
+    podman tag quay.io/ceph/ceph:v{{ cephadm_release }} localhost:5000/ceph:v{{ cephadm_release }}
+  changed_when: true
+
+- name: Push ceph image to local registry
+  ansible.builtin.command: >
+    podman push localhost:5000/ceph:v{{ cephadm_release }}
+  changed_when: true

--- a/roles/cephadm/tasks/local_registry_mirroring.yml
+++ b/roles/cephadm/tasks/local_registry_mirroring.yml
@@ -41,12 +41,8 @@
       - /var/lib/registry:/var/lib/registry
     restart_policy: always
 
-- name: Tag ceph image for local registry
-  ansible.builtin.command: >
-    podman tag quay.io/ceph/ceph:v{{ cephadm_release }} localhost:5000/ceph:v{{ cephadm_release }}
-  changed_when: true
-
 - name: Push ceph image to local registry
-  ansible.builtin.command: >
-    podman push localhost:5000/ceph:v{{ cephadm_release }}
-  changed_when: true
+  containers.podman.podman_image:
+    name: quay.io/ceph/ceph:v{{ cephadm_release }}
+    push: true
+    push_args: localhost:5000/ceph:v{{ cephadm_release }}

--- a/roles/cephadm/tasks/main.yml
+++ b/roles/cephadm/tasks/main.yml
@@ -165,7 +165,7 @@
       --skip-firewalld
       --config /tmp/ceph.conf
       --ssh-user cephadm
-      --mon-ip {{ hostvars[cephadm_first_node]['cluster_ip_addr'] }}
+      --mon-ip {{ hostvars[cephadm_first_node]['cephadm_ip_addr'] }}
 
 - name: Bootstrap Ceph cluster
   ansible.builtin.command: >-
@@ -177,7 +177,7 @@
     --skip-firewalld
     --config /tmp/ceph.conf
     --ssh-user cephadm
-    --mon-ip {{ hostvars[cephadm_first_node]['cluster_ip_addr'] }}
+    --mon-ip {{ hostvars[cephadm_first_node]['cephadm_ip_addr'] }}
   changed_when: true
   failed_when: false
   run_once: true
@@ -242,7 +242,7 @@
 
 # === adding monitor on other nodes ===
 - name: Add hosts to Ceph orchestrator with _admin label
-  ansible.builtin.command: "ceph orch host add {{ hostvars[item]['hostname'] }} --labels _admin"
+  ansible.builtin.command: "ceph orch host add {{ hostvars[item]['cephadm_hostname'] }} --labels _admin"
   loop: "{{ cephadm_mon_nodes_to_add }}"
   changed_when: true
   failed_when: false
@@ -258,7 +258,7 @@
   changed_when: false
   run_once: true
   delegate_to: "{{ cephadm_first_node }}"
-  until: "hostvars[item]['hostname'] in cephadm_mon_dump.stdout"
+  until: "hostvars[item]['cephadm_hostname'] in cephadm_mon_dump.stdout"
   loop: "{{ cephadm_mon_nodes_to_add }}"
   when: cephadm_mon_nodes_to_add | length > 0
 
@@ -279,7 +279,7 @@
   run_once: true
 - name: Set list of nodes that need OSDs
   ansible.builtin.set_fact:
-    cephadm_nodes_needing_osds: "{{ groups['hypervisors'] | intersect(groups['cluster_machines']) | map('extract', hostvars, 'hostname') | difference(cephadm_existing_osd_hosts) }}"
+    cephadm_nodes_needing_osds: "{{ groups['hypervisors'] | intersect(groups['cluster_machines']) | map('extract', hostvars, 'cephadm_hostname') | difference(cephadm_existing_osd_hosts) }}"
   run_once: true
 - name: Debug nodes needing OSDs
   ansible.builtin.debug:
@@ -290,7 +290,7 @@
   ansible.builtin.command: "{{ cephadm_bin }} --image {{ cephadm_registry }}/ceph:v{{ cephadm_release }} ceph-volume lvm zap vg_ceph/lv_ceph"
   delegate_to: "{{ item }}"
   run_once: true
-  when: hostvars[item]['hostname'] in cephadm_nodes_needing_osds
+  when: hostvars[item]['cephadm_hostname'] in cephadm_nodes_needing_osds
   loop: "{{ groups['hypervisors'] | intersect(groups['cluster_machines']) }}"
   changed_when: true
 

--- a/roles/cephadm/tasks/main.yml
+++ b/roles/cephadm/tasks/main.yml
@@ -1,7 +1,11 @@
 # Copyright (C) 2025 RTE
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 ---
+- name: Verify role variables are valid
+  ansible.builtin.import_tasks: validate.yml
+
 - name: Load distribution-specific variables
   ansible.builtin.include_vars: "{{ seapath_distro }}.yml"
 - name: Ensure group "cephadm" exists
@@ -120,53 +124,14 @@
       nonceph_nodes = {{ groups['nonceph_nodes'] | default([]) }}
   run_once: true
 
-- name: Ensure insecure registry localhost:5000 is in /etc/containers/registries.conf
-  ansible.builtin.blockinfile:
-    path: /etc/containers/registries.conf
-    marker: "# {mark} ANSIBLE MANAGED BLOCK for insecure registries"
-    block: |
-      [[registry]]
-      insecure = true
-      location = "localhost"
+- name: Configure localhost podman registry mirroring
+  ansible.builtin.import_tasks: local_registry_mirroring.yml
+  when: cephadm_use_localhost_registry | bool
 
-- name: Ensure /var/lib/registry exists
-  ansible.builtin.file:
-    path: /var/lib/registry
-    state: directory
-    owner: root
-    group: root
-    mode: "0755"
-
-- name: Pull needed Docker images
-  containers.podman.podman_image:
-    name: "{{ item }}"
-  when: cephadm_pullimages
-  loop:
-    - "docker.io/library/registry:2"
-    - "quay.io/ceph/ceph:v{{ cephadm_release }}"
-
-- name: Run local container registry using Podman
-  containers.podman.podman_container:
-    name: registry
-    image: registry:2
-    state: started
-    detach: true
-    privileged: true
-    ports:
-      - "5000:5000"
-    volume:
-      - /var/lib/registry:/var/lib/registry
-    restart_policy: always
-
-- name: Tag ceph image for local registry
-  ansible.builtin.command: >
-    podman tag quay.io/ceph/ceph:v{{ cephadm_release }} localhost:5000/ceph:v{{ cephadm_release }}
-  changed_when: true
-
-- name: Push ceph image to local registry
-  ansible.builtin.command: >
-    podman push localhost:5000/ceph:v{{ cephadm_release }}
-  changed_when: true
+# Handles both localhost registry and upstream registry
+- name: Set cephadm_registry based on localhost registry setting
+  ansible.builtin.set_fact:
+    cephadm_registry: "{{ 'localhost:5000' if cephadm_use_localhost_registry | bool else 'quay.io/ceph' }}"
 
 # === Bootstrap if currently no ceph nodes ===
 - name: Upload file ceph.conf needed for bootstrapping # noqa: risky-file-permissions
@@ -193,7 +158,7 @@
   ansible.builtin.debug:
     msg: >-
       {{ cephadm_bin }}
-      --image localhost:5000/ceph:v{{ cephadm_release }}
+      --image {{ cephadm_registry }}/ceph:v{{ cephadm_release }}
       bootstrap
       --skip-monitoring-stack
       --skip-dashboard
@@ -205,7 +170,7 @@
 - name: Bootstrap Ceph cluster
   ansible.builtin.command: >-
     {{ cephadm_bin }}
-    --image localhost:5000/ceph:v{{ cephadm_release }}
+    --image {{ cephadm_registry }}/ceph:v{{ cephadm_release }}
     bootstrap
     --skip-monitoring-stack
     --skip-dashboard
@@ -322,7 +287,7 @@
   run_once: true
 
 - name: Zap the volume on nodes that need OSDs
-  ansible.builtin.command: "{{ cephadm_bin }} --image localhost:5000/ceph:v{{ cephadm_release }} ceph-volume lvm zap vg_ceph/lv_ceph"
+  ansible.builtin.command: "{{ cephadm_bin }} --image {{ cephadm_registry }}/ceph:v{{ cephadm_release }} ceph-volume lvm zap vg_ceph/lv_ceph"
   delegate_to: "{{ item }}"
   run_once: true
   when: hostvars[item]['hostname'] in cephadm_nodes_needing_osds
@@ -338,7 +303,7 @@
   delegate_to: "{{ cephadm_first_node }}"
 
 - name: Add OSD daemon on nodes that need OSDs
-  ansible.builtin.command: "{{ cephadm_bin }} --image localhost:5000/ceph:v{{ cephadm_release }} shell -v /tmp/t.yaml:/tmp/t.yaml:ro -- ceph orch apply -i /tmp/t.yaml"
+  ansible.builtin.command: "{{ cephadm_bin }} --image {{ cephadm_registry }}/ceph:v{{ cephadm_release }} shell -v /tmp/t.yaml:/tmp/t.yaml:ro -- ceph orch apply -i /tmp/t.yaml"
   delegate_to: "{{ cephadm_first_node }}"
   run_once: true
   changed_when: true
@@ -402,3 +367,4 @@
   containers.podman.podman_container:
     name: registry
     state: absent
+  when: cephadm_use_localhost_registry | bool

--- a/roles/cephadm/tasks/validate.yml
+++ b/roles/cephadm/tasks/validate.yml
@@ -5,10 +5,18 @@
 - name: Verify required host variables are defined
   ansible.builtin.assert:
     that:
-      - hostname is defined
-      - hostname | length > 0
-      - cluster_ip_addr is defined
-      - cluster_ip_addr | length > 0
+      - cephadm_hostname is defined
+      - cephadm_hostname | length > 0
+      - cephadm_ip_addr is defined
+      - cephadm_ip_addr | length > 0
       - cephadm_network is defined
       - cephadm_network | length > 0
-    fail_msg: "hostname, cluster_ip_addr and cephadm_network must be set for each host in the cluster"
+    fail_msg: "cephadm_hostname, cephadm_ip_addr and cephadm_network must be set for each host in the cluster"
+
+- name: Verify seapath_distro is set and valid
+  ansible.builtin.assert:
+    that:
+      - seapath_distro is defined
+      - seapath_distro | length > 0
+      - seapath_distro in ['Yocto', 'Debian', 'CentOS', 'OracleLinux']
+    fail_msg: "seapath_distro must be set to either 'Yocto', 'Debian', 'CentOS' or 'OracleLinux'. Set it in your inventory or call the detect_seapath_distro role"

--- a/roles/cephadm/tasks/validate.yml
+++ b/roles/cephadm/tasks/validate.yml
@@ -1,0 +1,14 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Verify required host variables are defined
+  ansible.builtin.assert:
+    that:
+      - hostname is defined
+      - hostname | length > 0
+      - cluster_ip_addr is defined
+      - cluster_ip_addr | length > 0
+      - cephadm_network is defined
+      - cephadm_network | length > 0
+    fail_msg: "hostname, cluster_ip_addr and cephadm_network must be set for each host in the cluster"

--- a/roles/cephadm/templates/spec.yaml.j2
+++ b/roles/cephadm/templates/spec.yaml.j2
@@ -18,7 +18,7 @@ service_type: osd
 service_id: {{ 'osd' ~ (groups['osds'].index(host) + 1) }}
 service_name: osd.{{ 'osd' ~ (groups['osds'].index(host) + 1) }}
 placement:
-  host_pattern: {{ hostvars[host]['hostname'] }}
+  host_pattern: {{ hostvars[host]['cephadm_hostname'] }}
 spec:
   data_devices:
     paths:

--- a/roles/podman_registry_mirror/README.md
+++ b/roles/podman_registry_mirror/README.md
@@ -1,0 +1,28 @@
+# Podman Registry Mirror Role
+
+Configure podman registry mirroring for container registries.
+This role sets up mirroring for docker.io and quay.io to a specified mirror URL, with optional TLS support.
+
+## Requirements
+
+No requirements.
+
+## Role Variables
+
+| Variable                            | Required | Type    | Default | Comments                                                                                            |
+|-------------------------------------|----------|---------|---------|-----------------------------------------------------------------------------------------------------|
+| podman_registry_mirror_url          | Yes      | string  |         | Mirror URL (e.g. "192.168.1.10:5000").                                                              |
+| podman_registry_mirror_ca_cert_path | No*      | string  |         | Path to the registry CA certificate file on the Ansible control node. Required when TLS is enabled. |
+| podman_registry_mirror_tls_enabled  | No       | boolean | false   | Enable TLS when communicating with the mirror registry.                                             |
+
+## Example Playbook
+
+```yaml
+- hosts: cluster_machines
+  vars:
+    podman_registry_mirror_url: "192.168.1.10:5000"
+    podman_registry_mirror_ca_cert_path: "/tmp/registry-ca.crt"
+    podman_registry_mirror_tls_enabled: true
+  roles:
+    - { role: podman_registry_mirror }
+```

--- a/roles/podman_registry_mirror/defaults/main.yml
+++ b/roles/podman_registry_mirror/defaults/main.yml
@@ -1,0 +1,7 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+podman_registry_mirror_url:
+podman_registry_mirror_ca_cert_path:
+podman_registry_mirror_tls_enabled: false

--- a/roles/podman_registry_mirror/meta/main.yml
+++ b/roles/podman_registry_mirror/meta/main.yml
@@ -1,0 +1,20 @@
+# Copyright (C) 2025 RTE
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+galaxy_info:
+  author: "Seapath"
+  namespace: "seapath"
+  description: Configure podman registry mirroring on SEAPATH machines
+  min_ansible_version: "2.10"
+  license: Apache-2.0
+  platforms:
+    - name: EL
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+
+dependencies: []

--- a/roles/podman_registry_mirror/molecule/default/converge.yml
+++ b/roles/podman_registry_mirror/molecule/default/converge.yml
@@ -1,0 +1,13 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Converge
+  hosts: all
+  gather_facts: false
+  vars:
+    podman_registry_mirror_url: registry.internal.local:5000
+    podman_registry_mirror_ca_cert_path: /tmp/podman-registry-mirror-default-ca.crt
+    podman_registry_mirror_tls_enabled: false
+  roles:
+    - role: podman_registry_mirror

--- a/roles/podman_registry_mirror/molecule/default/molecule.yml
+++ b/roles/podman_registry_mirror/molecule/default/molecule.yml
@@ -1,0 +1,27 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+dependency:
+  name: galaxy
+
+driver:
+  name: podman
+
+platforms:
+  - name: instance
+    image: docker.io/geerlingguy/docker-debian13-ansible:latest
+    privileged: true
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      roles_path: "${MOLECULE_PROJECT_DIRECTORY}/.."
+  playbooks:
+    prepare: prepare.yml
+    converge: converge.yml
+    verify: verify.yml
+
+verifier:
+  name: ansible

--- a/roles/podman_registry_mirror/molecule/default/prepare.yml
+++ b/roles/podman_registry_mirror/molecule/default/prepare.yml
@@ -1,0 +1,33 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Prepare controller inputs
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Create dummy CA certificate file on controller
+      ansible.builtin.copy:
+        dest: /tmp/podman-registry-mirror-default-ca.crt
+        content: |
+          -----BEGIN CERTIFICATE-----
+          dummy-default-ca
+          -----END CERTIFICATE-----
+        mode: "0644"
+
+- name: Prepare
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Ensure containers configuration directory exists
+      ansible.builtin.file:
+        path: /etc/containers
+        state: directory
+        mode: "0755"
+
+    - name: Seed registries.conf with baseline content
+      ansible.builtin.copy:
+        dest: /etc/containers/registries.conf
+        content: |
+          unqualified-search-registries = ["docker.io"]
+        mode: "0644"

--- a/roles/podman_registry_mirror/molecule/default/verify.yml
+++ b/roles/podman_registry_mirror/molecule/default/verify.yml
@@ -1,0 +1,35 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Verify default behavior
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Read registries.conf
+      ansible.builtin.slurp:
+        path: /etc/containers/registries.conf
+      register: podman_registry_mirror_registries_conf
+
+    - name: Assert registry mirror block configured in insecure mode
+      ansible.builtin.assert:
+        that:
+          - "'unqualified-search-registries = [\"docker.io\"]' in registries_conf"
+          - "'location = \"docker.io\"' in registries_conf"
+          - "'location = \"quay.io\"' in registries_conf"
+          - "'location = \"registry.internal.local:5000\"' in registries_conf"
+          - "registries_conf.count('insecure = true') == 4"
+        fail_msg: "registries.conf does not contain the expected insecure registry mirror configuration"
+      vars:
+        registries_conf: "{{ podman_registry_mirror_registries_conf.content | b64decode }}"
+
+    - name: Check TLS certificate directory is absent when TLS is disabled
+      ansible.builtin.stat:
+        path: /etc/containers/certs.d/registry.internal.local:5000
+      register: podman_registry_mirror_certs_dir
+
+    - name: Assert TLS certificate directory is absent
+      ansible.builtin.assert:
+        that:
+          - not podman_registry_mirror_certs_dir.stat.exists
+        fail_msg: "TLS certificate directory should not be created when TLS is disabled"

--- a/roles/podman_registry_mirror/molecule/tls/converge.yml
+++ b/roles/podman_registry_mirror/molecule/tls/converge.yml
@@ -1,0 +1,13 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Converge
+  hosts: all
+  gather_facts: false
+  vars:
+    podman_registry_mirror_url: registry.internal.local:5000
+    podman_registry_mirror_ca_cert_path: /tmp/podman-registry-mirror-tls-ca.crt
+    podman_registry_mirror_tls_enabled: true
+  roles:
+    - role: podman_registry_mirror

--- a/roles/podman_registry_mirror/molecule/tls/molecule.yml
+++ b/roles/podman_registry_mirror/molecule/tls/molecule.yml
@@ -1,0 +1,27 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+dependency:
+  name: galaxy
+
+driver:
+  name: podman
+
+platforms:
+  - name: instance
+    image: docker.io/geerlingguy/docker-debian13-ansible:latest
+    privileged: true
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      roles_path: "${MOLECULE_PROJECT_DIRECTORY}/.."
+  playbooks:
+    prepare: prepare.yml
+    converge: converge.yml
+    verify: verify.yml
+
+verifier:
+  name: ansible

--- a/roles/podman_registry_mirror/molecule/tls/prepare.yml
+++ b/roles/podman_registry_mirror/molecule/tls/prepare.yml
@@ -1,0 +1,33 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Prepare controller inputs
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Create dummy CA certificate file on controller
+      ansible.builtin.copy:
+        dest: /tmp/podman-registry-mirror-tls-ca.crt
+        content: |
+          -----BEGIN CERTIFICATE-----
+          dummy-tls-ca
+          -----END CERTIFICATE-----
+        mode: "0644"
+
+- name: Prepare
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Ensure containers configuration directory exists
+      ansible.builtin.file:
+        path: /etc/containers
+        state: directory
+        mode: "0755"
+
+    - name: Seed registries.conf with baseline content
+      ansible.builtin.copy:
+        dest: /etc/containers/registries.conf
+        content: |
+          unqualified-search-registries = ["docker.io"]
+        mode: "0644"

--- a/roles/podman_registry_mirror/molecule/tls/verify.yml
+++ b/roles/podman_registry_mirror/molecule/tls/verify.yml
@@ -1,0 +1,60 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Verify TLS behavior
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Read registries.conf
+      ansible.builtin.slurp:
+        path: /etc/containers/registries.conf
+      register: podman_registry_mirror_registries_conf
+
+    - name: Assert registry mirror block configured in TLS mode
+      ansible.builtin.assert:
+        that:
+          - "'unqualified-search-registries = [\"docker.io\"]' in registries_conf"
+          - "'location = \"docker.io\"' in registries_conf"
+          - "'location = \"quay.io\"' in registries_conf"
+          - "'location = \"registry.internal.local:5000\"' in registries_conf"
+          - "registries_conf.count('insecure = false') == 4"
+        fail_msg: "registries.conf does not contain the expected TLS registry mirror configuration"
+      vars:
+        registries_conf: "{{ podman_registry_mirror_registries_conf.content | b64decode }}"
+
+    - name: Check TLS certificate directory exists
+      ansible.builtin.stat:
+        path: /etc/containers/certs.d/registry.internal.local:5000
+      register: podman_registry_mirror_certs_dir
+
+    - name: Assert TLS certificate directory exists with expected mode
+      ansible.builtin.assert:
+        that:
+          - podman_registry_mirror_certs_dir.stat.exists
+          - podman_registry_mirror_certs_dir.stat.isdir
+          - podman_registry_mirror_certs_dir.stat.mode == "0755"
+        fail_msg: "TLS certificate directory was not created with the expected properties"
+
+    - name: Check TLS CA certificate exists
+      ansible.builtin.stat:
+        path: /etc/containers/certs.d/registry.internal.local:5000/ca.crt
+      register: podman_registry_mirror_ca_cert
+
+    - name: Assert TLS CA certificate exists with expected mode
+      ansible.builtin.assert:
+        that:
+          - podman_registry_mirror_ca_cert.stat.exists
+          - podman_registry_mirror_ca_cert.stat.mode == "0644"
+        fail_msg: "TLS CA certificate was not copied with the expected properties"
+
+    - name: Read copied TLS CA certificate
+      ansible.builtin.slurp:
+        path: /etc/containers/certs.d/registry.internal.local:5000/ca.crt
+      register: podman_registry_mirror_ca_cert_content
+
+    - name: Assert copied TLS CA certificate content matches source
+      ansible.builtin.assert:
+        that:
+          - "'dummy-tls-ca' in (podman_registry_mirror_ca_cert_content.content | b64decode)"
+        fail_msg: "TLS CA certificate content does not match the prepared source file"

--- a/roles/podman_registry_mirror/tasks/main.yml
+++ b/roles/podman_registry_mirror/tasks/main.yml
@@ -1,0 +1,40 @@
+# Copyright (C) 2025 RTE
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Verify roles variable are defined
+  ansible.builtin.import_tasks: validate.yml
+
+- name: Create podman certs.d directory for registry
+  ansible.builtin.file:
+    path: "/etc/containers/certs.d/{{ podman_registry_mirror_url }}"
+    state: directory
+    mode: "0755"
+  when: podman_registry_mirror_tls_enabled
+
+- name: Copy registry CA certificate for podman
+  ansible.builtin.copy:
+    src: "{{ podman_registry_mirror_ca_cert_path }}"
+    dest: "/etc/containers/certs.d/{{ podman_registry_mirror_url }}/ca.crt"
+    mode: "0644"
+  when: podman_registry_mirror_tls_enabled
+
+- name: Configure podman registry mirroring
+  ansible.builtin.blockinfile:
+    path: /etc/containers/registries.conf
+    marker: "# {mark} ANSIBLE MANAGED BLOCK for registry mirroring"
+    block: |
+      [[registry]]
+      location = "docker.io"
+      insecure = {{ 'false' if podman_registry_mirror_tls_enabled else 'true' }}
+      [[registry.mirror]]
+      location = "{{ podman_registry_mirror_url }}"
+      insecure = {{ 'false' if podman_registry_mirror_tls_enabled else 'true' }}
+
+      [[registry]]
+      location = "quay.io"
+      insecure = {{ 'false' if podman_registry_mirror_tls_enabled else 'true' }}
+      [[registry.mirror]]
+      location = "{{ podman_registry_mirror_url }}"
+      insecure = {{ 'false' if podman_registry_mirror_tls_enabled else 'true' }}

--- a/roles/podman_registry_mirror/tasks/validate.yml
+++ b/roles/podman_registry_mirror/tasks/validate.yml
@@ -1,0 +1,33 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Verify required variables for podman_registry_mirror
+  ansible.builtin.assert:
+    that:
+      - podman_registry_mirror_url is not none
+      - podman_registry_mirror_url | length > 0
+    fail_msg: "podman_registry_mirror_url must be set"
+
+- name: Verify CA certificate path when TLS is enabled
+  ansible.builtin.assert:
+    that:
+      - podman_registry_mirror_ca_cert_path is not none
+      - podman_registry_mirror_ca_cert_path | length > 0
+    fail_msg: "podman_registry_mirror_ca_cert_path must be set when podman_registry_mirror_tls_enabled is true"
+  when: podman_registry_mirror_tls_enabled
+
+- name: Ensure registry CA certificate exists
+  ansible.builtin.stat:
+    path: "{{ podman_registry_mirror_ca_cert_path }}"
+  register: podman_registry_mirror_ca_cert_stat
+  delegate_to: localhost
+  become: false
+  when: podman_registry_mirror_tls_enabled
+
+- name: Fail when registry CA certificate does not exist
+  ansible.builtin.fail:
+    msg: "Registry CA certificate not found on the Ansible control node at {{ podman_registry_mirror_ca_cert_path }}"
+  when:
+    - podman_registry_mirror_tls_enabled
+    - not podman_registry_mirror_ca_cert_stat.stat.exists


### PR DESCRIPTION
The current disconnected setup embeds container images at OS build time (e.g. via build_debian_iso), which works well for initial deployment. However, day-2 operations — upgrading Ceph, rolling out new container images, or adding services — require either repackaging the ISO or manually transferring images to each node. A local registry provides a persistent, updatable image source that's independent of the installation media, and aligns with Ceph's recommended approach for isolated environments.                                                                         
                                                                                                                                                                                                                                                                                                 
This commit introduces a registry role that deploys docker.io/registry:v2 and allows importing images from internet (pull) or from an exported tarball (load). The seapath_setup_disconnected.yaml playbook installs the registry on the Ansible control node as a singleton.                  
                                                                                                                                                                                                                                                                                                 
TLS is enabled by default: the registry auto-generates a self-signed CA and server certificate when no user-provided certs are given. The CA is distributed to all cluster nodes so they trust the registry over HTTPS. The registry listens on port 443 to avoid specifying the port in image names.                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                 
The *_physical_machine roles are updated to use that registry as a mirror, which doesn't require changing the images names, both for Docker and Podman. They install the registry CA certificate in certs.d and set insecure = false when TLS is enabled.

The cephadm role is updated to remove image management, which is now handled by the registry role, so cephadm is focused on Ceph cluster management.

Contributes to #442