### PR TITLE
roles/deploy_vms_standalone: add autostart variable to VM deployment

### DIFF
--- a/roles/deploy_vms_standalone/README.md
+++ b/roles/deploy_vms_standalone/README.md
@@ -54,6 +54,7 @@ Below is a list of the VMs member variables that can be used with this XML file.
 |-----------------|------------------|-----------------|---------|--------------------------------------------------------------------------------------------------------------------|
 | uuid            |                  | Integer         | random  | Libvirt UUID of the VM                                                                                             |
 | description     |                  | String          | Test VM | Libvirt description of the VM                                                                                      |
+| autostart       |                  | Bool            | true    | Set the VM to autostart on hypervisor boot                                                                         |
 | memory          |                  | Integer         | 2048    | RAM of the VM in MiB                                                                                               |
 | additional_disk |                  | List of strings |         | Additional disks to give to the VM. The main disk is given by the vm_disk variable                                 |
 | vm_features     |                  | List of strings |         | List of vm features to enable. Possible values are "rt", "isolated", "secure-boot", "dpdk", "membaloon"            |

--- a/roles/deploy_vms_standalone/tasks/main.yml
+++ b/roles/deploy_vms_standalone/tasks/main.yml
@@ -109,5 +109,7 @@
   community.libvirt.virt:
     name: "{{ item }}"
     state: running
+    autostart: "{{ hostvars[item].autostart | default(true) }}"
   loop: "{{ groups['VMs'] }}"
   when: hostvars[item].enable | default(true)
+


### PR DESCRIPTION
The new VM variable "autostart" is added to the VM deployment role.

This variable allows to set the VM to autostart on hypervisor boot. By default, it is set to true, meaning that the VMs will be set to autostart unless specified otherwise.
