### PR TITLE
Fix capital letter typo in variable name remove_all_network_config

### DIFF
--- a/roles/network_basics/tasks/main.yml
+++ b/roles/network_basics/tasks/main.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-- when: Remove_all_network_config is defined and remove_all_network_config is true
+- when: remove_all_network_config is defined and remove_all_network_config is true
   block:
   - name: Wipe the network directory content 1/2, list files
     find:


### PR DESCRIPTION
Super small fix.
I just notice that there is a small typo in `roles/network_basics`. Variable `remove_all_network_config` is used to trigger action that wipes network directories. 
```yaml
- when: Remove_all_network_config is defined and remove_all_network_config is true
```
The variable name is mixing usage of upper_case `Remove_all_network_config` / lower_case `remove_all_network_config`. I guess the second one is the correct way.