### PR TITLE
[issue add_libvirtadmin_user] Fetch/Flat generates concurency troubles

### DIFF
--- a/roles/add_libvirtadmin_user/tasks/main.yml
+++ b/roles/add_libvirtadmin_user/tasks/main.yml
@@ -3,6 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
+- name: Define buffer directory
+  ansible.builtin.set_fact:
+    add_libvirtadmin_user_buffer_dir: "buffer"
+  run_once: true
+
 - name: Create Libvirt administration user
   user:
     name: "libvirtadmin"
@@ -10,11 +15,13 @@
     system: true
     group: libvirt
     create_home: true
+
 - name: Unlock the user
   replace:
       path: /etc/shadow
       regexp: '^libvirtadmin:!:'
       replace: 'libvirtadmin:*:'
+
 - name: Generate root SSH key
   user:
     name: "root"
@@ -30,25 +37,40 @@
     executable: /bin/bash
   register: add_libvirtadmin_user_root_home_dir
   changed_when: true
-- name: Fetch the root keyfile
-  fetch:
+
+- name: Compute cluster nodes list
+  ansible.builtin.set_fact:
+    add_libvirtadmin_user_cluster_nodes: >-
+      {{ (groups.get('hypervisors', []) | intersect(groups.get('cluster_machines', []))) }}
+
+- name: Fetch the root public key to controller 
+  ansible.builtin.fetch:
     src: "{{ add_libvirtadmin_user_root_home_dir.stdout }}/.ssh/id_rsa.pub"
-    dest: "buffer/{{ inventory_hostname }}-id_rsa.pub"
-    flat: true
-- name: Copy the key add to authorized_keys using Ansible module
+    dest: "{{ add_libvirtadmin_user_buffer_dir }}/"
+    flat: false
+
+- name: Fetch the SSH host ed25519 public key to controller
+  ansible.builtin.fetch:
+    src: "/etc/ssh/ssh_host_ed25519_key.pub"
+    dest: "{{ add_libvirtadmin_user_buffer_dir }}/"
+    flat: false
+
+- name: Copy cluster root keys into libvirtadmin authorized_keys
   ansible.posix.authorized_key:
     user: "libvirtadmin"
     state: present
-    key: "{{ lookup('file', 'buffer/' + item + '-id_rsa.pub') }}"
-  loop: "{{ groups['hypervisors'] | intersect(groups['cluster_machines']) }}"
-- name: Fetch the ssh keyfile
-  fetch:
-    src: "/etc/ssh/ssh_host_ed25519_key.pub"
-    dest: "buffer/{{ inventory_hostname }}-ssh_host_ed25519_key.pub"
-    flat: true
-- name: Populate the known_hosts files
-  known_hosts:
+    key: "{{ lookup('file', add_libvirtadmin_user_buffer_dir ~ '/' ~ item ~ '/root/.ssh/id_rsa.pub') }}"
+  loop: "{{ add_libvirtadmin_user_cluster_nodes }}"
+  loop_control:
+    label: "{{ item }}"
+  when: add_libvirtadmin_user_cluster_nodes | length > 0
+
+- name: Populate root known_hosts with cluster host keys
+  ansible.builtin.known_hosts:
     path: "{{ add_libvirtadmin_user_root_home_dir.stdout }}/.ssh/known_hosts"
     name: "{{ item }}"
-    key: "{{ item }} {{ lookup('file', 'buffer/' + item + '-ssh_host_ed25519_key.pub') }}"
-  loop: "{{ groups['hypervisors'] | intersect(groups['cluster_machines']) }}"
+    key: "{{ item }} {{ (lookup('file', add_libvirtadmin_user_buffer_dir ~ '/' ~ item ~ '/etc/ssh/ssh_host_ed25519_key.pub') | trim) }}"
+  loop: "{{ add_libvirtadmin_user_cluster_nodes }}"
+  loop_control:
+    label: "{{ item }}"
+  when: add_libvirtadmin_user_cluster_nodes | length > 0


### PR DESCRIPTION
This PR fixes a race condition in the role related to the use of `fetch` with `flat: true` when executed against multiple hosts in parallel.

While this issue is unlikely to surface in typical production environments, it can be reliably reproduced when running the role locally using containers (like Docker) where filesystem operations are fast and tasks execute truly concurrently.

### Problem

The role uses:
```yaml
fetch:
  src: <file>
  dest: "buffer/{{ inventory_hostname }}-<file>"
  flat: true
```
When multiple hosts execute this task in parallel, `fetch` internally creates a temporary file based on the basename of `src` before renaming it to the final destination.

For example, running on an host `hv1` for:
```yaml
src: /root/.ssh/id_rsa.pub
```
The module temporarily writes to:
```
buffer/id_rsa.pub
```
before renaming to:
```
buffer/hv1-id_rsa.pub
```
(this happens [here](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/copy.py#L625) in ansible source code)

If it runs on two hosts `hv1` and `hv2` it shall produce:
```
buffer/hv1-id_rsa.pub
buffer/hv2-id_rsa.pub
```
Because the temporary filename is shared, two hosts executing concurrently may:
- Overwrite the same temporary file
- Rename or delete it while another task still expects it to exist

### Observed Issues
When executed in parallel this led to two distinct problems:


**1) FileNotFoundError / rename failure**
```
FileNotFoundError: ... buffer/id_rsa.pub -> buffer/hv1-id_rsa.pub
```
This is a classic race condition caused by concurrent access to the same temporary file.
FYI, here the traceback i got when i managed to trigger this issue:
```
TASK [add_libvirtadmin_user : Fetch the ssh keyfile] *************************** 
 An exception occurred during task execution. To see the full traceback, use -vvv. The error was:  
 FileNotFoundError: [Errno 2] No such file or directory:  
 b'/home/antdup/seapath-ansible/roles/add_libvirtadmin_user/molecule/default/buffer/ssh_host_ed25519_key.pub' ->  
 b'/home/antdup/seapath-ansible/roles/add_libvirtadmin_user/molecule/default/buffer/hv1-ssh_host_ed25519_key.pub'  
 fatal: [hv1]: FAILED! => {"msg": "Unexpected failure during module execution: [Errno 2] No such file or directory:  
 b'/home/antdup/seapath-ansible/roles/add_libvirtadmin_user/molecule/default/buffer/ssh_host_ed25519_key.pub' ->  
 b'/home/antdup/seapath-ansible/roles/add_libvirtadmin_user/molecule/default/buffer/hv1-ssh_host_ed25519_key.pub'"  
 , "stdout": ""} │ changed: [hv2]
```

**2 key corruption / duplication**

In some runs, i got:
- One host’s key overwrote the other’s temporary file
- Both final destination files ended up containing the same key
- Result: duplicated SSH keys instead of distinct ones

Failing with outputs:
```
  │ TASK [add_libvirtadmin_user : Fetch the ssh keyfile] ***************************
  │ fatal: [hv2]: FAILED! => {"changed": false, "checksum": "07c526cb9e30b79c9bc12276481cc71ecbea5cee", "dest":
  │   "/home/antdup/seapath-ansible/roles/add_libvirtadmin_user/molecule/default/buffer/hv2-ssh_host_ed25519_key.pub", "file":
  │   "/etc/ssh/ssh_host_ed25519_key.pub", "md5sum": "46a5c7181c83d1acb0a03f70b74e3180", "msg": "checksum mismatch", "remote_checksum":
  │   "808cc30c5be11be3342f3a6043b8d09f8f3e12f4", "remote_md5sum": null}
  │ changed: [hv1]
```

Buffer outputs shows than only one key has been used, the second one has been erased:
```
[:~/...] cat buffer/hv2-ssh_host_ed25519_key.pub 
ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILcijzo4YFO017j9a5x2vdcAixJQqUKSEkLOb6ZfigWD root@hv1
[:~/...] cat buffer/hv1-ssh_host_ed25519_key.pub 
ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILcijzo4YFO017j9a5x2vdcAixJQqUKSEkLOb6ZfigWD root@hv1
```
### What this PR does:
This PR removes the use of `flat: true` and lets `fetch` create per-host directory structures (its default behavior).
Instead of:

```
buffer/hv1-id_rsa.pub
buffer/hv2-id_rsa.pub
```

We now use:

```
buffer/hv1/root/.ssh/id_rsa.pub
buffer/hv2/root/.ssh/id_rsa.pub
```
This guarantees:
- Files are copied in different directories named with hostname
- No shared temporary file
- No rename collision
- Deterministic behavior under parallel execution

All dependent lookup('file', ...) paths have been updated accordingly.

### impact
- No functional change in production behavior
- Fixes race condition in concurrent environments
- Makes the role safe for:
  - Container-based testing
  - CI pipelines
  - High fork values
  - Fast local filesystems
