### PR TITLE
[Improvement] Ensure backup_restore deployed scripts are owned by root

### DIFF
--- a/roles/backup_restore/tasks/main.yml
+++ b/roles/backup_restore/tasks/main.yml
@@ -9,6 +9,7 @@
     rsync_opts:
       - "--chown=root:root"
       - "--exclude=*.j2"
+
 - name: Copy backup-restore templates
   template:
     src: "{{ item }}"
@@ -16,6 +17,16 @@
     mode: '0755'
   with_fileglob:
     - scripts/*.j2
+
+- name: Ensure deployed scripts are owned by root
+  ansible.builtin.file:
+    path: /usr/local/bin/{{ item | basename | regex_replace('\.j2$', '') }}
+    owner: root
+    group: root
+  loop: "{{ lookup('ansible.builtin.fileglob', role_path ~ '/files/scripts/*', wantlist=True) }}"
+  loop_control:
+    label: "{{ item | basename }}"
+
 - name: Create /etc/backup-restore.conf file
   file:
     path: "/etc/backup-restore.conf"


### PR DESCRIPTION
While continuing to test some seapath roles inside Docker, I encountered an ownership issue with the scripts deployed through `ansible.posix.synchronize`.

Even though `--chown=root:root` is passed to `rsync`, ownership is not always reliably enforced depending on how `rsync` is executed (remote user, sudo handling, container environment). In particular, synchronize does not consistently fail if ownership is not properly applied.

In production this may not surface, but in custom test environments it can lead to scripts not being owned by root, without the task failing.

To make the role more robust and aligned with Ansible’s declarative philosophy, this PR adds an explicit file task that ensures the deployed scripts are owned by `root:root`.

Relying on a dedicated Ansible task to enforce state is more reliable than assuming rsync’s `--chown` will always succeed.
