### PR TITLE
Add no_log: true to tasks handling secrets/passwords

### DIFF
--- a/roles/centos/tasks/main.yml
+++ b/roles/centos/tasks/main.yml
@@ -88,6 +88,7 @@
     uid: 1000
     password: "{{ admin_passwd | default(omit) }}"
     append: no
+  no_log: true
 - name: Add authorized keys to admin user
   ansible.posix.authorized_key:
     user: "{{ admin_user }}"

--- a/roles/configure_libvirt_rdb_secret/tasks/main.yml
+++ b/roles/configure_libvirt_rdb_secret/tasks/main.yml
@@ -43,6 +43,7 @@
       changed_when: false
       register: configure_libvirt_rdb_secret_ceph_key
       run_once: true
+      no_log: true
 
 - name: Create libvirt RBD secret
   when:
@@ -64,3 +65,4 @@
   - name: Set key in libvirt secret
     command: 'virsh secret-set-value --secret "{{ configure_libvirt_rdb_secret_libvirt_uuid_rbd }}" --base64 "{{ configure_libvirt_rdb_secret_ceph_key.stdout }}"'
     changed_when: true
+    no_log: true

--- a/roles/debian/tasks/main.yml
+++ b/roles/debian/tasks/main.yml
@@ -115,6 +115,7 @@
     uid: 1000
     password: "{{ admin_passwd | default(omit) }}"
     append: no
+  no_log: true
 - name: Add authorized keys to admin user
   ansible.posix.authorized_key:
     user: "{{ admin_user }}"

--- a/roles/oraclelinux/tasks/main.yml
+++ b/roles/oraclelinux/tasks/main.yml
@@ -122,6 +122,7 @@
     uid: 1000
     password: "{{ admin_passwd | default(omit) }}"
     append: no
+  no_log: true
 - name: Add authorized keys to admin user
   ansible.posix.authorized_key:
     user: "{{ admin_user }}"


### PR DESCRIPTION

 Several tasks that handle sensitive data (Ceph secret keys, user passwords) can potentially logging their full input/output in plaintext. This means secrets could appear in:
  - Terminal output during playbook execution
  - `ansible.log` on disk
  - CI/CD logs (GitHub Actions, Jenkins, etc.)


  Added `no_log: true` tells Ansible to keep sensitive values out of logs. ([doc](https://docs.ansible.com/projects/ansible/latest/reference_appendices/logging.html#protecting-sensitive-data-with-no-log))

  This PR adds:
    - Add `no_log: true` to Ceph key retrieval and injection tasks in `configure_libvirt_rdb_secret` role
  - Add `no_log: true` to admin user creation tasks in `debian`, `centos`, and `oraclelinux` roles

I am not sure that this PR covers all potential cases. 
I notice some other key manipulation that look likes to be related to public keys, and does not require to be secret
