### PR TITLE
[Fix] Wrong parted module parameters name

### DIFF
--- a/roles/ceph_prepare_installation/tasks/main.yml
+++ b/roles/ceph_prepare_installation/tasks/main.yml
@@ -118,8 +118,8 @@
                     number: "{{ lvm_volumes[0].device_number }}"
                     label: gpt
                     name: ""
-                    ceph_prepare_installation_part_start: "{{ ceph_prepare_installation_part_start }}"
-                    ceph_prepare_installation_part_end: "{{ ceph_prepare_installation_part_end }}"
+                    part_start: "{{ ceph_prepare_installation_part_start }}"
+                    part_end: "{{ ceph_prepare_installation_part_end }}"
                     flags:
                       - lvm
                     state: present


### PR DESCRIPTION
 roles/ceph_prepare_installation/tasks/main.yml

Uses `ceph_prepare_installation_part_start` and `ceph_prepare_installation_part_end` as module parameters, but `community.general.parted  ` 
  expects `part_start` and `part_end`. The custom-prefixed names are silently ignored, creating partitions with default boundaries.