### PR TITLE
[Fix] Remove docker service tasks

### DIFF
--- a/roles/centos_physical_machine/tasks/main.yml
+++ b/roles/centos_physical_machine/tasks/main.yml
@@ -145,9 +145,6 @@
     enabled: yes
     state: started
 
-- name: Enable docker.service
-  ansible.builtin.systemd:
-    name: docker.service
 - name: "Add initramfs-tools scripts: script file (LVM rebooter and log handling)"
   ansible.builtin.copy:
     src: initramfs-tools/scripts/

--- a/roles/debian_physical_machine/tasks/main.yml
+++ b/roles/debian_physical_machine/tasks/main.yml
@@ -185,10 +185,6 @@
     name: libvirtd.service
     state: restarted
 
-- name: Enable docker.service
-  ansible.builtin.systemd:
-    name: docker.service
-
 - name: "Add initramfs-tools scripts: script file (LVM rebooter and log handling)"
   ansible.builtin.copy:
     src: initramfs-tools/scripts/


### PR DESCRIPTION
`Enable docker service` tasks does nothing on roles:
- roles/debian_physical_machine/tasks/main.yml
- roles/centos_physical_machine/tasks/main.yml


It misses `enable: true` and `state: started`