### PR TITLE
[Fix] Add missing directory path to vm standalone image

### DIFF
--- a/roles/deploy_vms_standalone/tasks/main.yml
+++ b/roles/deploy_vms_standalone/tasks/main.yml
@@ -69,7 +69,7 @@
 - name: Extract the gzipped disk on target
   command:
     cmd: "gzip -d -f {{ deploy_vms_standalone_disk_pool }}/{{ hostvars[item].inventory_hostname }}.img.gz"
-    creates: "{{ hostvars[item].inventory_hostname }}.img"
+    creates: "{{ deploy_vms_standalone_disk_pool }}/{{ hostvars[item].inventory_hostname }}.img"
   when:
     - deploy_vms_standalone_disk_copy | bool
     - hostvars[item].disk_extract is defined


### PR DESCRIPTION
Tasks unzip an image in a configured directory: `deploy_vms_standalone_disk_pool`.

`creates` parameter does not specify the full imagine directory.
