### PR TITLE
[Q&A] Risky file permission enable in linter and explicitely disabled in codebase

### DIFF
--- a/ansible-lint.conf
+++ b/ansible-lint.conf
@@ -14,7 +14,6 @@ exclude_paths:
 skip_list:
   - yaml                   # yaml syntax warnings
   - role-name              # All role names should match "^[a-z_][a-z0-9_]*$"
-  - risky-file-permissions # All file creation must specify permissions
   - fqcn-builtins          # Can't use buildins module without precising the full name with the "ansible.builtin." prefix
 
 warn_list:

--- a/playbooks/ci_prepare_publisher.yaml
+++ b/playbooks/ci_prepare_publisher.yaml
@@ -17,16 +17,16 @@
   hosts:
       - publisher_machine
   tasks:
-    - name: Copy ptp4l.service
+    - name: Copy ptp4l.service # noqa: risky-file-permissions
       ansible.builtin.template:
         src: "{{ (playbook_dir | dirname) }}/templates/ptp4l.service.j2"
         dest: /etc/systemd/system/ptp4l.service
       notify: Enable ptp4l.service
-    - name: Copy ptp4l.conf
+    - name: Copy ptp4l.conf # noqa: risky-file-permissions
       ansible.builtin.template:
         src: "{{ (playbook_dir | dirname) }}/templates/ptp4l.conf.j2"
         dest: /etc/linuxptp/ptp4l.conf
-    - name: Send phc2sys.service
+    - name: Send phc2sys.service # noqa: risky-file-permissions
       ansible.builtin.template:
         src: "{{ (playbook_dir | dirname) }}/templates/phc2sys.service.j2"
         dest: /etc/systemd/system/phc2sys.service

--- a/playbooks/seapath_setup_prerequisdebian.yaml
+++ b/playbooks/seapath_setup_prerequisdebian.yaml
@@ -123,7 +123,7 @@
     - VMs
   become: true
   tasks:
-    - name: Create /etc/apt/sources.list.d/
+    - name: Create /etc/apt/sources.list.d/ # noqa: risky-file-permissions
       file:
         state: directory
         path: /etc/apt/sources.list.d/

--- a/playbooks/seapath_update_yocto_cluster.yaml
+++ b/playbooks/seapath_update_yocto_cluster.yaml
@@ -20,7 +20,7 @@
         "Migrating" not in check_migration.stdout
       changed_when: false
       retries: 10
-    - name: Copy SWU file on machine
+    - name: Copy SWU file on machine # noqa: risky-file-permissions
       copy:
         src: "../{{ swu_image }}"
         dest: "/tmp/update.swu"

--- a/playbooks/seapath_update_yocto_standalone.yaml
+++ b/playbooks/seapath_update_yocto_standalone.yaml
@@ -9,7 +9,7 @@
 - name: Update machine
   hosts: "{{ machine_to_update }}"
   tasks:
-    - name: Copy SWU file on machine
+    - name: Copy SWU file on machine # noqa: risky-file-permissions
       copy:
         src: "../{{ swu_image }}"
         dest: "/tmp/update.swu"

--- a/roles/centos_physical_machine/tasks/main.yml
+++ b/roles/centos_physical_machine/tasks/main.yml
@@ -173,7 +173,7 @@
   set_fact:
     centos_physical_machine_lvm_rebooter_log_path: "{{ centos_physical_machine_varlog_path.stdout }}"
 
-- name: Copy rebooter.conf
+- name: Copy rebooter.conf # noqa: risky-file-permissions
   template:
     src: initramfs-tools/conf.d/rebooter.conf.j2
     dest: /etc/dracut.conf.d/rebooter.conf

--- a/roles/cephadm/tasks/main.yml
+++ b/roles/cephadm/tasks/main.yml
@@ -36,7 +36,7 @@
     shell: /sbin/nologin
   when: seapath_distro == "Debian"
 
-- name: Set cephadm user sudo permissions
+- name: Set cephadm user sudo permissions # noqa: risky-file-permissions
   copy:
     src: cephadm_sudoers
     dest: /etc/sudoers.d/cephadm
@@ -170,7 +170,7 @@
   changed_when: true
 
 # === Bootstrap if currently no ceph nodes ===
-- name: Upload file ceph.conf needed for bootstrapping
+- name: Upload file ceph.conf needed for bootstrapping # noqa: risky-file-permissions
   template:
       src: ceph.conf.j2
       dest: /tmp/ceph.conf

--- a/roles/ci_centos/tasks/main.yaml
+++ b/roles/ci_centos/tasks/main.yaml
@@ -14,7 +14,7 @@
   file:
     path: /usr/share/testdata/cukinia.conf
     state: absent
-- name: Copy Cukinia test configuration
+- name: Copy Cukinia test configuration # noqa: risky-file-permissions
   copy:
     src: files/cukinia.conf
     dest: /usr/share/testdata/cukinia.conf
@@ -29,11 +29,11 @@
 - name: Copy test vm domainxmls to the hypervisors
   when: "'hypervisors' in group_names"
   block:
-    - name: Copy vm.xml
+    - name: Copy vm.xml # noqa: risky-file-permissions
       copy:
         src: files/vm.xml
         dest: /usr/share/testdata/
-    - name: Copy wrong_vm_config.xml
+    - name: Copy wrong_vm_config.xml # noqa: risky-file-permissions
       copy:
         src: files/wrong_vm_config.xml
         dest: /usr/share/testdata/

--- a/roles/ci_yocto/synchronise_vms/tasks/main.yaml
+++ b/roles/ci_yocto/synchronise_vms/tasks/main.yaml
@@ -13,7 +13,7 @@
     name: phc2sys
     state: stopped
   when: "'phc2sys' in services"
-- name: Copy systemd service file to server
+- name: Copy systemd service file to server # noqa: risky-file-permissions
   template:
     src: phc2sys.service.j2
     dest: /etc/systemd/system/phc2sys.service

--- a/roles/configure_ha/tasks/main.yml
+++ b/roles/configure_ha/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: Load distribution-specific variables
   include_vars: "{{ seapath_distro }}.yml"
 
-- name: Save cluster machine informations
+- name: Save cluster machine informations # noqa: risky-file-permissions
   template:
     src: cluster.conf.j2
     dest: /etc/cluster.conf
@@ -61,7 +61,7 @@
         mode: 0400
       when: inventory_hostname != play_hosts[0]
 
-    - name: Templating corosync.conf
+    - name: Templating corosync.conf # noqa: risky-file-permissions
       template:
         src: corosync.conf.j2
         dest: /etc/corosync/corosync.conf
@@ -91,7 +91,7 @@
     - groups['valid_machine'] is defined
     - "'unconfigured_machine_group' in group_names"
   block:
-    - name: Templating corosync.conf
+    - name: Templating corosync.conf # noqa: risky-file-permissions
       template:
         src: corosync.conf.j2
         dest: /etc/corosync/corosync.conf

--- a/roles/configure_libvirt_rdb_secret/tasks/main.yml
+++ b/roles/configure_libvirt_rdb_secret/tasks/main.yml
@@ -50,7 +50,7 @@
     - configure_libvirt_rdb_secret_create_secret_pool
     - configure_libvirt_rdb_secret_secret_defined.stdout == ''
   block:
-  - name: Copy libvirt xml secret file
+  - name: Copy libvirt xml secret file # noqa: risky-file-permissions
     template:
         src: secret.xml.j2
         dest: /tmp/secret.xml

--- a/roles/debian/tasks/main.yml
+++ b/roles/debian/tasks/main.yml
@@ -201,7 +201,7 @@
           file:
             path: /etc/apt/sources.list.d
             state: absent
-        - name: Configure apt repositories
+        - name: Configure apt repositories # noqa: risky-file-permissions
           template:
             src: sources.list.j2
             dest: /etc/apt/sources.list

--- a/roles/debian_hardening/tasks/main.yml
+++ b/roles/debian_hardening/tasks/main.yml
@@ -31,7 +31,7 @@
   with_items: "{{ debian_hardening_kernel_params }}"
   when: revert
 
-- name: "Disable coredumps"
+- name: "Disable coredumps" # noqa: risky-file-permissions
   lineinfile:
     dest: /etc/sysctl.d/50-coredump.conf
     regexp: "^kernel.core_pattern=/dev/null$"
@@ -48,7 +48,7 @@
   notify: Update sysfs values using sysctl
   when: revert
 
-- name: "Disable kexec"
+- name: "Disable kexec" # noqa: risky-file-permissions
   lineinfile:
     dest: /etc/sysctl.d/50-kexec.conf
     regexp: "^kernel.kexec_load_disabled=1$"
@@ -65,7 +65,7 @@
   notify: Update sysfs values using sysctl
   when: revert
 
-- name: "Disable binfmt_misc"
+- name: "Disable binfmt_misc" # noqa: risky-file-permissions
   lineinfile:
     dest: /etc/sysctl.d/50-binfmt_misc.conf
     regexp: "^fs.binfmt_misc.status=0$"
@@ -82,7 +82,7 @@
   notify: Update sysfs values using sysctl
   when: revert
 
-- name: "Install hardened sysfs rules"
+- name: "Install hardened sysfs rules" # noqa: risky-file-permissions
   copy:
     src: sysctl/90-sysctl-hardening.conf
     dest: /etc/sysctl.d/zz-sysctl-hardening.conf
@@ -95,7 +95,7 @@
   notify: Update sysfs values using sysctl
   when: revert
 
-- name: "Install network hardened sysfs rules"
+- name: "Install network hardened sysfs rules" # noqa: risky-file-permissions
   copy:
     src: sysctl/99-sysctl-network.conf
     dest: /etc/sysctl.d/99-sysctl-network.conf
@@ -108,7 +108,7 @@
   notify: Update sysfs values using sysctl
   when: revert
 
-- name: "Install random-root-passwd.service"
+- name: "Install random-root-passwd.service" # noqa: risky-file-permissions
   copy:
     src: random-root-passwd.service
     dest: /etc/systemd/system/random-root-passwd.service
@@ -131,7 +131,7 @@
     state: absent
   when: revert
 
-- name: "Enable private TMPDIR"
+- name: "Enable private TMPDIR" # noqa: risky-file-permissions
   copy:
     src: mktmpdir.sh
     dest: /etc/profile.d/mktmpdir.sh
@@ -142,7 +142,7 @@
     state: absent
   when: revert
 
-- name: "Set bash timeout to 300s"
+- name: "Set bash timeout to 300s" # noqa: risky-file-permissions
   copy:
     src: terminal_idle.sh
     dest: /etc/profile.d/terminal_idle.sh
@@ -153,7 +153,7 @@
     state: absent
   when: revert
 
-- name: Install openssh hardening rules
+- name: Install openssh hardening rules # noqa: risky-file-permissions
   template:
     src: ssh-audit_hardening.conf.j2
     dest: /etc/ssh/sshd_config.d/ssh-audit_hardening.conf
@@ -222,7 +222,7 @@
   ignore_errors: true
   changed_when: false
 
-- name: Disable require tty for cockpit
+- name: Disable require tty for cockpit # noqa: risky-file-permissions
   copy:
     src: sudoers/cockpit
     dest: /etc/sudoers.d/cockpit
@@ -267,22 +267,22 @@
     - PASS_MAX_DAYS 90
   when: revert
 
-- name: Disable su
+- name: Disable su # noqa: risky-file-permissions
   copy:
     src: hardened_pam_su
     dest: /etc/pam.d/su
   when: not revert
-- name: Disable su-l
+- name: Disable su-l # noqa: risky-file-permissions
   copy:
     src: hardened_pam_su
     dest: /etc/pam.d/su-l
   when: not revert
-- name: Restore su pam setting
+- name: Restore su pam setting # noqa: risky-file-permissions
   copy:
     src: default_pam_su
     dest: /etc/pam.d/su
   when: revert
-- name: Restore su -l pam setting
+- name: Restore su -l pam setting # noqa: risky-file-permissions
   copy:
     src: default_pam_su-l
     dest: /etc/pam.d/su-l
@@ -325,7 +325,7 @@
     mode: 0755
   with_items: "{{ debian_hardening_hardened_services }}"
 
-- name: Add systemd service hardening rules
+- name: Add systemd service hardening rules # noqa: risky-file-permissions
   copy:
     src: "{{ item }}_hardening.conf"
     dest: "/etc/systemd/system/{{ item }}.service.d/hardening.conf"
@@ -368,12 +368,12 @@
     line: 'CLASS="--class gnu-linux --class gnu --class os"'
   when: revert
 
-- name: Copy syslog.conf
+- name: Copy syslog.conf # noqa: risky-file-permissions
   copy:
     src: auditd/syslog.conf
     dest: /etc/audit/plugins.d/syslog.conf
 
-- name: Copy audit.rules
+- name: Copy audit.rules # noqa: risky-file-permissions
   copy:
     src: auditd/audit.rules
     dest: /etc/audit/rules.d/audit.rules

--- a/roles/debian_hardening_physical_machine/tasks/main.yml
+++ b/roles/debian_hardening_physical_machine/tasks/main.yml
@@ -67,7 +67,7 @@
     mode: 0755
   with_items: "{{ debian_hardening_physical_machine_hardened_services }}"
 
-- name: Add systemd service hardening rules for physical machines
+- name: Add systemd service hardening rules for physical machines # noqa: risky-file-permissions
   copy:
     src: "{{ item }}_hardening.conf"
     dest: "/etc/systemd/system/{{ item }}.service.d/hardening.conf"

--- a/roles/debian_physical_machine/tasks/main.yml
+++ b/roles/debian_physical_machine/tasks/main.yml
@@ -214,7 +214,7 @@
   set_fact:
     debian_physical_machine_lvm_rebooter_log_path: "{{ debian_physical_machine_varlog_path.stdout }}"
 
-- name: Copy rebooter.conf
+- name: Copy rebooter.conf # noqa: risky-file-permissions
   template:
     src: initramfs-tools/conf.d/rebooter.conf.j2
     dest: /etc/initramfs-tools/conf.d/rebooter.conf

--- a/roles/debian_tests/tasks/main.yml
+++ b/roles/debian_tests/tasks/main.yml
@@ -10,7 +10,7 @@
     owner: false
     rsync_opts:
       - "--exclude=*.j2"
-- name: Copy Cukinia's tests templates
+- name: Copy Cukinia's tests templates # noqa: risky-file-permissions
   template:
     src: cukinia-tests/cukinia/{{ item.src }}
     dest: /etc/cukinia/{{ item.dest }}
@@ -32,7 +32,7 @@
     owner: root
     group: root
     mode: 0755
-- name: Copy Cukinia's includes
+- name: Copy Cukinia's includes # noqa: risky-file-permissions
   copy:
     src: cukinia-tests/includes/
     dest: /usr/share/cukinia/includes/
@@ -47,11 +47,11 @@
 - name: Tasks only on hosts
   when: "'hypervisors' in group_names"
   block:
-    - name: Copy vm.xml
+    - name: Copy vm.xml # noqa: risky-file-permissions
       copy:
         src: cukinia-tests/vm_manager_testdata/vm.xml
         dest: /usr/share/testdata
-    - name: Copy wrong_vm_config.xml
+    - name: Copy wrong_vm_config.xml # noqa: risky-file-permissions
       copy:
         src: cukinia-tests/vm_manager_testdata/wrong_vm_config.xml
         dest: /usr/share/testdata

--- a/roles/deploy_vms_cluster/tasks/main.yml
+++ b/roles/deploy_vms_cluster/tasks/main.yml
@@ -62,7 +62,7 @@
     vm_file: "{{ hostvars[item].vm_disk | default( deploy_vms_cluster_vms_disks_directory ~ '/' ~ item ~ '.qcow2') }}"
     vm_file_dest: "{{ deploy_vms_cluster_qcow2tmpuploadfolder + '/os.qcow2' }}"
   block:
-    - name: "Copy system disk on target for {{ item }}"
+    - name: "Copy system disk on target for {{ item }}" # noqa: risky-file-permissions
       copy:
         src: "{{ vm_file }}"
         dest: "{{ vm_file_dest }}"

--- a/roles/deploy_vms_standalone/tasks/main.yml
+++ b/roles/deploy_vms_standalone/tasks/main.yml
@@ -43,7 +43,7 @@
     - deploy_vms_standalone_qcow2tmpuploadfolder is defined
     - deploy_vms_standalone_qcow2tmpuploadfolder != "/tmp"
 
-- name: Copy the disk on target
+- name: Copy the disk on target # noqa: risky-file-permissions
   copy:
     src: "{{ hostvars[item].vm_disk }}"
     dest: "{{ deploy_vms_standalone_disk_pool }}/{{ hostvars[item].inventory_hostname }}.qcow2"
@@ -55,7 +55,7 @@
     - item not in deploy_vms_standalone_all_vms.list_vms or (item in deploy_vms_standalone_all_vms.list_vms and hostvars[item].force is defined and hostvars[item].force)
   loop: "{{ groups['VMs'] }}"
 
-- name: Copy the gzipped disk on target
+- name: Copy the gzipped disk on target # noqa: risky-file-permissions
   copy:
     src: "{{ hostvars[item].vm_disk }}"
     dest: "{{ deploy_vms_standalone_disk_pool }}/{{ hostvars[item].inventory_hostname }}.img.gz"
@@ -86,7 +86,7 @@
   loop: "{{ groups['VMs'] }}"
   when: item not in deploy_vms_standalone_all_vms.list_vms or (item in deploy_vms_standalone_all_vms.list_vms and hostvars[item].force is defined and hostvars[item].force)
 
-- name: Export VM config for debug in /tmp
+- name: Export VM config for debug in /tmp # noqa: risky-file-permissions
   template:
     src: "{{ hostvars[item].vm_template }}"
     dest: "/tmp/{{ hostvars[item].inventory_hostname }}.xml"

--- a/roles/network_configovs/tasks/main.yml
+++ b/roles/network_configovs/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: Load distribution-specific variables
   include_vars: "{{ seapath_distro }}.yml"
 
-- name: Create OVS configuration
+- name: Create OVS configuration # noqa: risky-file-permissions
   template:
     src: ovs_configuration.json.j2
     dest: /etc/ovs_configuration.json

--- a/roles/network_networkdwait/tasks/main.yml
+++ b/roles/network_networkdwait/tasks/main.yml
@@ -12,7 +12,7 @@
         owner: root
         group: root
         mode: 0755
-    - name: Copy systemd-networkd-wait-online.service overide
+    - name: Copy systemd-networkd-wait-online.service overide # noqa: risky-file-permissions
       template:
         src: systemd-networkd-wait-online.service.j2
         dest: /etc/systemd/system/systemd-networkd-wait-online.service.d/override.conf

--- a/roles/network_sriovpool/tasks/main.yml
+++ b/roles/network_sriovpool/tasks/main.yml
@@ -14,7 +14,7 @@
 - name: Configure SRIOV network pool if needed
   when: network_sriovpool_pool_defined.rc != 0
   block:
-    - name: Copy libvirt xml SRIOV network pool file
+    - name: Copy libvirt xml SRIOV network pool file # noqa: risky-file-permissions
       template:
           src: sriov_network_pool.xml.j2
           dest: /tmp/sriov_network_pool.xml

--- a/roles/snmp/tasks/main.yml
+++ b/roles/snmp/tasks/main.yml
@@ -102,7 +102,7 @@
           path: /var/lib/snmp/snmpd.conf
           regexp: '^usmUser.*'
           replace: ''
-      - name: Add new snmp v3 user account at the beginning of /var/lib/snmp/snmpd.conf
+      - name: Add new snmp v3 user account at the beginning of /var/lib/snmp/snmpd.conf # noqa: risky-file-permissions
         ansible.builtin.lineinfile:
           path: /var/lib/snmp/snmpd.conf
           line: "createUser {{ item.name }} SHA {{ item.password }} AES {{ item.password }}"

--- a/roles/timemaster/tasks/main.yml
+++ b/roles/timemaster/tasks/main.yml
@@ -29,7 +29,7 @@
     masked: true
   when: "'chrony.service' in services and (services['chrony.service'].status != 'not-found')"
   failed_when: false
-- name: Create timemaster configuration
+- name: Create timemaster configuration # noqa: risky-file-permissions
   template:
     src: timemaster.conf.j2
     dest: "{{ timemaster_path_timemaster_conf }}"
@@ -48,7 +48,7 @@
     group: root
     mode: 0755
   notify: Restart timemaster
-- name: Copy timemaster.service overide
+- name: Copy timemaster.service overide # noqa: risky-file-permissions
   template:
     src: timemaster.service.j2
     dest: /etc/systemd/system/timemaster.service.d/override.conf

--- a/roles/update/tasks/main.yaml
+++ b/roles/update/tasks/main.yaml
@@ -34,7 +34,7 @@
       until: update_check_migration.stdout == '0'
       retries: 10
 
-- name: Copy SWU file on machine
+- name: Copy SWU file on machine # noqa: risky-file-permissions
   copy:
     src: "{{ update_swu_image_path }}"
     dest: "/tmp/update.swu"

--- a/roles/yocto/hugepages/tasks/main.yaml
+++ b/roles/yocto/hugepages/tasks/main.yaml
@@ -6,7 +6,7 @@
 # It is called during yocto prerequisites, but can also be called alone.
 
 ---
-- name: Setup hugepages number
+- name: Setup hugepages number # noqa: risky-file-permissions
   copy:
     content: "{{ yocto_hugepages | string }}"
     dest: /etc/hugepages_nb.conf


### PR DESCRIPTION
This PR enables the `risky-file-permissions` ansible-lint rule, which was previously skipped globally in `ansible-lint.conf`.

Going forward, all new contributions that create or copy files must explicitly set file permissions. This ensures we maintain clear and intentional permission settings across the project.

For existing tasks that are currently missing explicit permissions, this PR adds `# noqa: risky-file-permissions` annotations rather than guessing the intended permissions for each task. This allows us to enable the rule immediately without risking unintended behavioral changes.

In practice, all these tasks currently end up with `0644` for files and `0755` for directories. This is determined by the default `umask 0022`, which is the standard default on all four supported distributions (Debian, CentOS, OracleLinux, Yocto). Nothing in this repository modifies the `umask`. So while the current behavior is reasonable, the permissions are implicit rather than explicit. The #
  noqa tags acknowledge this technical debt, without introducing new files without mode.

Each annotated task can be revisited individually in future commits to set explicit permissions where appropriate.