### PR TITLE
[Fix] wrong 99-sysctl-network.conf path on uninstall task

### DIFF
--- a/roles/debian_hardening/tasks/main.yml
+++ b/roles/debian_hardening/tasks/main.yml
@@ -101,9 +101,10 @@
     dest: /etc/sysctl.d/99-sysctl-network.conf
   notify: Update sysfs values using sysctl
   when: not revert
+
 - name: "Uninstall network hardened sysfs rules"
   file:
-    path: /etc/sysctl.d/sysctl/99-sysctl-network.conf
+    path: /etc/sysctl.d/99-sysctl-network.conf
     state: absent
   notify: Update sysfs values using sysctl
   when: revert


### PR DESCRIPTION
Fix small path issue.

`Install network hardened sysfs rules` deploys file in `/etc/sysctl.d/99-sysctl-network.conf`

`Uninstall network hardened sysfs rules` remove file from ` /etc/sysctl.d/sysctl/99-sysctl-network.conf`
