### PR TITLE
[Fix] Split /var/run/ceph  /var/log/ceph as separate items

### DIFF
--- a/playbooks/purge_ceph.yaml
+++ b/playbooks/purge_ceph.yaml
@@ -35,4 +35,5 @@
         - /var/lib/ceph/bootstrap-osd
         - /var/lib/ceph/bootstrap-rbd
         - /var/lib/ceph/bootstrap-rbd-mirror
-        - /var/run/ceph /var/log/ceph
+        - /var/run/ceph 
+        - /var/log/ceph


### PR DESCRIPTION
`- /var/run/ceph  /var/log/ceph ` are defined in the same line and should be seen as separated items.