### PR TITLE
[Proposal] Introduce molecule test in ci

### DIFF
--- a/.github/workflows/ci-molecule.yml
+++ b/.github/workflows/ci-molecule.yml
@@ -1,0 +1,32 @@
+# Copyright (C) 2025, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+name: Molecule
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  molecule:
+    name: Molecule Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Install Podman
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y podman
+
+      - name: Install Python dependencies
+        run: pip install -r molecule_requirements.txt
+
+      - name: Run Molecule tests
+        run: bash scripts/run-molecule-roles.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,18 +17,22 @@ jobs:
   ci-qa:
     uses: ./.github/workflows/ci-qa.yml
 
-  ci-debian:
+  ci-molecule:
     needs: ci-qa
+    uses: ./.github/workflows/ci-molecule.yml
+
+  ci-debian:
+    needs: ci-molecule
     uses: ./.github/workflows/ci-debian.yml
 
   ci-oraclelinux:
-    needs: ci-qa
+    needs: ci-molecule
     uses: ./.github/workflows/ci-oraclelinux.yml
 
   ci-yocto:
-    needs: ci-qa
+    needs: ci-molecule
     uses: ./.github/workflows/ci-yocto.yml
 
   ci-centos:
-    needs: ci-qa
+    needs: ci-molecule
     uses: ./.github/workflows/ci-centos.yml


### PR DESCRIPTION
 Add Molecule tests to CI pipeline                         
                                                                                                                                                               
  This PR integrates Molecule testing as a new stage in the CI pipeline, sitting between ansible-lint and the distribution-specific function tests.

  What changes

  - New workflow `ci-molecule.yml`: Runs all Molecule scenarios found across roles using the existing `scripts/run-molecule-roles.sh` script. It installs Podman and the Python dependencies from `molecule_requirements.txt` 
  - Updated `ci.yml` orchestrator: The pipeline now follows a sequential gating order: `ansible-lint → molecule → function tests`. Molecule must pass before any distro-specific CI (Debian, CentOS, OracleLinux, Yocto) is triggered, it garantes to not use ressources for Integration Test unitest are broken.


  Pipeline overview
```
  ci-qa (ansible-lint)
      └── ci-molecule (molecule tests)
              ├── ci-debian
              ├── ci-oraclelinux
              ├── ci-yocto
              └── ci-centos
```

<img width="960" height="386" alt="image" src="https://github.com/user-attachments/assets/f8f59b36-3879-4225-8de1-3bbeeabb1242" />


In future, we can think about parallel testing for molecule test to speed up things.