### PR TITLE
workflows: update all actions to version 6

### DIFF
--- a/.github/workflows/ci-debian.yml
+++ b/.github/workflows/ci-debian.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Upload test report
         if: ${{ always() && steps.conf.conclusion == 'success' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
             name: seapath-test-report-debian-cluster
             path: ${{ env.WORK_DIR }}/seapath-test-report.pdf

--- a/.github/workflows/ci-molecule.yml
+++ b/.github/workflows/ci-molecule.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
 

--- a/.github/workflows/ci-oraclelinux.yml
+++ b/.github/workflows/ci-oraclelinux.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Upload test report
         if: ${{ always() && steps.conf.conclusion == 'success' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
             name: seapath-test-report-oraclelinux-cluster
             path: ${{ env.WORK_DIR }}/seapath-test-report.pdf

--- a/.github/workflows/ci-qa.yml
+++ b/.github/workflows/ci-qa.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
 

--- a/.github/workflows/ci-yocto.yml
+++ b/.github/workflows/ci-yocto.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Upload test report
         if: ${{ always() && steps.conf.conclusion == 'success' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
             name: seapath-test-report-yocto-standalone
             path: ${{ env.WORK_DIR }}/seapath-test-report.pdf


### PR DESCRIPTION
Upload actions to version 6 to bump the npm version in use. See
- https://github.com/actions/upload-artifact#v6---whats-new
- https://github.com/actions/checkout#checkout-v6