### PR TITLE
playbooks/seapath_update_yocto_*: run journalctl with correct permission

### DIFF
--- a/playbooks/seapath_update_yocto_cluster.yaml
+++ b/playbooks/seapath_update_yocto_cluster.yaml
@@ -48,6 +48,7 @@
       command: crm node online "{{ machine_to_update }}"
       changed_when: true
     - name: Check if update has succeed
+      become: true
       shell:
         cmd: set -o pipefail && journalctl -u swupdate_check.service -b |grep "Update have failed"|wc -l
         executable: /bin/bash

--- a/playbooks/seapath_update_yocto_standalone.yaml
+++ b/playbooks/seapath_update_yocto_standalone.yaml
@@ -34,6 +34,7 @@
       tags:
         - skip_ansible_lint
     - name: Check if update has succeed
+      become: true
       shell:
         cmd: set -o pipefail && journalctl -u swupdate_check.service -b |grep "Update have failed"|wc -l
         executable: /bin/bash


### PR DESCRIPTION
swupdate_check.service is a system service, so its logs can only be accessed by privileged users. Otherwise, the task checking the update status will always succeed.