### PR TITLE
templates/vm/guest: add support for VNC display

### DIFF
--- a/roles/deploy_vms_cluster/README.md
+++ b/roles/deploy_vms_cluster/README.md
@@ -23,7 +23,7 @@ No requirement.
 The role uses the "VMs" group of the inventory. All members of this group will be deployed according to member's variable described below.
 The Ansible member inventory host name will be used as VM name.
 
-| *item* variables   | Required | Type        | Default                               | Comments                                                              |
+| *item* variables     | Required | Type        | Default                               | Comments                                                              |
 |--------------------|----------|-------------|---------------------------------------|-----------------------------------------------------------------------|
 | vm_disk            | No       | String      | vms_disks_directory + item + ".qcow2" | Path to the VM disk in `qcow2` format on the the Ansible machine      |
 | vm_template        | No       | String      |                                       | Path of the VM Libvirt XML templated file on the ansible machine      |
@@ -41,6 +41,8 @@ The Ansible member inventory host name will be used as VM name.
 | colocated_vms      | No       | String list |                                       | VM list to be be colocated with the new VM                            |
 | strong_colocation  | No       | Bool        | false                                 | Enable strong colocation on colocated_vms. The VM will will not be started when the constraint is not fulfilled |
 | disk_bus           | No       | String      |                                       | Disk bus type to use for the VM's disk (virtio, sata, scsi, ide, etc.) |
+| console            | No       | Bool        | true                                  | Enable serial console                                                 |
+| display            | No       | Bool        | false                                 | Enable graphical console (VNC)                                        |
 
 Here is an example of the structure for the VM inventory:
 

--- a/templates/vm/guest.xml.j2
+++ b/templates/vm/guest.xml.j2
@@ -195,14 +195,24 @@
 {%     endfor %}
 {% endif %}
         <controller type="pci" index="0" model="pcie-root" />
+{% if vm.display is defined and vm.display %}
+        <graphics type="vnc" port="-1" autoport="yes">
+            <listen type="address"/>
+        </graphics>
+        <video>
+           <model type="qxl" ram="65536" vram="65536" vgamem="16384" heads="1" primary="yes"/>
+        </video>
+{ % endif % }
         <serial type="pty">
             <target type="isa-serial" port="0">
                 <model name="isa-serial" />
             </target>
         </serial>
+{ % if vm.console is undefined or vm.console % }
         <console type="pty">
             <target type="serial" port="0" />
         </console>
+{ % endif % }
 {% if "memballoon" in vm_features %}
         <memballoon model="virtio">
           <stats period="5" />


### PR DESCRIPTION
Add a new VM variable display to enable VNC display and video output.

Also allow to disable the console by setting console to false (default is true).