### PR TITLE
roles/ptp_status_vsock: PTP domain number

### DIFF
--- a/inventories/examples/seapath-cluster.yaml
+++ b/inventories/examples/seapath-cluster.yaml
@@ -38,6 +38,9 @@ all:
     subnet: 24 # Subnet mask in CIDR notation. TODO
     ntp_servers: # NTP servers IP. TODO
       - "185.254.101.25" # public NTP server example
+    ptp_domain_number: 0 # PTP domain number (0 to 255)
+    timemaster_ptp_domain_number: "{{ ptp_domain_number }}"
+    ptp_status_vsock_domain_number: "{{ ptp_domain_number }}"
 
     # SEAPATH ansible variables
     ansible_connection: ssh

--- a/roles/ptp_status_vsock/README.md
+++ b/roles/ptp_status_vsock/README.md
@@ -8,7 +8,9 @@ No requirement.
 
 ## Role Variables
 
-No variable.
+| Variable                         | Required | Type    | Default | Comments                                                                                                                               |
+|----------------------------------|----------|---------|---------|----------------------------------------------------------------------------------------------------------------------------------------|
+| ptp_status_vsock_domain_number   | no       | Integer | 0       | PTP domain number. Value from 0 to 255                                                                                                      |
 
 ## Example Playbook
 

--- a/roles/ptp_status_vsock/defaults/main.yml
+++ b/roles/ptp_status_vsock/defaults/main.yml
@@ -1,0 +1,5 @@
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+ptp_status_vsock_domain_number: 0

--- a/roles/ptp_status_vsock/tasks/main.yml
+++ b/roles/ptp_status_vsock/tasks/main.yml
@@ -11,8 +11,8 @@
         state: directory
         mode: "0755"
     - name: Copy ptp_status executable files
-      ansible.builtin.copy:
-        src: ptpstatus/ptpstatus.sh
+      ansible.builtin.template:
+        src: ptpstatus/ptpstatus.sh.j2
         dest: /var/lib/ptp/ptpstatus.sh
         mode: "0755"
     - name: Copy ptp_vsock executable files

--- a/roles/ptp_status_vsock/templates/ptpstatus/ptpstatus.sh.j2
+++ b/roles/ptp_status_vsock/templates/ptpstatus/ptpstatus.sh.j2
@@ -513,7 +513,7 @@ function getPtpStatus() {
   fi
 
   local _pmcOutput="$( \
-    "$PMC_EXE" $PMC_SOCKET_OPTION -u -b 0 \
+    "$PMC_EXE" $PMC_SOCKET_OPTION -d {{ ptp_status_vsock_domain_number }} -u -b 0 \
       'GET TIME_PROPERTIES_DATA_SET' \
       'GET TIME_STATUS_NP' \
       'GET PARENT_DATA_SET' \


### PR DESCRIPTION
Allow setting the PTP domain number that is used with the pmc command.

When using the pmc tool to read the PTP status from ptp4l, the domain numbers
used in both applications need to match.

This is related to the additions made in #902. 