### PR TITLE
refactor(playbooks): extract extra file upload logic into dedicated role

### DIFF
--- a/playbooks/seapath_setup_prerequiscentos.yaml
+++ b/playbooks/seapath_setup_prerequiscentos.yaml
@@ -55,27 +55,5 @@
     - standalone_machine
     - VMs
   become: true
-  tasks:
-    - name: Upload extra files
-      ansible.builtin.copy:
-        src: "{{ item.src }}"
-        dest: "{{ item.dest }}"
-        owner: "{{ item.owner | default('root') }}"
-        group: "{{ item.group | default('root') }}"
-        mode: "{{ item.mode | default('0644') }}"
-        backup: true
-      with_items: "{{ upload_files }}"
-      when:
-        - upload_files is defined
-        - item.extract is not defined or item.extract is false
-    - name: Upload extra files and extract them
-      ansible.builtin.unarchive:
-        src: "{{ item.src }}"
-        dest: "{{ item.dest }}"
-        owner: "{{ item.owner | default('root') }}"
-        group: "{{ item.group | default('root') }}"
-        mode: "{{ item.mode | default('0644') }}"
-      with_items: "{{ upload_files }}"
-      when:
-        - upload_files is defined
-        - item.extract is defined and item.extract is true
+  roles:
+    - upload_extra_files

--- a/playbooks/seapath_setup_prerequisdebian.yaml
+++ b/playbooks/seapath_setup_prerequisdebian.yaml
@@ -68,36 +68,8 @@
     - standalone_machine
     - VMs
   become: true
-  tasks:
-    - name: Upload extra files
-      ansible.builtin.copy:
-        src: "{{ item.src }}"
-        dest: "{{ item.dest }}"
-        owner: "{{ item.owner | default('root') }}"
-        group: "{{ item.group | default('root') }}"
-        mode: "{{ item.mode | default('0644') }}"
-        backup: true
-      with_items: "{{ upload_files }}"
-      when:
-        - upload_files is defined
-        - item.extract is not defined or item.extract is false
-    - name: Upload extra files and extract them
-      ansible.builtin.unarchive:
-        src: "{{ item.src }}"
-        dest: "{{ item.dest }}"
-        owner: "{{ item.owner | default('root') }}"
-        group: "{{ item.group | default('root') }}"
-        mode: "{{ item.mode | default('0644') }}"
-      with_items: "{{ upload_files }}"
-      when:
-        - upload_files is defined
-        - item.extract is defined and item.extract is true
-    - name: Run extra commands after upload
-      shell: "{{ item }}"
-      tags:
-        - skip_ansible_lint
-      loop: "{{ commands_to_run_after_upload }}"
-      when: commands_to_run_after_upload is defined
+  roles:
+    - upload_extra_files
 
 - name: Remove what is not needed after installation on guests
   hosts:

--- a/playbooks/seapath_setup_prerequisoraclelinux.yaml
+++ b/playbooks/seapath_setup_prerequisoraclelinux.yaml
@@ -54,33 +54,5 @@
     - standalone_machine
     - VMs
   become: true
-  tasks:
-    - name: Upload extra files
-      ansible.builtin.copy:
-        src: "{{ item.src }}"
-        dest: "{{ item.dest }}"
-        owner: "{{ item.owner | default('root') }}"
-        group: "{{ item.group | default('root') }}"
-        mode: "{{ item.mode | default('0644') }}"
-        backup: true
-      with_items: "{{ upload_files }}"
-      when:
-        - upload_files is defined
-        - item.extract is not defined or item.extract is false
-    - name: Upload extra files and extract them
-      ansible.builtin.unarchive:
-        src: "{{ item.src }}"
-        dest: "{{ item.dest }}"
-        owner: "{{ item.owner | default('root') }}"
-        group: "{{ item.group | default('root') }}"
-        mode: "{{ item.mode | default('0644') }}"
-      with_items: "{{ upload_files }}"
-      when:
-        - upload_files is defined
-        - item.extract is defined and item.extract is true
-    - name: Run extra commands after upload
-      shell: "{{ item }}"
-      tags:
-        - skip_ansible_lint
-      loop: "{{ commands_to_run_after_upload }}"
-      when: commands_to_run_after_upload is defined
+  roles:
+    - upload_extra_files

--- a/playbooks/seapath_setup_prerequisyocto.yaml
+++ b/playbooks/seapath_setup_prerequisyocto.yaml
@@ -32,33 +32,5 @@
     - standalone_machine
     - VMs
   become: true
-  tasks:
-    - name: Upload extra files
-      ansible.builtin.copy:
-        src: "{{ item.src }}"
-        dest: "{{ item.dest }}"
-        owner: "{{ item.owner | default('root') }}"
-        group: "{{ item.group | default('root') }}"
-        mode: "{{ item.mode | default('0644') }}"
-        backup: true
-      with_items: "{{ upload_files }}"
-      when:
-        - upload_files is defined
-        - item.extract is not defined or item.extract is false
-    - name: Upload extra files and extract them
-      ansible.builtin.unarchive:
-        src: "{{ item.src }}"
-        dest: "{{ item.dest }}"
-        owner: "{{ item.owner | default('root') }}"
-        group: "{{ item.group | default('root') }}"
-        mode: "{{ item.mode | default('0644') }}"
-      with_items: "{{ upload_files }}"
-      when:
-        - upload_files is defined
-        - item.extract is defined and item.extract is true
-    - name: Run extra commands after upload
-      shell: "{{ item }}"
-      tags:
-        - skip_ansible_lint
-      loop: "{{ commands_to_run_after_upload }}"
-      when: commands_to_run_after_upload is defined
+  roles:
+    - upload_extra_files

--- a/roles/upload_extra_files/README.md
+++ b/roles/upload_extra_files/README.md
@@ -1,0 +1,49 @@
+# Upload extra files Role
+
+This role uploads additional files and archives to target hosts.
+It ensures destination directories exist before upload and extraction.
+
+## Requirements
+
+No specific requirement.
+
+## Role Variables
+
+| Variable                       | Required | Type | Default | Comments |
+|--------------------------------|----------|------|---------|----------|
+| `upload_extra_files_upload_files`                 | No       | List | `[]`    | List of files/archives to upload. Each item supports `src`, `dest`, optional `owner`, `group`, `mode`, optional `extract` (boolean), and optional `dir_mode`. |
+| `upload_extra_files_commands_to_run_after_upload` | No       | List | `[]`    | Shell commands executed after all uploads. |
+
+## `upload_extra_files_upload_files` item format
+
+- `src`: Local source file path.
+- `dest`: Remote destination path.
+- `extract`: When `true`, the role uses `unarchive` and treats `dest` as destination directory.
+- `owner` / `group`: Ownership of created content (default `root:root`).
+- `mode`: Permission mode for copied or extracted files (default `0644`).
+- `dir_mode`: Permission mode for created directories (default `0755`).
+
+## Example Playbook
+
+```yaml
+- hosts:
+    - cluster_machines
+    - standalone_machine
+    - VMs
+  become: true
+  roles:
+    - role: upload_extra_files
+      vars:
+        upload_extra_files_upload_files:
+          - src: files/custom.conf
+            dest: /etc/myapp/custom.conf
+            owner: root
+            group: root
+            mode: "0644"
+          - src: files/plugins.tar.gz
+            dest: /opt/myapp/plugins
+            extract: true
+            dir_mode: "0755"
+        upload_extra_files_commands_to_run_after_upload:
+          - systemctl restart myapp
+```

--- a/roles/upload_extra_files/defaults/main.yml
+++ b/roles/upload_extra_files/defaults/main.yml
@@ -1,0 +1,5 @@
+# Copyright (C) 2026 RTE
+# SPDX-License-Identifier: Apache-2.0
+---
+upload_extra_files_upload_files: []
+upload_extra_files_commands_to_run_after_upload: []

--- a/roles/upload_extra_files/meta/main.yml
+++ b/roles/upload_extra_files/meta/main.yml
@@ -1,0 +1,10 @@
+# Copyright (C) 2026 RTE
+# SPDX-License-Identifier: Apache-2.0
+---
+galaxy_info:
+  author: "Seapath"
+  namespace: "seapath"
+  description: Uploads extra files and archives, ensuring destination paths exist.
+  min_ansible_version: 2.9.10
+  license: Apache-2.0
+dependencies: []

--- a/roles/upload_extra_files/tasks/main.yml
+++ b/roles/upload_extra_files/tasks/main.yml
@@ -1,0 +1,54 @@
+# Copyright (C) 2026 RTE
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Ensure destination directory exists for extra uploaded files
+  ansible.builtin.file:
+    path: "{{ item.dest | dirname }}"
+    state: directory
+    owner: "{{ item.owner | default('root') }}"
+    group: "{{ item.group | default('root') }}"
+    mode: "{{ item.dir_mode | default('0755') }}"
+  loop: "{{ upload_extra_files_upload_files }}"
+  when:
+    - item.extract is not defined or item.extract is false
+
+- name: Upload extra files
+  ansible.builtin.copy:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    owner: "{{ item.owner | default('root') }}"
+    group: "{{ item.group | default('root') }}"
+    mode: "{{ item.mode | default('0644') }}"
+    backup: true
+  loop: "{{ upload_extra_files_upload_files }}"
+  when:
+    - item.extract is not defined or item.extract is false
+
+- name: Ensure destination directory exists for extra archives
+  ansible.builtin.file:
+    path: "{{ item.dest }}"
+    state: directory
+    owner: "{{ item.owner | default('root') }}"
+    group: "{{ item.group | default('root') }}"
+    mode: "{{ item.dir_mode | default('0755') }}"
+  loop: "{{ upload_extra_files_upload_files }}"
+  when:
+    - item.extract is defined and item.extract is true
+
+- name: Upload extra files and extract them
+  ansible.builtin.unarchive:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    owner: "{{ item.owner | default('root') }}"
+    group: "{{ item.group | default('root') }}"
+    mode: "{{ item.mode | default('0644') }}"
+  loop: "{{ upload_extra_files_upload_files }}"
+  when:
+    - item.extract is defined and item.extract is true
+
+- name: Run extra commands after upload
+  ansible.builtin.shell: "{{ item }}"
+  tags:
+    - skip_ansible_lint
+  loop: "{{ upload_extra_files_commands_to_run_after_upload }}"


### PR DESCRIPTION
Create a reusable `upload_extra_files` role and replace duplicated upload tasks in Debian,
CentOS, Oracle Linux, and Yocto prerequisite playbooks. The role now ensures destination
directories exist before `copy`/`unarchive` and includes defaults, metadata, and README.
