### PR TITLE
feature/networkmanager

### DIFF
--- a/playbooks/seapath_setup_network.yaml
+++ b/playbooks/seapath_setup_network.yaml
@@ -14,11 +14,15 @@
   roles:
     - detect_seapath_distro
     - role: network_basics
+      when: ansible_os_family != 'RedHat'
     - role: network_systemdnetworkd
       vars:
         network_systemdnetworkd_apply_config: "{{ apply_network_config | default(false) }}"
         network_systemdnetworkd_no_cluster_network: "{{ no_cluster_network | default(false) }}"
-      when: netplan_configurations is not defined
+      when: netplan_configurations is not defined and ansible_os_family != 'RedHat'
+    - role: network_networkmanager
+      when: ansible_os_family == 'RedHat'
+
     - role: network_netplan
       when: netplan_configurations is defined
 
@@ -39,10 +43,12 @@
       vars:
         network_configovs_apply_config: "{{ apply_network_config | default(false) }}"
     - network_buildhosts
-    - network_resolved
+    - role: network_resolved
+      when: ansible_os_family != 'RedHat'
     - role: network_networkdwait
       vars:
         network_networkdwait_no_cluster_network: "{{ no_cluster_network | default(false) }}"
+      when: ansible_os_family != 'RedHat'
 
 - name: Configure sriov libvirt network pool
   hosts:

--- a/roles/centos/tasks/main.yml
+++ b/roles/centos/tasks/main.yml
@@ -134,21 +134,14 @@
     state: present
   notify: Update Grub
 
-- name: Stop and Disable NetworkManager
-  ansible.builtin.service:
+- name: Ensure NetworkManager is started and enabled
+  ansible.builtin.systemd:
     name: NetworkManager
-    state: stopped
-    enabled: false
-  register: centos_nm_stop
-
-- name: Start and Enable systemd-networkd
-  ansible.builtin.service:
-    name: systemd-networkd
     state: started
-    enabled: true
-  register: centos_sd_start
+    enabled: yes
+  register: centos_nm_start
 
-- name: Set need_reboot to true if any change was made
+- name: Set need_reboot to true if NetworkManager state changed
   ansible.builtin.set_fact:
     need_reboot: true # noqa: var-naming[no-role-prefix]
-  when: centos_nm_stop is changed or centos_sd_start is changed
+  when: centos_nm_start.changed

--- a/roles/centos/tasks/main.yml
+++ b/roles/centos/tasks/main.yml
@@ -138,10 +138,10 @@
   ansible.builtin.systemd:
     name: NetworkManager
     state: started
-    enabled: yes
+    enabled: true
   register: centos_nm_start
 
-- name: Set need_reboot to true if NetworkManager state changed
+- name: Set need_reboot to true if NetworkManager state changed # noqa: no-handler
   ansible.builtin.set_fact:
     need_reboot: true # noqa: var-naming[no-role-prefix]
   when: centos_nm_start.changed

--- a/roles/network_networkmanager/handlers/main.yml
+++ b/roles/network_networkmanager/handlers/main.yml
@@ -1,0 +1,17 @@
+---
+- name: Reload NetworkManager connection
+  ansible.builtin.shell: |
+    nmcli connection reload
+    nmcli connection up br0
+  changed_when: true
+  failed_when: false
+
+- name: Reload NetworkManager daemon
+  ansible.builtin.systemd:
+    name: NetworkManager
+    state: reloaded
+
+- name: Restart seapath-team0-ip service
+  ansible.builtin.systemd:
+    name: seapath-team0-ip
+    state: restarted

--- a/roles/network_networkmanager/tasks/main.yml
+++ b/roles/network_networkmanager/tasks/main.yml
@@ -1,0 +1,119 @@
+---
+- name: Ensure base networking services are running
+  ansible.builtin.service:
+    name: "{{ item }}"
+    state: started
+    enabled: yes
+  loop:
+    - NetworkManager
+    - openvswitch
+
+- name: Create br0 bridge for management and VMs
+  community.general.nmcli:
+    conn_name: br0
+    ifname: br0
+    type: bridge
+    ip4: "{{ ansible_host }}/{{ subnet | default('24') }}"
+    gw4: "{{ gateway_addr | default(omit) }}"
+    dns4: "{{ dns_servers | default(omit) }}"
+    method4: manual
+    autoconnect: yes
+    state: present
+  notify: Reload NetworkManager connection
+
+- name: Attach physical management interface to br0
+  community.general.nmcli:
+    conn_name: "{{ network_interface }}"
+    ifname: "{{ network_interface }}"
+    type: ethernet
+    master: br0
+    slave_type: bridge
+    state: present
+  notify: Reload NetworkManager connection
+
+- name: Cluster Network Configuration
+  when: cluster_ip_addr is defined
+  block:
+    - name: Unmanage OVS bridge and ports in NetworkManager
+      ansible.builtin.copy:
+        dest: /etc/NetworkManager/conf.d/99-unmanaged-team0.conf
+        content: |
+          [keyfile]
+          unmanaged-devices=interface-name:team0;interface-name:{{ team0_0 | default('enp2s0') }};interface-name:{{ team0_1 | default('enp3s0') }}
+      notify: Reload NetworkManager daemon
+
+    - name: Flush handlers to apply NM unmanage rules immediately
+      ansible.builtin.meta: flush_handlers
+
+    - name: Create OVS bridge and physical ports manually
+      ansible.builtin.shell: |
+        /usr/bin/ovs-vsctl --may-exist add-br team0
+        /usr/bin/ovs-vsctl --may-exist add-port team0 {{ team0_0 | default('enp2s0') }}
+        /usr/bin/ovs-vsctl --may-exist add-port team0 {{ team0_1 | default('enp3s0') }}
+        /usr/bin/ovs-vsctl set Bridge team0 rstp_enable=true
+        /usr/bin/ovs-vsctl set Bridge team0 other_config=rstp-priority={{ br_rstp_priority | default(16384) }}
+      changed_when: false
+
+    - name: Create systemd service for team0 cluster IP
+      ansible.builtin.copy:
+        dest: /etc/systemd/system/seapath-team0-ip.service
+        content: |
+          [Unit]
+          Description=Configure SEAPATH Cluster IP on team0
+          After=openvswitch.service network.target
+          Requires=openvswitch.service
+
+          [Service]
+          Type=oneshot
+          RemainAfterExit=yes
+          ExecStartPre=/usr/sbin/ip link set {{ team0_0 | default('enp2s0') }} mtu 1800
+          ExecStartPre=/usr/sbin/ip link set {{ team0_0 | default('enp2s0') }} up
+          ExecStartPre=/usr/sbin/ip link set {{ team0_1 | default('enp3s0') }} mtu 1800
+          ExecStartPre=/usr/sbin/ip link set {{ team0_1 | default('enp3s0') }} up
+          ExecStartPre=/usr/sbin/ip link set team0 mtu 1800
+          ExecStartPre=/usr/sbin/ip link set team0 up
+          ExecStart=/bin/sh -c 'ip addr show team0 | grep -q "{{ cluster_ip_addr }}/" || ip addr add {{ cluster_ip_addr }}/{{ team0subnet | default("24") }} brd + dev team0'
+
+          [Install]
+          WantedBy=multi-user.target
+      notify: Restart seapath-team0-ip service
+
+    - name: Enable and start team0 IP systemd service
+      ansible.builtin.systemd:
+        name: seapath-team0-ip
+        state: started
+        enabled: yes
+        daemon_reload: yes
+
+    - name: Enforce cluster IP immediately during playbook run
+      ansible.builtin.shell: |
+        /usr/bin/ip link set {{ team0_0 | default('enp2s0') }} mtu 1800
+        /usr/bin/ip link set {{ team0_0 | default('enp2s0') }} up
+        /usr/bin/ip link set {{ team0_1 | default('enp3s0') }} mtu 1800
+        /usr/bin/ip link set {{ team0_1 | default('enp3s0') }} up
+        /usr/bin/ip link set team0 mtu 1800
+        /usr/bin/ip link set team0 up
+        ip addr show team0 | grep -q "{{ cluster_ip_addr }}/" || ip addr add {{ cluster_ip_addr }}/{{ team0subnet | default("24") }} brd + dev team0
+      changed_when: false
+
+    - name: Ensure firewalld is running
+      ansible.builtin.systemd:
+        name: firewalld
+        state: started
+        enabled: yes
+
+    - name: Add team0 to trusted zone in firewalld
+      ansible.posix.firewalld:
+        zone: trusted
+        interface: team0
+        permanent: yes
+        immediate: yes
+        state: enabled
+
+    - name: Protect our bridge from being destroyed by network_clusternetwork role
+      ansible.builtin.set_fact:
+        skip_recreate_team0_config: true
+
+- name: Refresh Ansible network facts so Ceph sees the new IP
+  ansible.builtin.setup:
+    gather_subset: network

--- a/roles/network_networkmanager/tasks/main.yml
+++ b/roles/network_networkmanager/tasks/main.yml
@@ -46,6 +46,9 @@
     - name: Flush handlers to apply NM unmanage rules immediately
       ansible.builtin.meta: flush_handlers
 
+    - name: Reset SSH connection after network changes
+      ansible.builtin.meta: reset_connection
+
     - name: Create OVS bridge and physical ports manually
       ansible.builtin.shell: |
         /usr/bin/ovs-vsctl --may-exist add-br team0

--- a/roles/network_networkmanager/tasks/main.yml
+++ b/roles/network_networkmanager/tasks/main.yml
@@ -3,7 +3,7 @@
   ansible.builtin.service:
     name: "{{ item }}"
     state: started
-    enabled: yes
+    enabled: true
   loop:
     - NetworkManager
     - openvswitch
@@ -17,7 +17,7 @@
     gw4: "{{ gateway_addr | default(omit) }}"
     dns4: "{{ dns_servers | default(omit) }}"
     method4: manual
-    autoconnect: yes
+    autoconnect: true
     state: present
   notify: Reload NetworkManager connection
 
@@ -40,6 +40,7 @@
         content: |
           [keyfile]
           unmanaged-devices=interface-name:team0;interface-name:{{ team0_0 | default('enp2s0') }};interface-name:{{ team0_1 | default('enp3s0') }}
+        mode: "0644"
       notify: Reload NetworkManager daemon
 
     - name: Flush handlers to apply NM unmanage rules immediately
@@ -76,43 +77,47 @@
 
           [Install]
           WantedBy=multi-user.target
+        mode: "0644"
       notify: Restart seapath-team0-ip service
 
     - name: Enable and start team0 IP systemd service
       ansible.builtin.systemd:
         name: seapath-team0-ip
         state: started
-        enabled: yes
-        daemon_reload: yes
+        enabled: true
+        daemon_reload: true
 
     - name: Enforce cluster IP immediately during playbook run
-      ansible.builtin.shell: |
-        /usr/bin/ip link set {{ team0_0 | default('enp2s0') }} mtu 1800
-        /usr/bin/ip link set {{ team0_0 | default('enp2s0') }} up
-        /usr/bin/ip link set {{ team0_1 | default('enp3s0') }} mtu 1800
-        /usr/bin/ip link set {{ team0_1 | default('enp3s0') }} up
-        /usr/bin/ip link set team0 mtu 1800
-        /usr/bin/ip link set team0 up
-        ip addr show team0 | grep -q "{{ cluster_ip_addr }}/" || ip addr add {{ cluster_ip_addr }}/{{ team0subnet | default("24") }} brd + dev team0
+      ansible.builtin.shell:
+        cmd: |
+          set -o pipefail
+          /usr/bin/ip link set {{ team0_0 | default('enp2s0') }} mtu 1800
+          /usr/bin/ip link set {{ team0_0 | default('enp2s0') }} up
+          /usr/bin/ip link set {{ team0_1 | default('enp3s0') }} mtu 1800
+          /usr/bin/ip link set {{ team0_1 | default('enp3s0') }} up
+          /usr/bin/ip link set team0 mtu 1800
+          /usr/bin/ip link set team0 up
+          ip addr show team0 | grep -q "{{ cluster_ip_addr }}/" || ip addr add {{ cluster_ip_addr }}/{{ team0subnet | default("24") }} brd + dev team0
+        executable: /bin/bash
       changed_when: false
 
     - name: Ensure firewalld is running
       ansible.builtin.systemd:
         name: firewalld
         state: started
-        enabled: yes
+        enabled: true
 
     - name: Add team0 to trusted zone in firewalld
       ansible.posix.firewalld:
         zone: trusted
         interface: team0
-        permanent: yes
-        immediate: yes
+        permanent: true
+        immediate: true
         state: enabled
 
     - name: Protect our bridge from being destroyed by network_clusternetwork role
       ansible.builtin.set_fact:
-        skip_recreate_team0_config: true
+        skip_recreate_team0_config: true # noqa: var-naming[no-role-prefix]
 
 - name: Refresh Ansible network facts so Ceph sees the new IP
   ansible.builtin.setup:

--- a/roles/network_networkmanager/tasks/main.yml
+++ b/roles/network_networkmanager/tasks/main.yml
@@ -46,8 +46,10 @@
     - name: Flush handlers to apply NM unmanage rules immediately
       ansible.builtin.meta: flush_handlers
 
-    - name: Reset SSH connection after network changes
-      ansible.builtin.meta: reset_connection
+    - name: Wait for network to stabilize and reconnect
+      ansible.builtin.wait_for_connection:
+        delay: 15
+        timeout: 120
 
     - name: Create OVS bridge and physical ports manually
       ansible.builtin.shell: |


### PR DESCRIPTION
Hi everyone! I'm opening this PR as a draft first just to run the CI and validate my changes.

Basically, these changes involve replacing the systemd-networkd package with NetworkManager only in Red Hat family distributions, as it is the standard for CentOS/RHEL. To make this work, I created a new dedicated role called network_networkmanager that uses nmcli to configure the management bridge and the OVS cluster interface.

I also tweaked the main network playbook so it automatically skips the Debian specific roles, like systemd-networkd and networkdwait, when running on RedHat, applying the new NetworkManager role instead.

I'll let the CI do its thing now to see how it goes :)

Cheers!