### PR TITLE
ceph_prepare_installation: auto-create LVM when ceph_osd_disk is defined

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,72 @@
+# SEAPATH Ansible — Agent Quick Reference
+
+## Development Environment
+
+- **Primary toolchain**: `cqfd` (Docker wrapper). All commands should be prefixed with `cqfd run` unless running natively.
+- **Ansible version**: Exactly `2.16.x` is required. `prepare.sh` enforces this.
+- **One-time setup**:
+  ```bash
+  cqfd init           # build the dev container
+  cqfd -b prepare     # install galaxy deps, submodules, patches, plugins
+  ```
+- **Without cqfd**: install `ansible-core~=2.16.0`, `netaddr`, `six`, `rsync`, then run `./prepare.sh`.
+
+## Lint / Format
+
+- **Lint**: `cqfd -b lint`  (or `ansible-lint` natively)
+- **Format**: `cqfd -b format`  (or `ansible-lint --fix=yaml` natively)
+- **Pre-commit**: `pre-commit install` — runs `ansible-lint v26.1.1` on every commit.
+- **Config**:
+  - `.ansible-lint.yml` — skips `role-name`, warns on `no-handler` / `no-changed-when`
+  - `.yamllint` — line-length max 1024 (allows ansible-lint --fix=yaml to work)
+
+## Testing
+
+- **Run all molecule tests**: `tox -m molecule`
+- **Role tests only**: `tox -ie molecule-roles`  (runs `scripts/run-molecule-roles.sh`)
+- **Playbook tests only**: `tox -e molecule-playbooks`  (runs from `playbooks/` dir)
+- **Single role**: `cd roles/<role> && molecule test --all`
+- **Backend**: Podman. Molecule tests require podman installed.
+
+## CI Pipeline (PRs to `main`)
+
+```
+qa (ansible-lint) → molecule → debian / yocto / centos / oraclelinux integration
+```
+
+Integration tests run on self-hosted runners and use the external `seapath/ci` repo.
+
+## Repo Structure & Entrypoints
+
+- **Main setup playbook**: `playbooks/seapath_setup_main.yaml`
+- **Debian hardening**: `playbooks/seapath_setup_hardened_debian.yaml`
+- **Example inventories**: `inventories/examples/` (cluster, standalone, vm-deployment, ovs)
+- **Roles**: `roles/` — most have a `README`. Some include `molecule/` for unit tests.
+- **Custom modules**: `library/`
+- **Ceph integration**: `ceph-ansible/` is a **submodule** (`stable-8.0`). It is patched at setup time by `prepare.sh` from `src/ceph-ansible-patches/` and `src/ceph-ansible-site.yaml`.
+
+## Important Ansible Config (`ansible.cfg`)
+
+- `gathering = explicit` — facts are not gathered by default.
+- `any_errors_fatal = True` — any host failure stops the playbook.
+- `tags: skip = package-install` — package-install tag is skipped by default.
+- `inventory = inventories/examples/seapath-cluster.yaml` — default inventory (mostly for CI).
+- `roles_path = ./roles:ceph-ansible/roles` — local roles take precedence over ceph-ansible roles.
+
+## Submodules
+
+```
+ceph-ansible                         → https://github.com/ceph/ceph-ansible.git (stable-8.0)
+roles/deploy_cukinia/files/cukinia   → https://github.com/savoirfairelinux/cukinia.git
+roles/deploy_python3_setup_ovs/...   → https://github.com/seapath/python3-setup-ovs.git
+roles/deploy_vm_manager/files/...    → https://github.com/seapath/vm_manager.git
+```
+
+Run `git submodule update --init --force` (done by `prepare.sh`) after clone or when submodules change.
+
+## Gotchas
+
+- **Always run `prepare.sh` after fresh clone or when `ansible-requirements.yaml` / submodules change.** It installs galaxy roles/collections, initializes submodules, patches ceph-ansible, and downloads Cockpit plugins.
+- ** ceph-ansible is excluded from lint** (see `.ansible-lint.yml` `exclude_paths`). Do not lint inside it.
+- **Molecule playbooks** run from the `playbooks/` directory, not the repo root.
+- **Molecule roles** are discovered dynamically — only roles with a `molecule/` directory are tested.

--- a/roles/ceph_prepare_installation/README.md
+++ b/roles/ceph_prepare_installation/README.md
@@ -8,10 +8,13 @@ no requirement.
 
 ## Role Variables
 
-| Variable      | Required | Type             | Comments                                                                                |
-|---------------|----------|------------------|-----------------------------------------------------------------------------------------|
-| lvm_volumes   | No       | List of one dict | LVM volumes to be used for Ceph OSD. To use one entire disk, use ceph_osd_disk variable |
-| ceph_osd_disk | No       | String           | Node device disk to use for Ceph OSD. The whole disk will be used.                      |
+| Variable      | Required | Type             | Comments                                                                                                          |
+|---------------|----------|------------------|-------------------------------------------------------------------------------------------------------------------|
+| lvm_volumes   | No       | List of one dict | LVM volumes to be used for Ceph OSD. To use one entire disk, use ceph_osd_disk variable                           |
+| ceph_osd_disk | No       | String           | Node device disk to use for Ceph OSD. The whole disk will be used.                                                |
+| ceph_prepare_installation_flush_osds | No       | Boolean          | Force re-creation of OSD LVM volumes even if they already exist. Defaults to false.                               |
+
+When `ceph_osd_disk` is provided and `lvm_volumes` is **not** defined, the role automatically creates a single LVM volume group `vg_ceph` and logical volume `lv_ceph` using the full disk. This is skipped if `vg_ceph/lv_ceph` already exists, unless `ceph_prepare_installation_flush_osds` is set to `true`.
 
 lvm_volumes structure is a list of one dictionnary. All the variables available on the dictionnary are described as follow.
 **Warning** : lvm_volumes must only contain one element it its list. Multiple volumes is not handled by SEAPATH.

--- a/roles/ceph_prepare_installation/defaults/main.yml
+++ b/roles/ceph_prepare_installation/defaults/main.yml
@@ -1,0 +1,7 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+ceph_prepare_installation_is_using_cephadm: "{{ is_using_cephadm | default(false) }}"
+ceph_prepare_installation_ceph_volume_cmd: "{{ 'cephadm ceph-volume' if ceph_prepare_installation_is_using_cephadm else 'ceph-volume' }}"
+ceph_prepare_installation_flush_osds: false

--- a/roles/ceph_prepare_installation/tasks/main.yml
+++ b/roles/ceph_prepare_installation/tasks/main.yml
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
+
 - name: Check for existing installation (ceph-ansible only)
-  when: not (is_using_cephadm | default(false))
+  when: not ceph_prepare_installation_is_using_cephadm
   block:
     - name: Create Ceph log directory
       ansible.builtin.file:
@@ -23,7 +24,7 @@
 
 - name: Prepare OSD disk # noqa: no-handler
   when:
-    - ceph_prepare_installation_new_ceph_installation.changed | default(false) or is_using_cephadm | default(false)
+    - ceph_prepare_installation_new_ceph_installation.changed | default(false) or ceph_prepare_installation_is_using_cephadm
   block:
     - name: Refresh LVM VG
       ansible.builtin.command:
@@ -33,30 +34,70 @@
       when:
         - lvm_volumes is defined
         - ansible_lvm['lvs'][lvm_volumes[0].data] is defined
-        - not (is_using_cephadm | default(false))
+        - not ceph_prepare_installation_is_using_cephadm
+      ansible.builtin.command: "ceph-volume lvm zap /dev/{{ lvm_volumes[0].data_vg }}/{{ lvm_volumes[0].data }}"
+      changed_when: true
+    - name: Create Ceph LVM on full disk when lvm_volumes is not defined
+      when:
+        - lvm_volumes is not defined
+        - ceph_osd_disk is defined
+        - ansible_lvm is not defined
+          or ansible_lvm['lvs'] is not defined
+          or ansible_lvm['lvs']['lv_ceph'] is not defined
+          or ceph_prepare_installation_flush_osds | bool
       block:
-        - name: Cleanup Ceph LV with ceph-volume
-          ansible.builtin.command: "ceph-volume lvm zap /dev/{{ lvm_volumes[0].data_vg }}/{{ lvm_volumes[0].data }}"
+        - name: Get real path for OSD disk for auto LVM
+          ansible.builtin.command: "realpath {{ ceph_osd_disk }}"
+          register: ceph_prepare_installation_auto_ceph_osd_realdisk
+          changed_when: false
+        - name: Check if OSD disk exists
+          ansible.builtin.stat:
+            path: "{{ ceph_prepare_installation_auto_ceph_osd_realdisk.stdout }}"
+          register: ceph_prepare_installation_disk_stat
+        - name: Fail if OSD disk does not exist
+          ansible.builtin.fail:
+            msg: "The OSD disk {{ ceph_osd_disk }} does not exist."
+          when: not ceph_prepare_installation_disk_stat.stat.exists
+        - name: Zap OSD disk for auto LVM
+          ansible.builtin.command: "{{ ceph_prepare_installation_ceph_volume_cmd }} lvm zap {{ ceph_prepare_installation_auto_ceph_osd_realdisk.stdout }} --destroy"
           changed_when: true
+        - name: Create full disk partition with LVM flag
+          community.general.parted:
+            device: "{{ ceph_prepare_installation_auto_ceph_osd_realdisk.stdout }}"
+            number: 1
+            label: gpt
+            part_start: "0%"
+            part_end: "100%"
+            flags:
+              - lvm
+            state: present
+          register: ceph_prepare_installation_full_disk_part
+        - name: Get disk/by-path of OSD disk
+          ansible.builtin.command: "/usr/bin/find -L /dev/disk/by-path -samefile {{ ceph_prepare_installation_full_disk_part.disk.dev }} -print -quit"
+          register: ceph_prepare_installation_ceph_osd_finddisk
+          changed_when: false
+        - name: Create volume group vg_ceph
+          community.general.lvg:
+            vg: vg_ceph
+            pvs: "{{ ceph_prepare_installation_ceph_osd_finddisk.stdout }}-part1"
+        - name: Create logical volume lv_ceph
+          community.general.lvol:
+            vg: vg_ceph
+            lv: lv_ceph
+            size: 100%VG
     - name: Create VG/LV if they don't exist
       when:
-        - lvm_volumes is not defined or ansible_lvm['lvs'][lvm_volumes[0].data] is not defined
+        - lvm_volumes is defined
+        - ansible_lvm['lvs'][lvm_volumes[0].data] is not defined
       block:
         - name: Get real path for OSD disk
           ansible.builtin.command: "realpath {{ ceph_osd_disk }}"
           register: ceph_prepare_installation_ceph_osd_realdisk
           changed_when: false
         - name: Cleanup Ceph OSD disks with ceph-volume
-          ansible.builtin.command: "ceph-volume lvm zap {{ ceph_prepare_installation_ceph_osd_realdisk.stdout }} --destroy"
+          ansible.builtin.command: "{{ ceph_prepare_installation_ceph_volume_cmd }} lvm zap {{ ceph_prepare_installation_ceph_osd_realdisk.stdout }} --destroy"
           when:
-            - lvm_volumes is not defined or lvm_volumes[0].device_number == 1 # The disk must not be zapped in the case of a single disk for linux and ceph
-            - not (is_using_cephadm | default(false))
-          changed_when: true
-        - name: Cleanup Ceph lvm's partition with ceph-volume
-          ansible.builtin.command: "ceph-volume lvm zap /dev/{{ lvm_volumes[0].data_vg }}"
-          when:
-            - lvm_volumes is defined and ansible_lvm['lvs'][lvm_volumes[0].data] is defined
-            - not (is_using_cephadm | default(false))
+            - lvm_volumes[0].device_number == 1
           changed_when: true
         - name: Create volumes for OSD disk
           when:


### PR DESCRIPTION
When only ceph_osd_disk is provided (no lvm_volumes), the role now automatically creates a single LVM volume group "vg_ceph" and logical volume "lv_ceph" using the full disk. This is needed for the cephadm playbook which expects this exact VG/LV naming.

- Add ceph_prepare_installation_flush_osds variable (default false) to   force re-creation even if the LVM already exists. 
- Check that the disk exists before attempting to create partitions.
- Zap the disk using the appropriate ceph-volume command (cephadm ceph-volume or ceph-volume depending on deployment mode).
- Create a single GPT partition with the lvm flag, then vg_ceph/lv_ceph.
- Restrict the legacy lvm_volumes creation path to only run when lvm_volumes is actually defined.
- Update README to document the new automatic LVM creation behavior and the flush_osds variable.
- Remove the ceph-volume dependency when we use cephadm.