### PR TITLE
cephadm: create RBD/cephfs pool with fixed pg_num to avoid failure on small disks

### DIFF
--- a/roles/cephadm/tasks/main.yml
+++ b/roles/cephadm/tasks/main.yml
@@ -363,7 +363,7 @@
   failed_when: false
 
 - name: Create RBD pool if it doesn't exist
-  ansible.builtin.command: ceph osd pool create rbd
+  ansible.builtin.command: ceph osd pool create rbd 1 1
   when: cephadm_rbd_pool_check.rc != 0
   changed_when: true
   run_once: true
@@ -371,6 +371,13 @@
 
 - name: Enable RBD application on the pool
   ansible.builtin.command: ceph osd pool application enable rbd rbd
+  when: cephadm_rbd_pool_check.rc != 0
+  changed_when: true
+  run_once: true
+  delegate_to: "{{ cephadm_first_node }}"
+
+- name: Enable autoscale on the RBD pool
+  ansible.builtin.command: ceph osd pool set rbd pg_autoscale_mode on
   when: cephadm_rbd_pool_check.rc != 0
   changed_when: true
   run_once: true

--- a/roles/deploy_cephfs/tasks/main.yml
+++ b/roles/deploy_cephfs/tasks/main.yml
@@ -21,11 +21,66 @@
     msg: "First monitor node detected: {{ deploy_cephfs_first_mon_node }}"
   run_once: true
 
-- name: Create CephFS volume 'seapathcephfs' on the first monitor
-  ansible.builtin.command: ceph fs volume create seapathcephfs
+- name: Check if CephFS 'seapathcephfs' already exists
+  ansible.builtin.command: ceph fs volume ls --format json
+  register: deploy_cephfs_volume_ls
+  changed_when: false
   delegate_to: "{{ deploy_cephfs_first_mon_node }}"
   run_once: true
+
+- name: Set fact for CephFS existence
+  ansible.builtin.set_fact:
+    deploy_cephfs_exists: "{{ (deploy_cephfs_volume_ls.stdout | default('[]') | from_json | selectattr('name', 'equalto', 'seapathcephfs') | list | length) > 0 }}"
+  run_once: true
+
+- name: Create CephFS metadata pool with fixed PG count
+  ansible.builtin.command: ceph osd pool create cephfs.seapathcephfs.meta 1 1
+  when: not deploy_cephfs_exists
   changed_when: true
+  delegate_to: "{{ deploy_cephfs_first_mon_node }}"
+  run_once: true
+
+- name: Create CephFS data pool with fixed PG count
+  ansible.builtin.command: ceph osd pool create cephfs.seapathcephfs.data 1 1
+  when: not deploy_cephfs_exists
+  changed_when: true
+  delegate_to: "{{ deploy_cephfs_first_mon_node }}"
+  run_once: true
+
+- name: Enable CephFS application on metadata pool
+  ansible.builtin.command: ceph osd pool application enable cephfs.seapathcephfs.meta cephfs
+  when: not deploy_cephfs_exists
+  changed_when: true
+  delegate_to: "{{ deploy_cephfs_first_mon_node }}"
+  run_once: true
+
+- name: Enable CephFS application on data pool
+  ansible.builtin.command: ceph osd pool application enable cephfs.seapathcephfs.data cephfs
+  when: not deploy_cephfs_exists
+  changed_when: true
+  delegate_to: "{{ deploy_cephfs_first_mon_node }}"
+  run_once: true
+
+- name: Create CephFS volume 'seapathcephfs' with explicit pools
+  ansible.builtin.command: ceph fs volume create seapathcephfs '' cephfs.seapathcephfs.meta cephfs.seapathcephfs.data
+  when: not deploy_cephfs_exists
+  changed_when: true
+  delegate_to: "{{ deploy_cephfs_first_mon_node }}"
+  run_once: true
+
+- name: Enable autoscale on CephFS metadata pool
+  ansible.builtin.command: ceph osd pool set cephfs.seapathcephfs.meta pg_autoscale_mode on
+  when: not deploy_cephfs_exists
+  changed_when: true
+  delegate_to: "{{ deploy_cephfs_first_mon_node }}"
+  run_once: true
+
+- name: Enable autoscale on CephFS data pool
+  ansible.builtin.command: ceph osd pool set cephfs.seapathcephfs.data pg_autoscale_mode on
+  when: not deploy_cephfs_exists
+  changed_when: true
+  delegate_to: "{{ deploy_cephfs_first_mon_node }}"
+  run_once: true
 
 - name: Get CephFS info to find the data pool
   ansible.builtin.command: ceph fs ls --format json


### PR DESCRIPTION
When creating the RBD pool without explicit PG count, Ceph's pg generator tries to autoscale immediately. On small disks this can fail because the initial PG count is too high for the available OSD space.

Create the pool with a fixed 1 PG (1 1) first, then explicitly re-enable pg_autoscale_mode afterwards. This lets the pool exist safely on small clusters while still benefiting from autoscaling as the cluster grows.

Do the same with cephfs.