### PR TITLE
network_systemdnetworkd, network_netplan: auto-create PTP VLAN interface

### DIFF
--- a/roles/network_netplan/README.md
+++ b/roles/network_netplan/README.md
@@ -11,6 +11,10 @@ No requirement.
 | Variable               | Required  | Type           | Comments                                                                               |
 |------------------------|-----------|----------------|----------------------------------------------------------------------------------------|
 | netplan_configurations | No        | List of string | List of netplan Ansible template files on the Ansible machine to be uploaded on target |
+| ptp_interface          | No        | String         | PTP interface name.                                                                    |
+| ptp_vlanid             | No        | Integer        | VLAN ID for PTP. If defined and non-empty, the role auto-generates `/etc/netplan/99-ptp-vlan.yaml`. |
+
+When both `ptp_interface` and `ptp_vlanid` are defined and non-empty, the role creates a supplemental netplan file (`99-ptp-vlan.yaml`) to bring up the VLAN interface. If you prefer to define the VLAN manually in your own netplan template, leave `ptp_vlanid` undefined.
 
 ## Example Playbook
 

--- a/roles/network_netplan/tasks/main.yml
+++ b/roles/network_netplan/tasks/main.yml
@@ -21,6 +21,21 @@
         mode: "0600"
       with_items: "{{ netplan_configurations }}"
       notify: Apply Netplan configuration
+    - name: Generate PTP VLAN netplan configuration
+      when:
+        - ptp_interface is defined
+        - ptp_interface is not none
+        - ptp_interface | length > 0
+        - ptp_vlanid is defined
+        - ptp_vlanid is not none
+        - ptp_vlanid | string | length > 0
+      ansible.builtin.template:
+        src: ptp_vlan.yaml.j2
+        dest: /etc/netplan/99-ptp-vlan.yaml
+        owner: root
+        group: root
+        mode: "0600"
+      notify: Apply Netplan configuration
     - name: Avoid reboot for netplan
       ansible.builtin.set_fact:
         need_reboot: false # noqa: var-naming[no-role-prefix]

--- a/roles/network_netplan/templates/ptp_vlan.yaml.j2
+++ b/roles/network_netplan/templates/ptp_vlan.yaml.j2
@@ -1,0 +1,6 @@
+network:
+  version: 2
+  vlans:
+    {{ ptp_interface }}.{{ ptp_vlanid }}:
+      id: {{ ptp_vlanid }}
+      link: {{ ptp_interface }}

--- a/roles/network_systemdnetworkd/README.md
+++ b/roles/network_systemdnetworkd/README.md
@@ -65,6 +65,10 @@ It can be used to connect to the VMs and the hypervisor on the same interface.
 | gateway_addr       | Yes      | String  |         | IP address of the gateway on the administration network                |
 | subnet             | No       | Integer | 24      | Subnet of the administration network in CIDR notation                  |
 | br0vlan            | No       | Integer |         | Number of the VLAN to configure a VLAN on the br0 bridge               |
+| ptp_interface      | No       | String  |         | PTP interface name. If set together with `ptp_vlanid`, a VLAN interface is automatically created. |
+| ptp_vlanid         | No       | Integer |         | VLAN ID for PTP. If defined and non-empty, the role creates `{{ ptp_interface }}.{{ ptp_vlanid }}`. |
+
+When both `ptp_interface` and `ptp_vlanid` are defined and non-empty, the role automatically generates the required `.netdev` and `.network` systemd-networkd profiles for the PTP VLAN interface.
 
 ## Example Playbook
 

--- a/roles/network_systemdnetworkd/meta/main.yml
+++ b/roles/network_systemdnetworkd/meta/main.yml
@@ -3,6 +3,7 @@
 ---
 galaxy_info:
   author: "Anthony Ruhier; Seapath"
+  namespace: "seapath"
   description: configures the network via systemd-networkd
   license: BSD
   min_ansible_version: 2.9.10

--- a/roles/network_systemdnetworkd/molecule/default/converge.yml
+++ b/roles/network_systemdnetworkd/molecule/default/converge.yml
@@ -1,0 +1,8 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: true
+  tasks:
+    - name: Apply role under test
+      ansible.builtin.include_role:
+        name: network_systemdnetworkd

--- a/roles/network_systemdnetworkd/molecule/default/molecule.yml
+++ b/roles/network_systemdnetworkd/molecule/default/molecule.yml
@@ -1,0 +1,49 @@
+---
+dependency:
+  name: galaxy
+
+driver:
+  name: podman
+
+platforms:
+  - name: hv1
+    image: docker.io/geerlingguy/docker-debian13-ansible:latest
+    privileged: true
+    command: /sbin/init
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      roles_path: "${MOLECULE_PROJECT_DIRECTORY}/.."
+  playbooks:
+    prepare: prepare.yml
+    converge: converge.yml
+    verify: verify.yml
+  inventory:
+    host_vars:
+      hv1:
+        network_simple: true
+        network_systemdnetworkd_enable_resolved: false
+        network_systemdnetworkd_link:
+          10-eth0:
+            - Match:
+                - Name: "eth0"
+            - Link:
+                - MTUBytes: 1800
+        custom_netdev:
+          20-bridge0:
+            - NetDev:
+                - Name: "bridge0"
+                - Kind: "bridge"
+        custom_network:
+          30-test0:
+            - Match:
+                - Name: "eth0"
+            - Network:
+                - DHCP: "yes"
+
+verifier:
+  name: ansible

--- a/roles/network_systemdnetworkd/molecule/default/prepare.yml
+++ b/roles/network_systemdnetworkd/molecule/default/prepare.yml
@@ -1,0 +1,31 @@
+---
+- name: Prepare test environment (Debian 13)
+  hosts: all
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Ensure group systemd-network exists
+      ansible.builtin.group:
+        name: systemd-network
+        state: present
+
+    - name: Ensure /etc/systemd/network directory exists
+      ansible.builtin.file:
+        path: /etc/systemd/network
+        state: directory
+        mode: "0755"
+
+    - name: Ensure udev package is installed
+      ansible.builtin.apt:
+        name:
+          - udev
+        state: present
+        update_cache: true
+
+    - name: Ensure systemd-udev-trigger service exists
+      ansible.builtin.systemd:
+        name: systemd-udev-trigger
+        enabled: true
+        daemon_reload: true
+      failed_when: false

--- a/roles/network_systemdnetworkd/molecule/default/verify.yml
+++ b/roles/network_systemdnetworkd/molecule/default/verify.yml
@@ -1,0 +1,99 @@
+---
+- name: Verify network_systemdnetworkd configuration
+  hosts: all
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Ensure /etc/systemd/network/10-eth0.link exists
+      ansible.builtin.stat:
+        path: /etc/systemd/network/10-eth0.link
+      register: network_systemdnetworkd_link_stat
+
+    - name: Assert /etc/systemd/network/10-eth0.link exists with correct ownership and permissions
+      ansible.builtin.assert:
+        that:
+          - network_systemdnetworkd_link_stat.stat.exists
+          - network_systemdnetworkd_link_stat.stat.mode == "0640"
+          - network_systemdnetworkd_link_stat.stat.pw_name == "root"
+          - network_systemdnetworkd_link_stat.stat.gr_name == "systemd-network"
+        fail_msg: "/etc/systemd/network/10-eth0.link missing or wrong permissions/ownership"
+
+    - name: Read /etc/systemd/network/10-eth0.link content
+      ansible.builtin.slurp:
+        src: /etc/systemd/network/10-eth0.link
+      register: network_systemdnetworkd_link_content
+
+    - name: Assert /etc/systemd/network/10-eth0.link has expected content
+      ansible.builtin.assert:
+        that:
+          - "'[Match]' in network_systemdnetworkd_link_content.content | b64decode"
+          - "'Name=eth0' in network_systemdnetworkd_link_content.content | b64decode"
+          - "'[Link]' in network_systemdnetworkd_link_content.content | b64decode"
+          - "'MTUBytes=1800' in network_systemdnetworkd_link_content.content | b64decode"
+        fail_msg: "/etc/systemd/network/10-eth0.link does not contain expected values"
+
+    - name: Ensure /etc/systemd/network/20-bridge0.netdev exists
+      ansible.builtin.stat:
+        path: /etc/systemd/network/20-bridge0.netdev
+      register: network_systemdnetworkd_netdev_stat
+
+    - name: Assert /etc/systemd/network/20-bridge0.netdev exists with correct ownership and permissions
+      ansible.builtin.assert:
+        that:
+          - network_systemdnetworkd_netdev_stat.stat.exists
+          - network_systemdnetworkd_netdev_stat.stat.mode == "0640"
+          - network_systemdnetworkd_netdev_stat.stat.pw_name == "root"
+          - network_systemdnetworkd_netdev_stat.stat.gr_name == "systemd-network"
+        fail_msg: "/etc/systemd/network/20-bridge0.netdev missing or wrong permissions/ownership"
+
+    - name: Read /etc/systemd/network/20-bridge0.netdev content
+      ansible.builtin.slurp:
+        src: /etc/systemd/network/20-bridge0.netdev
+      register: network_systemdnetworkd_netdev_content
+
+    - name: Assert /etc/systemd/network/20-bridge0.netdev has expected content
+      ansible.builtin.assert:
+        that:
+          - "'[NetDev]' in network_systemdnetworkd_netdev_content.content | b64decode"
+          - "'Name=bridge0' in network_systemdnetworkd_netdev_content.content | b64decode"
+          - "'Kind=bridge' in network_systemdnetworkd_netdev_content.content | b64decode"
+        fail_msg: "/etc/systemd/network/20-bridge0.netdev does not contain expected values"
+
+    - name: Ensure /etc/systemd/network/30-test0.network exists
+      ansible.builtin.stat:
+        path: /etc/systemd/network/30-test0.network
+      register: network_systemdnetworkd_network_stat
+
+    - name: Assert /etc/systemd/network/30-test0.network exists with correct ownership and permissions
+      ansible.builtin.assert:
+        that:
+          - network_systemdnetworkd_network_stat.stat.exists
+          - network_systemdnetworkd_network_stat.stat.mode == "0640"
+          - network_systemdnetworkd_network_stat.stat.pw_name == "root"
+          - network_systemdnetworkd_network_stat.stat.gr_name == "systemd-network"
+        fail_msg: "/etc/systemd/network/30-test0.network missing or wrong permissions/ownership"
+
+    - name: Read /etc/systemd/network/30-test0.network content
+      ansible.builtin.slurp:
+        src: /etc/systemd/network/30-test0.network
+      register: network_systemdnetworkd_network_content
+
+    - name: Assert /etc/systemd/network/30-test0.network has expected content
+      ansible.builtin.assert:
+        that:
+          - "'[Match]' in network_systemdnetworkd_network_content.content | b64decode"
+          - "'Name=eth0' in network_systemdnetworkd_network_content.content | b64decode"
+          - "'[Network]' in network_systemdnetworkd_network_content.content | b64decode"
+          - "'DHCP=yes' in network_systemdnetworkd_network_content.content | b64decode"
+        fail_msg: "/etc/systemd/network/30-test0.network does not contain expected values"
+
+    - name: Gather service facts
+      ansible.builtin.service_facts:
+
+    - name: Assert systemd-networkd is enabled
+      ansible.builtin.assert:
+        that:
+          - services['systemd-networkd.service'] is defined
+          - services['systemd-networkd.service'].status == 'enabled'
+        fail_msg: "systemd-networkd is not enabled"

--- a/roles/network_systemdnetworkd/molecule/ptp_vlan/molecule.yml
+++ b/roles/network_systemdnetworkd/molecule/ptp_vlan/molecule.yml
@@ -1,0 +1,53 @@
+---
+dependency:
+  name: galaxy
+
+driver:
+  name: podman
+
+platforms:
+  - name: hv1
+    image: docker.io/geerlingguy/docker-debian13-ansible:latest
+    privileged: true
+    command: /sbin/init
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      roles_path: "${MOLECULE_PROJECT_DIRECTORY}/.."
+  playbooks:
+    prepare: ../default/prepare.yml
+    converge: ../default/converge.yml
+    verify: verify.yml
+  inventory:
+    host_vars:
+      hv1:
+        network_systemdnetworkd_enable_resolved: false
+        network_interface: "eth0"
+        ip_addr: "192.168.1.10"
+        gateway_addr: "192.168.1.1"
+        ptp_interface: "eth0"
+        ptp_vlanid: 100
+        network_systemdnetworkd_link:
+          10-eth0:
+            - Match:
+                - Name: "eth0"
+            - Link:
+                - MTUBytes: 1800
+        custom_netdev:
+          20-bridge0:
+            - NetDev:
+                - Name: "bridge0"
+                - Kind: "bridge"
+        custom_network:
+          30-test0:
+            - Match:
+                - Name: "eth0"
+            - Network:
+                - DHCP: "yes"
+
+verifier:
+  name: ansible

--- a/roles/network_systemdnetworkd/molecule/ptp_vlan/verify.yml
+++ b/roles/network_systemdnetworkd/molecule/ptp_vlan/verify.yml
@@ -1,0 +1,183 @@
+---
+- name: Verify network_systemdnetworkd PTP VLAN configuration
+  hosts: all
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Ensure /etc/systemd/network/10-eth0.link exists
+      ansible.builtin.stat:
+        path: /etc/systemd/network/10-eth0.link
+      register: network_systemdnetworkd_link_stat
+
+    - name: Assert /etc/systemd/network/10-eth0.link exists with correct ownership and permissions
+      ansible.builtin.assert:
+        that:
+          - network_systemdnetworkd_link_stat.stat.exists
+          - network_systemdnetworkd_link_stat.stat.mode == "0640"
+          - network_systemdnetworkd_link_stat.stat.pw_name == "root"
+          - network_systemdnetworkd_link_stat.stat.gr_name == "systemd-network"
+        fail_msg: "/etc/systemd/network/10-eth0.link missing or wrong permissions/ownership"
+
+    - name: Read /etc/systemd/network/10-eth0.link content
+      ansible.builtin.slurp:
+        src: /etc/systemd/network/10-eth0.link
+      register: network_systemdnetworkd_link_content
+
+    - name: Assert /etc/systemd/network/10-eth0.link has expected content
+      ansible.builtin.assert:
+        that:
+          - "'[Match]' in network_systemdnetworkd_link_content.content | b64decode"
+          - "'Name=eth0' in network_systemdnetworkd_link_content.content | b64decode"
+          - "'[Link]' in network_systemdnetworkd_link_content.content | b64decode"
+          - "'MTUBytes=1800' in network_systemdnetworkd_link_content.content | b64decode"
+        fail_msg: "/etc/systemd/network/10-eth0.link does not contain expected values"
+
+    - name: Ensure /etc/systemd/network/20-bridge0.netdev exists
+      ansible.builtin.stat:
+        path: /etc/systemd/network/20-bridge0.netdev
+      register: network_systemdnetworkd_netdev_stat
+
+    - name: Assert /etc/systemd/network/20-bridge0.netdev exists with correct ownership and permissions
+      ansible.builtin.assert:
+        that:
+          - network_systemdnetworkd_netdev_stat.stat.exists
+          - network_systemdnetworkd_netdev_stat.stat.mode == "0640"
+          - network_systemdnetworkd_netdev_stat.stat.pw_name == "root"
+          - network_systemdnetworkd_netdev_stat.stat.gr_name == "systemd-network"
+        fail_msg: "/etc/systemd/network/20-bridge0.netdev missing or wrong permissions/ownership"
+
+    - name: Read /etc/systemd/network/20-bridge0.netdev content
+      ansible.builtin.slurp:
+        src: /etc/systemd/network/20-bridge0.netdev
+      register: network_systemdnetworkd_netdev_content
+
+    - name: Assert /etc/systemd/network/20-bridge0.netdev has expected content
+      ansible.builtin.assert:
+        that:
+          - "'[NetDev]' in network_systemdnetworkd_netdev_content.content | b64decode"
+          - "'Name=bridge0' in network_systemdnetworkd_netdev_content.content | b64decode"
+          - "'Kind=bridge' in network_systemdnetworkd_netdev_content.content | b64decode"
+        fail_msg: "/etc/systemd/network/20-bridge0.netdev does not contain expected values"
+
+    - name: Ensure /etc/systemd/network/30-test0.network exists
+      ansible.builtin.stat:
+        path: /etc/systemd/network/30-test0.network
+      register: network_systemdnetworkd_network_stat
+
+    - name: Assert /etc/systemd/network/30-test0.network exists with correct ownership and permissions
+      ansible.builtin.assert:
+        that:
+          - network_systemdnetworkd_network_stat.stat.exists
+          - network_systemdnetworkd_network_stat.stat.mode == "0640"
+          - network_systemdnetworkd_network_stat.stat.pw_name == "root"
+          - network_systemdnetworkd_network_stat.stat.gr_name == "systemd-network"
+        fail_msg: "/etc/systemd/network/30-test0.network missing or wrong permissions/ownership"
+
+    - name: Read /etc/systemd/network/30-test0.network content
+      ansible.builtin.slurp:
+        src: /etc/systemd/network/30-test0.network
+      register: network_systemdnetworkd_network_content
+
+    - name: Assert /etc/systemd/network/30-test0.network has expected content
+      ansible.builtin.assert:
+        that:
+          - "'[Match]' in network_systemdnetworkd_network_content.content | b64decode"
+          - "'Name=eth0' in network_systemdnetworkd_network_content.content | b64decode"
+          - "'[Network]' in network_systemdnetworkd_network_content.content | b64decode"
+          - "'DHCP=yes' in network_systemdnetworkd_network_content.content | b64decode"
+        fail_msg: "/etc/systemd/network/30-test0.network does not contain expected values"
+
+    - name: Ensure /etc/systemd/network/80-ptp-vlan.netdev exists
+      ansible.builtin.stat:
+        path: /etc/systemd/network/80-ptp-vlan.netdev
+      register: network_systemdnetworkd_ptp_vlan_netdev_stat
+
+    - name: Assert /etc/systemd/network/80-ptp-vlan.netdev exists with correct ownership and permissions
+      ansible.builtin.assert:
+        that:
+          - network_systemdnetworkd_ptp_vlan_netdev_stat.stat.exists
+          - network_systemdnetworkd_ptp_vlan_netdev_stat.stat.mode == "0640"
+          - network_systemdnetworkd_ptp_vlan_netdev_stat.stat.pw_name == "root"
+          - network_systemdnetworkd_ptp_vlan_netdev_stat.stat.gr_name == "systemd-network"
+        fail_msg: "/etc/systemd/network/80-ptp-vlan.netdev missing or wrong permissions/ownership"
+
+    - name: Read /etc/systemd/network/80-ptp-vlan.netdev content
+      ansible.builtin.slurp:
+        src: /etc/systemd/network/80-ptp-vlan.netdev
+      register: network_systemdnetworkd_ptp_vlan_netdev_content
+
+    - name: Assert /etc/systemd/network/80-ptp-vlan.netdev has expected content
+      ansible.builtin.assert:
+        that:
+          - "'[NetDev]' in network_systemdnetworkd_ptp_vlan_netdev_content.content | b64decode"
+          - "'Name=eth0.100' in network_systemdnetworkd_ptp_vlan_netdev_content.content | b64decode"
+          - "'Kind=vlan' in network_systemdnetworkd_ptp_vlan_netdev_content.content | b64decode"
+          - "'[VLAN]' in network_systemdnetworkd_ptp_vlan_netdev_content.content | b64decode"
+          - "'Id=100' in network_systemdnetworkd_ptp_vlan_netdev_content.content | b64decode"
+        fail_msg: "/etc/systemd/network/80-ptp-vlan.netdev does not contain expected values"
+
+    - name: Ensure /etc/systemd/network/80-ptp-parent.network exists
+      ansible.builtin.stat:
+        path: /etc/systemd/network/80-ptp-parent.network
+      register: network_systemdnetworkd_ptp_parent_network_stat
+
+    - name: Assert /etc/systemd/network/80-ptp-parent.network exists with correct ownership and permissions
+      ansible.builtin.assert:
+        that:
+          - network_systemdnetworkd_ptp_parent_network_stat.stat.exists
+          - network_systemdnetworkd_ptp_parent_network_stat.stat.mode == "0640"
+          - network_systemdnetworkd_ptp_parent_network_stat.stat.pw_name == "root"
+          - network_systemdnetworkd_ptp_parent_network_stat.stat.gr_name == "systemd-network"
+        fail_msg: "/etc/systemd/network/80-ptp-parent.network missing or wrong permissions/ownership"
+
+    - name: Read /etc/systemd/network/80-ptp-parent.network content
+      ansible.builtin.slurp:
+        src: /etc/systemd/network/80-ptp-parent.network
+      register: network_systemdnetworkd_ptp_parent_network_content
+
+    - name: Assert /etc/systemd/network/80-ptp-parent.network has expected content
+      ansible.builtin.assert:
+        that:
+          - "'[Match]' in network_systemdnetworkd_ptp_parent_network_content.content | b64decode"
+          - "'Name=eth0' in network_systemdnetworkd_ptp_parent_network_content.content | b64decode"
+          - "'[Network]' in network_systemdnetworkd_ptp_parent_network_content.content | b64decode"
+          - "'VLAN=eth0.100' in network_systemdnetworkd_ptp_parent_network_content.content | b64decode"
+        fail_msg: "/etc/systemd/network/80-ptp-parent.network does not contain expected values"
+
+    - name: Ensure /etc/systemd/network/80-ptp-vlan.network exists
+      ansible.builtin.stat:
+        path: /etc/systemd/network/80-ptp-vlan.network
+      register: network_systemdnetworkd_ptp_vlan_network_stat
+
+    - name: Assert /etc/systemd/network/80-ptp-vlan.network exists with correct ownership and permissions
+      ansible.builtin.assert:
+        that:
+          - network_systemdnetworkd_ptp_vlan_network_stat.stat.exists
+          - network_systemdnetworkd_ptp_vlan_network_stat.stat.mode == "0640"
+          - network_systemdnetworkd_ptp_vlan_network_stat.stat.pw_name == "root"
+          - network_systemdnetworkd_ptp_vlan_network_stat.stat.gr_name == "systemd-network"
+        fail_msg: "/etc/systemd/network/80-ptp-vlan.network missing or wrong permissions/ownership"
+
+    - name: Read /etc/systemd/network/80-ptp-vlan.network content
+      ansible.builtin.slurp:
+        src: /etc/systemd/network/80-ptp-vlan.network
+      register: network_systemdnetworkd_ptp_vlan_network_content
+
+    - name: Assert /etc/systemd/network/80-ptp-vlan.network has expected content
+      ansible.builtin.assert:
+        that:
+          - "'[Match]' in network_systemdnetworkd_ptp_vlan_network_content.content | b64decode"
+          - "'Name=eth0.100' in network_systemdnetworkd_ptp_vlan_network_content.content | b64decode"
+          - "'[Network]' in network_systemdnetworkd_ptp_vlan_network_content.content | b64decode"
+        fail_msg: "/etc/systemd/network/80-ptp-vlan.network does not contain expected values"
+
+    - name: Gather service facts
+      ansible.builtin.service_facts:
+
+    - name: Assert systemd-networkd is enabled
+      ansible.builtin.assert:
+        that:
+          - services['systemd-networkd.service'] is defined
+          - services['systemd-networkd.service'].status == 'enabled'
+        fail_msg: "systemd-networkd is not enabled"

--- a/roles/network_systemdnetworkd/vars/network_defaults.yml
+++ b/roles/network_systemdnetworkd/vars/network_defaults.yml
@@ -64,8 +64,37 @@ network_systemdnetworkd_br0_network:
 network_systemdnetworkd_wired_netdev: "{{ network_systemdnetworkd_br0vlan_netdev if br0vlan is defined else network_systemdnetworkd_br0_netdev }}"
 network_systemdnetworkd_wired_network: "{{ network_systemdnetworkd_br0vlan_network if br0vlan is defined else network_systemdnetworkd_br0_network }}"
 
-network_systemdnetworkd_netdev_nocluster: "{{ network_systemdnetworkd_wired_netdev | combine(network_systemdnetworkd_netdev_custom) }}"
-network_systemdnetworkd_network_nocluster: "{{ network_systemdnetworkd_wired_network | combine(network_systemdnetworkd_network_custom) }}"
+network_systemdnetworkd_ptp_vlan_enabled: >-
+  {{ ptp_interface is defined and ptp_interface is not none and ptp_interface | length > 0
+     and ptp_vlanid is defined and ptp_vlanid is not none and ptp_vlanid | string | length > 0 }}
+
+network_systemdnetworkd_ptp_vlan_netdev:
+  80-ptp-vlan:
+    - NetDev:
+        - Name: "{{ (ptp_interface | default('')) + '.' + (ptp_vlanid | default('') | string) }}"
+        - Kind: "vlan"
+    - VLAN:
+        - Id: "{{ ptp_vlanid | default('') }}"
+
+network_systemdnetworkd_ptp_vlan_network:
+  80-ptp-parent:
+    - Match:
+        - Name: "{{ ptp_interface | default('') }}"
+    - Network:
+        - VLAN: "{{ (ptp_interface | default('')) + '.' + (ptp_vlanid | default('') | string) }}"
+  80-ptp-vlan:
+    - Match:
+        - Name: "{{ (ptp_interface | default('')) + '.' + (ptp_vlanid | default('') | string) }}"
+    - Network: []
+
+network_systemdnetworkd_netdev_nocluster: >-
+  {{ network_systemdnetworkd_wired_netdev
+     | combine(network_systemdnetworkd_netdev_custom)
+     | combine(network_systemdnetworkd_ptp_vlan_netdev if network_systemdnetworkd_ptp_vlan_enabled else {}) }}
+network_systemdnetworkd_network_nocluster: >-
+  {{ network_systemdnetworkd_wired_network
+     | combine(network_systemdnetworkd_network_custom)
+     | combine(network_systemdnetworkd_ptp_vlan_network if network_systemdnetworkd_ptp_vlan_enabled else {}) }}
 
 ## Helper variables, this should probably be refactored with the other network vars files TODO
 network_systemdnetworkd_no_cluster_network_variable: "{{ network_systemdnetworkd_no_cluster_network is defined and network_systemdnetworkd_no_cluster_network }}"


### PR DESCRIPTION
When both ptp_interface and ptp_vlanid are defined and non-empty, the network roles now automatically create the VLAN interface needed by the timemaster role.

- network_systemdnetworkd: generate .netdev and .network profiles for the PTP VLAN interface (e.g. eno1.100).
- network_netplan: generate a supplemental /etc/netplan/99-ptp-vlan.yaml.
- Document the new ptp_interface and ptp_vlanid variables in both roles' README.md.

If ptp_vlanid or ptp_interface is undefined, none, or empty, nothing is created (backward compatible).