### PR TITLE
Wrynose migration

### DIFF
--- a/playbooks/cluster_setup_cephadm.yaml
+++ b/playbooks/cluster_setup_cephadm.yaml
@@ -35,4 +35,5 @@
   roles:
     - detect_seapath_distro
     - cephadm
-    - deploy_cephfs
+    - role: deploy_cephfs
+      when: seapath_distro == "Debian"

--- a/roles/ceph_expansion_lv/tasks/main.yml
+++ b/roles/ceph_expansion_lv/tasks/main.yml
@@ -44,7 +44,7 @@
         ceph_expansion_lv_osdid: "{{ item.key | regex_search('@(osd\\.[0-9]+)\\.service', '\\1') | list | first }}"
         ceph_expansion_lv_osdid_number: "{{ ((item.key | regex_search('@(osd\\.[0-9]+)\\.service', '\\1') | list).0).split('.')[-1] }}"
       loop: "{{ ansible_facts.services | dict2items }}"
-      when: "'osd' in item.key"
+      when: item.key | regex_search('@osd\\.[0-9]+\\.service') is not none
       loop_control:
         label: "{{ item.key }}"
     - name: Show result

--- a/roles/network_netplan/tasks/main.yml
+++ b/roles/network_netplan/tasks/main.yml
@@ -21,6 +21,15 @@
         mode: "0600"
       with_items: "{{ netplan_configurations }}"
       notify: Apply Netplan configuration
+    - name: Check of netplan-configure service exist on the target
+      ansible.builtin.service_facts:
+    - name: Enable netplan-configure.service
+      ansible.builtin.systemd:
+        name: netplan-configure.service
+        enabled: true
+        state: restarted
+      when:
+        - '"netplan-configure.service" in ansible_facts.services'
     - name: Avoid reboot for netplan
       ansible.builtin.set_fact:
         need_reboot: false # noqa: var-naming[no-role-prefix]


### PR DESCRIPTION
Hello,
This PR adds minor fixes to prepare the upcoming release of the Wrynose LTS of Yocto on the SEAPATH Yocto version.
* Run only `deploy_cephfs` on SEAPATH Debian as this role is currently not supported on SEAPATH Yocto
* Fix a failing task in with `ceph_expansion_lv` role when a cephadm installation is run on a fresh installation of a SEAPATH Yocto hypervisor
* Enable the `netplan-configure.service` systemd service when using Netplan. This service is new since Netplan 1.2.0, and is used to run all the Netplan backend operation, including the setup of the network interfaces on startup.