### PR TITLE
hardening: bug cephadm account

### DIFF
--- a/roles/debian_hardening_physical_machine/tasks/main.yml
+++ b/roles/debian_hardening_physical_machine/tasks/main.yml
@@ -48,7 +48,7 @@
   when:
     - not revert
     - cluster_ip_addr is defined
-    - force_cephadm | default(false)
+    - is_using_cephadm | default(false)
 
 - name: Adding Debian-snmp user to group privileged
   ansible.builtin.user:


### PR DESCRIPTION
force_cephadm is the variable used in the inventory, but the correct variable to determine whether we are using cephadm is is_using_cephadm.