### PR TITLE
inventories/examples: drop osd_pool_default_pg{,p}_num overrides

### DIFF
--- a/inventories/examples/seapath-cluster.yaml
+++ b/inventories/examples/seapath-cluster.yaml
@@ -109,8 +109,6 @@ mons:
       global:
         osd_pool_default_size: "{{ groups['hypervisors'] | length }}"
         osd_pool_default_min_size: 1
-        osd_pool_default_pg_num: 128
-        osd_pool_default_pgp_num: 128
         osd_crush_chooseleaf_type: 1
         mon_osd_min_down_reporters: 1
       mon:


### PR DESCRIPTION
## Summary
- Remove \`osd_pool_default_pg_num: 128\` and \`osd_pool_default_pgp_num: 128\` from the example SEAPATH cluster inventory.
- These overrides conflict with the PG autoscaler (enabled by default in Quincy+), which starts new pools at \`pg_num = 1\`. The mismatch makes pool creation fail with \`Error ERANGE: 'pgp_num' must be greater than 0 and lower or equal than 'pg_num', which in this case is 1\` on small clusters.
- Replaces #917, which worked around the symptom by creating pools with a fixed \`pg_num\` and re-enabling the autoscaler. The inventory-level fix removes the need for that workaround entirely.

Closes #922.

## Test plan
- [x] Deploy a 3-node SEAPATH cluster with small OSDs using the example inventory.
- [x] Verify the RBD pool is created without ERANGE errors.
- [x] Verify CephFS pools are created without EINVAL errors.
- [x] Verify \`ceph osd pool autoscale-status\` shows the autoscaler managing pg_num/pgp_num.