### PR TITLE
cluster_setup_cephadm: add cephfs support for Yocto

### DIFF
--- a/playbooks/cluster_setup_cephadm.yaml
+++ b/playbooks/cluster_setup_cephadm.yaml
@@ -43,5 +43,4 @@
   roles:
     - detect_seapath_distro
     - cephadm
-    - role: deploy_cephfs
-      when: seapath_distro == "Debian"
+    - deploy_cephfs

--- a/roles/deploy_cephfs/README.md
+++ b/roles/deploy_cephfs/README.md
@@ -11,6 +11,7 @@ You need to use cephadm and not ceph-ansible to use this feature
 | Variable                      | Required | Type   | Default                                    | Comments                                                                 |
 |-------------------------------|----------|--------|--------------------------------------------|--------------------------------------------------------------------------|
 | `deploy_cephfs_localdirtoupload` | No       | string | No default                                  | Local directory that will be uploaded to ceph_fs volume once created |
+| `deploy_cephfs_remotedir_map`    | No       | Map    | No default                                  | Destination directory of the CephFS mount point depending of the SEAPATH distribution |
 | `deploy_cephfs_remotedir`        | No       | string | `/mnt/cephfs/`                              | Destination directory on the remote hosts (CephFS mount point). Files from `deploy_cephfs_localdirtoupload` will be copied here. |
 
 ## Example Playbook

--- a/roles/deploy_cephfs/README.md
+++ b/roles/deploy_cephfs/README.md
@@ -8,11 +8,10 @@ You need to use cephadm and not ceph-ansible to use this feature
 
 ## Role Variables
 
-| Variable                      | Required | Type   | Default                                    | Comments                                                                 |
-|-------------------------------|----------|--------|--------------------------------------------|--------------------------------------------------------------------------|
-| `deploy_cephfs_localdirtoupload` | No       | string | No default                                  | Local directory that will be uploaded to ceph_fs volume once created |
-| `deploy_cephfs_remotedir_map`    | No       | Map    | No default                                  | Destination directory of the CephFS mount point depending of the SEAPATH distribution |
-| `deploy_cephfs_remotedir`        | No       | string | `/mnt/cephfs/`                              | Destination directory on the remote hosts (CephFS mount point). Files from `deploy_cephfs_localdirtoupload` will be copied here. |
+| Variable                      | Required | Type   | Default                                           | Comments                                                                 |
+|-------------------------------|----------|--------|---------------------------------------------------|--------------------------------------------------------------------------|
+| `deploy_cephfs_localdirtoupload` | No       | string | No default                                     | Local directory that will be uploaded to ceph_fs volume once created |
+| `deploy_cephfs_remotedir`        | No       | string | `/mnt/cephfs/` (/mnt/persistant/ceph on Yocto) | Destination directory on the remote hosts (CephFS mount point). Files from `deploy_cephfs_localdirtoupload` will be copied here. |
 
 ## Example Playbook
 

--- a/roles/deploy_cephfs/defaults/main.yml
+++ b/roles/deploy_cephfs/defaults/main.yml
@@ -2,4 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-deploy_cephfs_remotedir: "/mnt/cephfs/"
+deploy_cephfs_remotedir_map:
+  Debian: "/mnt/cephfs/"
+  Yocto: "/mnt/persistent/cephfs/"
+
+deploy_cephfs_remotedir: "{{ deploy_cephfs_remotedir_map[seapath_distro] | default('/mnt/cephfs/') }}"

--- a/roles/deploy_cephfs/defaults/main.yml
+++ b/roles/deploy_cephfs/defaults/main.yml
@@ -1,9 +1,6 @@
 # Copyright (C) 2025 RTE
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-deploy_cephfs_remotedir_map:
-  Debian: "/mnt/cephfs/"
-  Yocto: "/mnt/persistent/cephfs/"
-
-deploy_cephfs_remotedir: "{{ deploy_cephfs_remotedir_map[seapath_distro] | default('/mnt/cephfs/') }}"
+deploy_cephfs_remotedir: "{{ '/mnt/persistent/cephfs/' if seapath_distro == 'Yocto' else '/mnt/cephfs/' }}"

--- a/roles/deploy_cephfs/tasks/main.yml
+++ b/roles/deploy_cephfs/tasks/main.yml
@@ -92,6 +92,7 @@
     mode: "0755"
     owner: root
     group: root
+  when: seapath_distro == "Debian"
 
 - name: Install ceph-mds-ready@seapathcephfs.service
   ansible.builtin.copy:
@@ -100,6 +101,7 @@
     mode: "0644"
     owner: root
     group: root
+  when: seapath_distro == "Debian"
 
 - name: Enable and start ceph-mds-ready@seapathcephfs.service
   ansible.builtin.systemd:

--- a/roles/deploy_cephfs/tasks/main.yml
+++ b/roles/deploy_cephfs/tasks/main.yml
@@ -92,7 +92,7 @@
     mode: "0755"
     owner: root
     group: root
-  when: seapath_distro == "Debian"
+  when: seapath_distro != "Yocto"
 
 - name: Install ceph-mds-ready@seapathcephfs.service
   ansible.builtin.copy:
@@ -101,7 +101,7 @@
     mode: "0644"
     owner: root
     group: root
-  when: seapath_distro == "Debian"
+  when: seapath_distro != "Yocto"
 
 - name: Enable and start ceph-mds-ready@seapathcephfs.service
   ansible.builtin.systemd:
@@ -109,6 +109,7 @@
     enabled: true
     state: started
     daemon_reload: true
+  when: seapath_distro != "Yocto"
 
 - name: Build Ceph monitor list for fstab from detected monitors
   ansible.builtin.set_fact:


### PR DESCRIPTION
Add the needed modification to support Cephfs integration in SEAPATH Yocto. Note that:
- Required files `ceph-mds-ready@seapathcephfs.service` and `wait-for-mds.sh` are already installed in the image.
- The default Cephfs directory is located in the persistent directory.

**NOTE:** This PR is currently only compatible on SEAPATH Yocto Wrynose. 