### PR TITLE
debian: adapt tests (docker/dpdk), disable install-recommends, fix ssh warning

### DIFF
--- a/roles/debian/tasks/main.yml
+++ b/roles/debian/tasks/main.yml
@@ -123,6 +123,14 @@
     group: "{{ admin_user }}"
     mode: "0644"
 
+- name: Configure APT Install-Recommends
+  ansible.builtin.copy:
+    dest: /etc/apt/apt.conf.d/99norecommends
+    content: 'APT::Install-Recommends "0";'
+    owner: root
+    group: root
+    mode: "0644"
+
 - name: Configure APT repositories
   when: apt_repo is defined
   block:

--- a/roles/debian_hardening/templates/ssh-audit_hardening.conf.j2
+++ b/roles/debian_hardening/templates/ssh-audit_hardening.conf.j2
@@ -7,7 +7,7 @@ HostKey /etc/ssh/ssh_host_ed25519_key
 
 # Restrict key exchange, cipher, and MAC algorithms, as per sshaudit.com
 # hardening guide.
-KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha256
+KexAlgorithms mlkem768x25519-sha256,curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha256
 Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
 MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com
 HostKeyAlgorithms ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,sk-ssh-ed25519-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-512,rsa-sha2-256-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com

--- a/roles/debian_tests/cukinia-tests/cukinia/common_security_tests.d/apt.conf.j2
+++ b/roles/debian_tests/cukinia-tests/cukinia/common_security_tests.d/apt.conf.j2
@@ -59,8 +59,6 @@ cpuset|\
 crmsh|\
 curl|\
 dbus|\
-docker-compose|\
-docker.io|\
 dstat|\
 firmware-linux-nonfree|\
 gnupg|\
@@ -95,6 +93,7 @@ nginx|\
 ntfs-3g|\
 openssh-server|\
 openvswitch-switch|\
+openvswitch-switch-dpdk|\
 ovmf|\
 pacemaker|\
 patch|\

--- a/roles/debian_tests/cukinia-tests/cukinia/common_security_tests.d/systemd.conf
+++ b/roles/debian_tests/cukinia-tests/cukinia/common_security_tests.d/systemd.conf
@@ -20,7 +20,7 @@ corosync|\
 cron|\
 dbus|\
 dm-event|\
-docker|\
+dpdk|\
 getty|\
 hddtemp|\
 irqbalance|\


### PR DESCRIPTION
debian-tests: remove docker and add dpdk
The debian iso contains ovs-dpdk by default now.
At the same time, docker is not used anymore (replaced by podman).

----
debian: disable apt install-recommends by default
This is to prevent recommended packages from being pulled in automatically, reducing unnecessary package bloat on managed hosts.

----
fix(debian/hardning/ssh): add ML-KEM-768 to KexAlgorithms in ssh-audit hardening config
The ANSSI BP-28 hardening config generated by ssh-audit predates
post-quantum key exchange support in OpenSSH. As a result, OpenSSH 10.0
was unable to negotiate mlkem768x25519-sha256 and fell back to classical
algorithms, triggering a "store now, decrypt later" warning on every
connection despite both client and server supporting PQ.
Prepend mlkem768x25519-sha256 to the KexAlgorithms list in
sshd_config.d/ssh-audit_hardening.conf. This hybrid algorithm combines
ML-KEM-768 (FIPS 203) with X25519, retaining full classical security
while adding quantum resistance. The remainder of the hardened algorithm
list is unchanged.