### PR TITLE
fix: various fixes

### DIFF
--- a/library/cluster_vm.py
+++ b/library/cluster_vm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
 # SPDX-License-Identifier: Apache-2.0

--- a/roles/configure_ha/tasks/main.yml
+++ b/roles/configure_ha/tasks/main.yml
@@ -75,7 +75,7 @@
     - groups['valid_machine'] is defined
     - groups['unconfigured_machine_group'] is defined
   run_once: true
-  delegate_to: "{{ groups['valid_machine'][0] }}"
+  delegate_to: "{{ (groups.get('valid_machine') or [inventory_hostname]) | first }}"
   block:
     - name: Fetch corosync key
       ansible.builtin.fetch:

--- a/roles/configure_libvirt_rdb_secret/tasks/main.yml
+++ b/roles/configure_libvirt_rdb_secret/tasks/main.yml
@@ -18,7 +18,7 @@
     configure_libvirt_rdb_secret_create_secret_pool: "{% if hostvars[item]['configure_libvirt_rdb_secret_secret_defined'].stdout == '' %}true{% else %}{{ configure_libvirt_rdb_secret_create_secret_pool | default(false) }}{% endif %}"
   loop: "{{ groups['hypervisors'] | intersect(groups['cluster_machines']) }}"
 
-- when: configure_libvirt_rdb_secret_create_secret_pool
+- when: configure_libvirt_rdb_secret_create_secret_pool | bool
   block:
     - name: Check if the secret is already defined
       ansible.builtin.set_fact:
@@ -47,7 +47,7 @@
 
 - name: Create libvirt RBD secret
   when:
-    - configure_libvirt_rdb_secret_create_secret_pool
+    - configure_libvirt_rdb_secret_create_secret_pool | bool
     - configure_libvirt_rdb_secret_secret_defined.stdout == ''
   block:
     - name: Copy libvirt xml secret file # noqa: risky-file-permissions

--- a/templates/vm/guest.xml.j2
+++ b/templates/vm/guest.xml.j2
@@ -11,7 +11,7 @@
 {% set vm_features = vm.vm_features if "vm_features" in vm else [] %}
 {% set cpu_nb = (vm.cpuset | length) if vm.cpuset is defined else vm.nb_cpu | default(1) %}
 
-<domain type="kvm">
+<domain type="{{ vm.vm_domain_type | default('kvm') }}">
     <name>{{ vm.inventory_hostname }}</name>
     <uuid>{{ vm.uuid |default( 9999999999999999999999 | random | to_uuid) }}</uuid>
     <description>


### PR DESCRIPTION
## Summary

- Fix string-to-boolean conditional error in `configure_libvirt_rdb_secret` by adding `| bool` filter
- Fix `delegate_to` crash in `configure_ha` when `valid_machine` group doesn't exist
- Fix errors with Ansible 2.20

## Details

### configure_libvirt_rdb_secret
The Jinja2 template in the `set_fact` task produces a string `"true"` instead of a boolean. Adding `| bool` to the `when` conditions fixes the "Conditional result (True) was derived from value of type 'str'" error.

### configure_ha
The `delegate_to: "{{ groups['valid_machine'][0] }}"` expression fails with "object of type 'dict' has no attribute 'valid_machine'" when no hosts were added to that group. Using `groups.get()` with a fallback avoids the crash. The `when` condition still prevents the task from actually running.