### PR TITLE
roles/cephadm_install: remove /var/lib/registry creation

### DIFF
--- a/roles/cephadm_install/tasks/main.yml
+++ b/roles/cephadm_install/tasks/main.yml
@@ -79,14 +79,6 @@
       insecure = true
       location = "localhost"
 
-- name: Ensure /var/lib/registry exists
-  ansible.builtin.file:
-    path: /var/lib/registry
-    state: directory
-    owner: root
-    group: root
-    mode: "0755"
-
 - name: Pull needed Docker images
   containers.podman.podman_image:
     name: "{{ item }}"


### PR DESCRIPTION
Since we use a volume with the Podman registry container, we can remove the /var/lib/registry creation.