### PR TITLE
debian_tests: fix SEAPATH-00050 kernel configs tests

### DIFF
--- a/roles/debian_tests/cukinia-tests/includes/kernel_config_functions
+++ b/roles/debian_tests/cukinia-tests/includes/kernel_config_functions
@@ -22,10 +22,9 @@ function check_kernel_configuration() {
         for testcase in ${kernel_options["${category}"]}; do
             state=${testcase#*:}
             option=${testcase%:*}
-            id "SEAPATH-00050" as "Linux kernel '${category}' : \
+            test_id "SEAPATH-00050" as "Linux kernel '${category}' : \
                 ${option} is $(get_string_from_option ${state})" \
                 cukinia_kconf "${option}" "${state}"
         done
     done
 }
-


### PR DESCRIPTION
Starting from cukinia 0.9.0, the "id" keyword was replaced with "test_id" to prevent any conflict with the "id" command from coreutils. Commit [1] adapted most tests to follow this change.

However, helper file "cukinia-tests/includes/kernel_config_functions" was not adapted.
This file provides a helper function "check_kernel_configuration()" checking a list of kernel configurations under the test ID SEAPATH-00050.
Without the change of keyword, every time the function is called the id command would return "‘[x]’: no such user". However, with cukinia, if a function call return an error (RC >= 1) cukinia will silently ignore it.

  E.g.: With a cukinia.conf containing:

    f() {
        return 1
    }

    f

  the `cukinia cukinia.conf` command will return 0.

Therefore, since cukinia was updated to 0.9.0, SEAPATH-00050 tests were silently ignored.

Fix this by correctly changing to the "test_id" keyword.

[1]: https://github.com/seapath/ansible/commit/4fce4bf94cf8ca1424918510f5487cf78af8038b