### PR TITLE
feat(galaxy): publish seapath.ansible collection on GitHub releases

### DIFF
--- a/.github/workflows/ci-debian.yml
+++ b/.github/workflows/ci-debian.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Upload test report
         if: ${{ always() && steps.conf.conclusion == 'success' }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
             name: seapath-test-report-debian-cluster
             path: ${{ env.WORK_DIR }}/seapath-test-report.pdf

--- a/.github/workflows/ci-oraclelinux.yml
+++ b/.github/workflows/ci-oraclelinux.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Upload test report
         if: ${{ always() && steps.conf.conclusion == 'success' }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
             name: seapath-test-report-oraclelinux-cluster
             path: ${{ env.WORK_DIR }}/seapath-test-report.pdf

--- a/.github/workflows/ci-qa.yml
+++ b/.github/workflows/ci-qa.yml
@@ -23,7 +23,8 @@ jobs:
       - name: Install dependencies
         run: |
           pip install ansible-core~=2.16.0 ansible-lint
-          ansible-galaxy collection install -r ansible-requirements.yaml
+          ansible-galaxy collection install -p collections -r ansible-requirements.yaml
+          ansible-galaxy collection install -p collections --force .
 
       - name: Setup Ansible environment
         run: cp src/ceph-ansible-site.yaml ceph-ansible/site.yml

--- a/.github/workflows/ci-yocto.yml
+++ b/.github/workflows/ci-yocto.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Upload test report
         if: ${{ always() && steps.conf.conclusion == 'success' }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
             name: seapath-test-report-yocto-standalone
             path: ${{ env.WORK_DIR }}/seapath-test-report.pdf

--- a/.github/workflows/galaxy-publish.yml
+++ b/.github/workflows/galaxy-publish.yml
@@ -1,0 +1,78 @@
+# Copyright (C) 2026 RTE
+# SPDX-License-Identifier: Apache-2.0
+
+name: Publish Ansible Collection
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Collection version (e.g. 99.99.99-test for a dry run)
+        required: true
+        default: "0.0.0-test"
+      publish:
+        description: Publish to Ansible Galaxy (leave false to only build the tarball)
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Build and publish to Galaxy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install Ansible
+        run: pip install 'ansible-core~=2.16.0'
+
+      - name: Set collection version
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION="${{ inputs.version }}"
+          fi
+          sed -i "s/^version:.*/version: ${VERSION}/" galaxy.yml
+          echo "Collection version: ${VERSION}"
+          echo "VERSION=${VERSION}" >> "${GITHUB_ENV}"
+
+      - name: Build collection
+        run: ansible-galaxy collection build
+
+      - name: Upload collection artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: seapath-ansible-${{ env.VERSION }}
+          path: seapath-ansible-*.tar.gz
+
+      - name: Check Galaxy API key is configured
+        if: github.event_name == 'release' || inputs.publish == true
+        env:
+          ANSIBLE_GALAXY_API_KEY: ${{ secrets.GALAXY_API_KEY }}
+        run: |
+          if [ -z "${ANSIBLE_GALAXY_API_KEY}" ]; then
+            echo "::error::GALAXY_API_KEY repository secret is missing or empty."
+            echo "Add it under Settings → Secrets and variables → Actions → Repository secrets."
+            exit 1
+          fi
+
+      - name: Publish collection to Ansible Galaxy
+        if: github.event_name == 'release' || inputs.publish == true
+        env:
+          ANSIBLE_GALAXY_API_KEY: ${{ secrets.GALAXY_API_KEY }}
+        run: >-
+          ansible-galaxy collection publish seapath-ansible-*.tar.gz
+          --api-key "${ANSIBLE_GALAXY_API_KEY}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Ansible generated files
 collections/
 ansible.log
+seapath-ansible-*.tar.gz
 
 # Ignore user defined playbooks and inventory
 playbooks/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Integration tests run on self-hosted runners and use the external `seapath/ci` r
 - **Debian hardening**: `playbooks/seapath_setup_hardened_debian.yaml`
 - **Example inventories**: `inventories/examples/` (cluster, standalone, vm-deployment, ovs)
 - **Roles**: `roles/` — most have a `README`. Some include `molecule/` for unit tests.
-- **Custom modules**: `library/`
+- **Custom modules**: `plugins/modules/` (Galaxy collection + `ansible.cfg` `library = ./plugins/modules:...` for checkout/cqfd/CI)
 - **Ceph integration**: `ceph-ansible/` is a **submodule** (`stable-8.0`). It is patched at setup time by `prepare.sh` from `src/ceph-ansible-patches/` and `src/ceph-ansible-site.yaml`.
 
 ## Important Ansible Config (`ansible.cfg`)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+<!--
+Copyright (C) 2026 RTE
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# seapath.ansible
+
+Ansible collection to deploy and manage [SEAPATH](https://lfenergy.org/projects/seapath/) infrastructures (cluster or standalone).
+
+Full documentation: [README-ansible-galaxy.md](README-ansible-galaxy.md).
+
+Published on [Ansible Galaxy](https://galaxy.ansible.com/ui/repo/published/seapath/ansible/).

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -7,7 +7,7 @@
 # NOT after the option, otherwise the comment will be interpreted as a value to that option.
 
 [defaults]
-library = ./library:./ceph-ansible/library
+library = ./plugins/modules:./ceph-ansible/library
 action_plugins = ./ceph-ansible/plugins/actions
 callback_plugins = ./ceph-ansible/plugins/callback
 filter_plugins = ./ceph-ansible/plugins/filter

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1,0 +1,4 @@
+# Copyright (C) 2026 RTE
+# SPDX-License-Identifier: Apache-2.0
+---
+releases: {}

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,0 +1,54 @@
+# Copyright (C) 2026 RTE
+# SPDX-License-Identifier: Apache-2.0
+---
+namespace: seapath
+name: ansible
+version: 1.0.0
+readme: README-ansible-galaxy.md
+authors:
+  - RTE (https://www.rte-france.com)
+  - Savoir-faire Linux (https://www.savoirfairelinux.com)
+description: Ansible collection to deploy and manage SEAPATH clusters and standalone machines.
+license:
+  - Apache-2.0
+tags:
+  - infrastructure
+  - linux
+repository: https://github.com/seapath/ansible
+documentation: https://github.com/seapath/ansible/blob/main/README-ansible-galaxy.md
+homepage: https://lfenergy.org/projects/seapath/
+issues: https://github.com/seapath/ansible/issues
+dependencies:
+  ansible.posix: ">=1.5.0"
+  ansible.utils: ">=2.0.0"
+  community.general: ">=8.0.0"
+  community.libvirt: ">=1.0.0"
+  containers.podman: ">=1.0.0"
+build_ignore:
+  - .github
+  - .gitignore
+  - .pre-commit-config.yaml
+  - .ansible-lint.yml
+  - .yamllint
+  - AGENTS.md
+  - README.adoc
+  - ansible-requirements.yaml
+  - ansible.cfg
+  - ansible.log
+  - ceph-ansible
+  - cqfd
+  - files
+  - inventories
+  - library
+  - molecule_requirements.txt
+  - module_documentation
+  - prepare.sh
+  - scripts
+  - src
+  - templates
+  - tests_results
+  - tox.ini
+  - "**/molecule/**"
+  - "*.tar.gz"
+  - "*.csv"
+  - "*.xml"

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,4 @@
+# Copyright (C) 2026 RTE
+# SPDX-License-Identifier: Apache-2.0
+---
+requires_ansible: ">=2.16.0"

--- a/plugins/modules/cluster_vm.py
+++ b/plugins/modules/cluster_vm.py
@@ -306,17 +306,17 @@ EXAMPLES = r"""
     system_image: my_disk.qcow2
     xml: "{{ lookup('file', 'my_vm_config.xml', errors='strict') }}"
     metadata:
-        myMetadata: value
-        anotherMetadata: value
+      myMetadata: value
+      anotherMetadata: value
     pacemaker_meta:
-        resource-stickiness: 1
+      resource-stickiness: 1
     pacemaker_params:
-        autoset_utilization_cpu: False
-        autoset_utilization_host_memory: False
-        autoset_utilization_hv_memory: False
+      autoset_utilization_cpu: false
+      autoset_utilization_host_memory: false
+      autoset_utilization_hv_memory: false
     pacemaker_utilization:
-        cpu: 4
-        memory: 2048
+      cpu: 4
+      memory: 2048
 
 # Create a VM with additional disks
 - name: Create guest0 with an extra data disk
@@ -326,7 +326,7 @@ EXAMPLES = r"""
     system_image: my_disk.qcow2
     xml: "{{ lookup('template', 'my_vm_config.xml.j2') }}"
     additional_disks:
-        - additional_data.qcow2
+      - additional_data.qcow2
 
 # Remove a VM
 - name: Remove guest0
@@ -377,7 +377,7 @@ EXAMPLES = r"""
     src_name: guest0
     command: clone
     xml: "{{ lookup('template', 'my_vm_config.xml', errors='strict') }}"
-    clear_pacemaker_params: True
+    clear_pacemaker_params: true
 
 # Create a VM snapshot
 - name: Create a snapshot of guest0
@@ -405,8 +405,8 @@ EXAMPLES = r"""
     name: guest0
     command: purge_image
     purge_date:
-        date: '2021-01-24'
-        time: '08:00'
+      date: '2021-01-24'
+      time: '08:00'
 
 # Restore a VM from a snapshot
 - name: Rollback guest0 into snapshot snap1
@@ -440,8 +440,8 @@ EXAMPLES = r"""
     name: guest0
     command: colocation
     colocated_vms:
-     - guest1
-     - guest2
+      - guest1
+      - guest2
 
 # Define a list of crm command to run when enabling the guest
 - name: create a guest and run extra crm commands
@@ -449,7 +449,7 @@ EXAMPLES = r"""
     name: GUEST1
     command: create
     crm_config_cmd:
-     - location ping_test_GUEST1 GUEST1 rule pingd: defined pingd
+      - location ping_test_GUEST1 GUEST1 rule pingd: defined pingd
 
 # Configure a pacemaker remote
 - name: Add a pacemaker remote

--- a/prepare.sh
+++ b/prepare.sh
@@ -52,6 +52,9 @@ echo "Install collections in ansible-requirements.yaml"
 ansible-galaxy collection install --collections-path="$(pwd)/collections" -r \
     ansible-requirements.yaml
 
+echo "Install local seapath.ansible collection (plugins/modules, roles, playbooks)"
+ansible-galaxy collection install --collections-path="$(pwd)/collections" --force .
+
 echo "Update git submodules"
 git submodule update --init --force
 


### PR DESCRIPTION
Add galaxy.yml, meta/runtime.yml and changelogs/changelog.yaml for Ansible Galaxy.
Add a release workflow (and manual dry-run) to build and publish the collection.
Move cluster_vm to plugins/modules, load it via ansible.cfg and prepare.sh for checkout/cqfd/CI.
Install the local collection in ci-qa for ansible-lint.