### PR TITLE
Add initial SEAPATH SLES standalone support

### DIFF
--- a/playbooks/seapath_setup_main.yaml
+++ b/playbooks/seapath_setup_main.yaml
@@ -30,6 +30,10 @@
   import_playbook: seapath_setup_prerequisdebian.yaml
   when: seapath_distro == "Debian"
 
+- name: Import seapath_setup_prerequissles playbook
+  import_playbook: seapath_setup_prerequissles.yaml
+  when: seapath_distro == "SLES"
+
 - name: Import seapath_setup_cockpit_plugins playbook
   import_playbook: seapath_setup_cockpit_plugins.yaml
   when: seapath_distro != "Yocto"

--- a/playbooks/seapath_setup_prerequissles.yaml
+++ b/playbooks/seapath_setup_prerequissles.yaml
@@ -1,0 +1,79 @@
+# Copyright (C) 2023, RTE (http://www.rte-france.com)
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Detect Seapath distribution
+  hosts:
+    - cluster_machines
+    - standalone_machine
+    - VMs
+  roles:
+    - detect_seapath_distro
+
+- name: SLES machines prerequisites
+  gather_facts: true
+  hosts:
+    - cluster_machines
+    - standalone_machine
+    - VMs
+  become: true
+  roles:
+    - syslog_ng_client
+    - role: configure_seapath_distro
+      vars:
+        configure_seapath_distro_vim_config_dir: /etc
+        configure_seapath_distro_grub_update_command: grub2-mkconfig -o /boot/grub2/grub.cfg
+
+- name: SLES physical machine prerequisites
+  hosts:
+    - cluster_machines
+    - standalone_machine
+  become: true
+  roles:
+    - role: configure_physical_machine
+      vars:
+        configure_physical_machine_distro_extra_modules:
+          - br_netfilter
+          - raid6_pq
+        configure_physical_machine_initramfs: dracut
+
+- name: SLES hypervisor prerequisites
+  hosts:
+    - hypervisors
+    - standalone_machine
+  become: true
+  roles:
+    - configure_hypervisor
+
+
+- name: Add admin user to haclient group
+  hosts:
+    - cluster_machines
+  become: true
+  tasks:
+    - name: Add admin user to haclient group
+      ansible.builtin.user:
+        name: "{{ admin_user }}"
+        groups: haclient
+        append: true
+
+- name: Disable libvirt-guests.service
+  hosts:
+    - cluster_machines
+  become: true
+  tasks:
+    - name: Disable libvirt-guests.service
+      ansible.builtin.systemd:
+        name: libvirt-guests.service
+        enabled: false
+        state: stopped
+
+- name: Upload extra files
+  hosts:
+    - cluster_machines
+    - standalone_machine
+    - VMs
+  become: true
+  roles:
+    - upload_extra_files

--- a/roles/configure_hypervisor/files/30-watchdog.conf
+++ b/roles/configure_hypervisor/files/30-watchdog.conf
@@ -1,0 +1,3 @@
+[Manager]
+RuntimeWatchdogSec=20
+RebootWatchdogSec=5min

--- a/roles/configure_hypervisor/tasks/watchdog.yml
+++ b/roles/configure_hypervisor/tasks/watchdog.yml
@@ -3,15 +3,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-- name: Systemd conf RuntimeWatchdogSec
-  ansible.builtin.lineinfile:
-    path: /etc/systemd/system.conf
-    regexp: "^RuntimeWatchdogSec=.*$"
-    line: "RuntimeWatchdogSec=20"
-    state: present
-- name: Systemd conf RebootWatchdogSec
-  ansible.builtin.lineinfile:
-    path: /etc/systemd/system.conf
-    regexp: "^RebootWatchdogSec=.*$"
-    line: "RebootWatchdogSec=5min"
-    state: present
+- name: Create /etc/systemd/system.conf.d
+  ansible.builtin.file:
+    path: /etc/systemd/system.conf.d
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Systemd conf Watchdog
+  ansible.builtin.copy:
+    src: 30-watchdog.conf
+    dest: /etc/systemd/system.conf.d/30-watchdog.conf
+    owner: root
+    group: root
+    mode: "0644"

--- a/roles/configure_seapath_distro/tasks/grub.yml
+++ b/roles/configure_seapath_distro/tasks/grub.yml
@@ -19,18 +19,10 @@
     line: "GRUB_CMDLINE_LINUX=\" \""
   when: configure_seapath_distro_check_grub_cmdline_linux.found == 0
 
-- name: Make sure GRUB_CMDLINE_LINUX starts with a space
-  ansible.builtin.lineinfile:
-    dest: /etc/default/grub
-    regexp: "^(GRUB_CMDLINE_LINUX=)\"([ ]*)(.*)\""
-    line: '\1" \3"'
-    state: present
-    backrefs: true
-
 - name: Make grub conf
   ansible.builtin.lineinfile:
     dest: /etc/default/grub
-    regexp: "^(GRUB_CMDLINE_LINUX=(?!.* {{ item }})\"[^\"]*)(\".*)"
+    regexp: "^(GRUB_CMDLINE_LINUX=(?!.*[ \"]{{ item }})\"[^\"]*)(\".*)"
     line: "\\1 {{ item }}\\2"
     state: present
     backrefs: true

--- a/roles/configure_seapath_distro/tasks/main.yml
+++ b/roles/configure_seapath_distro/tasks/main.yml
@@ -4,7 +4,7 @@
 
 ---
 - name: Remove old admin user
-  when: seapath_distro in ["Debian", "OracleLinux"]
+  when: seapath_distro in ["Debian", "OracleLinux", "SLES"]
   ansible.builtin.import_tasks: remove_old_admin.yml
 
 - name: Apply vim configurations

--- a/roles/configure_seapath_distro/tasks/users.yml
+++ b/roles/configure_seapath_distro/tasks/users.yml
@@ -33,6 +33,15 @@
     regexp: "^{{ admin_user }}"
     validate: visudo -cf %s
 
+- name: Create /etc/environment
+  ansible.builtin.file:
+    path: "/etc/environment"
+    state: touch
+    access_time: preserve
+    modification_time: preserve
+    owner: root
+    group: root
+    mode: "0640"
 - name: Customize /etc/environment
   ansible.builtin.lineinfile:
     dest: "/etc/environment"

--- a/roles/deploy_python3_setup_ovs/vars/SLES.yml
+++ b/roles/deploy_python3_setup_ovs/vars/SLES.yml
@@ -1,0 +1,5 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+deploy_python3_setup_ovs_pip_options: "--root-user-action=ignore --no-build-isolation --prefix=/usr/local/"

--- a/roles/deploy_vm_manager/vars/SLES.yml
+++ b/roles/deploy_vm_manager/vars/SLES.yml
@@ -1,0 +1,5 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+deploy_vm_manager_pip_options: "--root-user-action=ignore --no-build-isolation --prefix=/usr/local/"

--- a/roles/detect_seapath_distro/README.md
+++ b/roles/detect_seapath_distro/README.md
@@ -6,6 +6,7 @@ seapath_distro can have one of the following value:
 - CentOS
 - OracleLinux
 - Yocto
+- SLES
 
 If the role can't detect one of these distro it fails.
 

--- a/roles/detect_seapath_distro/tasks/main.yaml
+++ b/roles/detect_seapath_distro/tasks/main.yaml
@@ -30,6 +30,11 @@
     detect_seapath_distro_distro: OracleLinux
   when: ansible_distribution | regex_search("Oracle") != None
 
+- name: Detect SLES distribution
+  ansible.builtin.set_fact:
+    detect_seapath_distro_distro: SLES
+  when: ansible_distribution | regex_search("SLES") != None
+
 - name: Show detect_seapath_distro_distro
   ansible.builtin.debug:
     var: detect_seapath_distro_distro

--- a/roles/network_configovs/vars/SLES.yml
+++ b/roles/network_configovs/vars/SLES.yml
@@ -1,0 +1,5 @@
+# Copyright (C) 2024 RTE
+# SPDX-License-Identifier: Apache-2.0
+
+---
+network_configovs_setup_ovs_command_path: "/usr/local/bin/setup_ovs"

--- a/roles/network_resolved/tasks/main.yml
+++ b/roles/network_resolved/tasks/main.yml
@@ -7,27 +7,22 @@
     - dns_servers is defined
     - netplan_configurations is not defined
   block:
-    - name: Configure LLMNR /etc/systemd/resolved.conf
-      ansible.builtin.lineinfile:
-        dest: /etc/systemd/resolved.conf
-        regexp: "^#?LLMNR="
-        line: "LLMNR=no"
-        state: present
+    - name: Create /etc/systemd/resolved.conf.d
+      ansible.builtin.file:
+        path: /etc/systemd/resolved.conf.d
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+    - name: Copy SEAPATH systemd-resolved configuration
+      ansible.builtin.template:
+        src: 30-seapath.conf.j2
+        dest: /etc/systemd/resolved.conf.d/30-seapath.conf
+        owner: root
+        group: root
+        mode: "0644"
       notify: Restart systemd-resolved
-    - name: Configure DNS /etc/systemd/resolved.conf
-      ansible.builtin.lineinfile:
-        dest: /etc/systemd/resolved.conf
-        regexp: "^#?DNS="
-        line: "DNS={{ dns_servers | join(' ') if dns_servers is not string else dns_servers }}"
-        state: present
-      notify: Restart systemd-resolved
-    - name: Configure MulticastDNS /etc/systemd/resolved.conf
-      ansible.builtin.lineinfile:
-        dest: /etc/systemd/resolved.conf
-        regexp: "^#?MulticastDNS="
-        line: "MulticastDNS=no"
-        state: present
-      notify: Restart systemd-resolved
+
     - name: Create resolv.conf stub link
       ansible.builtin.file:
         src: /run/systemd/resolve/resolv.conf

--- a/roles/network_resolved/templates/30-seapath.conf.j2
+++ b/roles/network_resolved/templates/30-seapath.conf.j2
@@ -1,0 +1,4 @@
+[Resolve]
+LLMNR=no
+DNS={{ dns_servers | join(' ') if dns_servers is not string else dns_servers }}
+MulticastDNS=no

--- a/roles/snmp/vars/SLES.yml
+++ b/roles/snmp/vars/SLES.yml
@@ -1,0 +1,5 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+snmp_user_name: "snmp"

--- a/roles/timemaster/vars/SLES.yml
+++ b/roles/timemaster/vars/SLES.yml
@@ -1,0 +1,7 @@
+# Copyright (C) 2024 RTE
+# SPDX-License-Identifier: Apache-2.0
+
+---
+timemaster_path_timemaster_conf: "/etc/timemaster.conf"
+timemaster_path_chrony_conf: "/etc/chrony.conf"
+timemaster_service_name_chrony: "chronyd"


### PR DESCRIPTION
This PR bring the initial support for the SEAPATH SLES flavor:

* Add the `SLES` seapath distro type to the `detect_seapath_distro` role.
* In the configuration roles, when required and possible, move some configurations from a monolithic file to a configuration fragment. This is necessary to assure compatibility of some configuration tasks between multiple distros beyond Debian.
* Add the SEAPATH SLES prerequisite playbook.
* In roles already containing per-distro var files, add one for SEAPATH SLES.
* Various improvements to existing configuration roles to better.

With this PR, the `playbook/seapath_setup_main.yaml` and associated roles now supports configuring a SEAPATH SLES standalone hypervisor.

Note that following PRs will bring compatibility for SEAPATH SLES cluster machine configuration, hardening confgiruation and cukinia tests.