### PR TITLE
upload_extra_files: J2 support + user exceptions in debian_tests

### DIFF
--- a/roles/debian_tests/README.md
+++ b/roles/debian_tests/README.md
@@ -1,17 +1,16 @@
 # Deploy cukinia tests Role
-
 This role deploys the cukinia tests for Debian
 
 ## Requirements
-
 No requirement.
 
 ## Role Variables
-
-No variable.
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `debian_tests_extra_essential_services` | list | `[]` | Additional systemd services to whitelist in the unrecognized services check (SEAPATH-00200). |
+| `debian_tests_extra_essential_packages` | list | `[]` | Additional apt packages to whitelist in the unrecognized packages check (SEAPATH-00198). |
 
 ## Example Playbook
-
 ```yaml
 - name: deploy cukinia tests
   hosts:
@@ -21,4 +20,11 @@ No variable.
   become: true
   roles:
     - { role: seapath_ansible.debian_tests, filter: "none" }
+  vars:
+    debian_tests_extra_essential_services:
+      - ha_cluster_exporter
+      - my_custom_service
+    debian_tests_extra_essential_packages:
+      - my_custom_package
+\```
 ```

--- a/roles/debian_tests/cukinia-tests/cukinia/common_security_tests.d/apt.conf.j2
+++ b/roles/debian_tests/cukinia-tests/cukinia/common_security_tests.d/apt.conf.j2
@@ -216,10 +216,17 @@ vim-tiny|\
 whiptail|\
 zstd"
 
+{% if debian_tests_extra_essential_packages | default([]) %}
+ESSENTIAL_PACKAGES_EXTRA="|\
+{{ debian_tests_extra_essential_packages | join('|\\\n') }}"
+{% else %}
+ESSENTIAL_PACKAGES_EXTRA=""
+{% endif %}
 ESSENTIAL_PACKAGES="(\
 $ESSENTIAL_PACKAGES_SEAPATH|\
 $ESSENTIAL_PACKAGES_FAI|\
 $ESSENTIAL_PACKAGES_DEBOOTSTRAP\
+$ESSENTIAL_PACKAGES_EXTRA\
 )"
 
 UNRECOGNIZED_PACKAGES=""

--- a/roles/debian_tests/cukinia-tests/cukinia/common_security_tests.d/systemd.conf
+++ b/roles/debian_tests/cukinia-tests/cukinia/common_security_tests.d/systemd.conf
@@ -42,7 +42,7 @@ ovs-record-hostname|\
 ovs-vswitchd|\
 ovsdb-server|\
 pacemaker|\
-podman-restart|\
+podman|\
 polkit|\
 ptp_vsock|\
 ptpstatus|\

--- a/roles/debian_tests/cukinia-tests/cukinia/common_security_tests.d/systemd.conf.j2
+++ b/roles/debian_tests/cukinia-tests/cukinia/common_security_tests.d/systemd.conf.j2
@@ -5,6 +5,13 @@ cukinia_log "$(_colorize yellow "--- check systemd settings ---")"
 
 test_id "SEAPATH-00199" as "No systemd service failed" cukinia_systemd_failed
 
+{% if debian_tests_extra_essential_services | default([]) %}
+ESSENTIAL_SERVICES_EXTRA="|\
+{{ debian_tests_extra_essential_services | join('|\\\n') }}"
+{% else %}
+ESSENTIAL_SERVICES_EXTRA=""
+{% endif %}
+
 ESSENTIAL_SERVICES="(\
 apparmor|\
 atd|\
@@ -91,6 +98,7 @@ virtlogd|\
 wtmpdb-update-boot|\
 seapath-config_ovs|\
 kthread-taskset\
+$ESSENTIAL_SERVICES_EXTRA\
 )"
 
 UNRECOGNIZED_SERVICES="$(systemctl list-units --type service --plain --no-pager --no-legend | awk -F ' ' '{ print $1}' | grep -Ev '^'${ESSENTIAL_SERVICES}'(@.*)?'.service'$')"

--- a/roles/debian_tests/tasks/main.yml
+++ b/roles/debian_tests/tasks/main.yml
@@ -16,6 +16,7 @@
     dest: /etc/cukinia/{{ item.dest }}
   with_items:
     - { src: "common_security_tests.d/apt.conf.j2", dest: "common_security_tests.d/apt.conf" }
+    - { src: "common_security_tests.d/systemd.conf.j2", dest: "common_security_tests.d/systemd.conf" }
     - { src: "hypervisor_security_tests.d/shadow.conf.j2", dest: "hypervisor_security_tests.d/shadow.conf" }
     - { src: "hypervisor_security_tests.d/passwd.conf.j2", dest: "hypervisor_security_tests.d/passwd.conf" }
     - { src: "hypervisor_security_tests.d/groups.conf.j2", dest: "hypervisor_security_tests.d/groups.conf" }

--- a/roles/upload_extra_files/tasks/main.yml
+++ b/roles/upload_extra_files/tasks/main.yml
@@ -13,7 +13,7 @@
   when:
     - item.extract is not defined or item.extract is false
 
-- name: Upload extra files
+- name: Upload extra files (static)
   ansible.builtin.copy:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
@@ -24,6 +24,20 @@
   loop: "{{ upload_extra_files_upload_files }}"
   when:
     - item.extract is not defined or item.extract is false
+    - not item.src.endswith('.j2')
+
+- name: Upload extra files (template)
+  ansible.builtin.template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    owner: "{{ item.owner | default('root') }}"
+    group: "{{ item.group | default('root') }}"
+    mode: "{{ item.mode | default('0644') }}"
+    backup: true
+  loop: "{{ upload_extra_files_upload_files }}"
+  when:
+    - item.extract is not defined or item.extract is false
+    - item.src.endswith('.j2')
 
 - name: Ensure destination directory exists for extra archives
   ansible.builtin.file:


### PR DESCRIPTION
upload_extra_files: Jinja2 template support
  The role now supports .j2 template files in addition to static files. Files
  ending with .j2 are rendered via ansible.builtin.template while static files
  continue to use ansible.builtin.copy. No changes are needed to the variable
  structure — the role detects the file type automatically based on the
  extension.

----
debian_tests: Extensible cukinia checks for packages and services
  - Fixes the podman service name in the essential services whitelist
  (podman-restart → podman).
  - Converts systemd.conf to a Jinja2 template, enabling dynamic generation of
  the service and package whitelists.
  - Introduces two new optional role variables:
    - debian_tests_extra_essential_services — additional systemd services to
  - Fixes the podman service name in the essential services whitelist (podman-restart → podman).
  - Converts systemd.conf to a Jinja2 template, enabling dynamic generation of the service and package whitelists.
  - Introduces two new optional role variables:
    - debian_tests_extra_essential_services — additional systemd services to whitelist in the unrecognized services check
  (SEAPATH-00200).
    - debian_tests_extra_essential_packages — additional apt packages to whitelist in the unrecognized packages check
  (SEAPATH-00198).

  These variables allow downstream deployments to extend the default whitelists without modifying the role itself.