### PR TITLE
Update hardening configurations and add the OpenSCAP support for SLES

### DIFF
--- a/playbooks/seapath_setup_hardening.yaml
+++ b/playbooks/seapath_setup_hardening.yaml
@@ -37,6 +37,19 @@
   roles:
     - configure_hardening_physical_machine
 
+- name: Run OpenSCAP remediation
+  become: true
+  hosts:
+    - cluster_machines
+    - standalone_machine
+  vars:
+    revert: false
+  pre_tasks:
+    - name: Load distribution-specific hardening variables
+      ansible.builtin.include_vars: ../vars/{{ seapath_distro }}_hardening.yml
+  roles:
+    - configure_hardening_oscap
+
 - name: Reboot to apply hardening
   become: true
   hosts:

--- a/roles/configure_hardening/files/sudoers/security
+++ b/roles/configure_hardening/files/sudoers/security
@@ -1,4 +1,4 @@
-Defaults noexec ,requiretty ,use_pty ,umask=0027 ,ignore_dot ,env_reset
+Defaults noexec ,requiretty ,use_pty ,umask=0077 ,ignore_dot ,env_reset
 
 # These tags are required by the ANSSI-BP-028-R39
 # This file is integrated as 00-security on the target in order to be read

--- a/roles/configure_hardening/templates/01_password.j2
+++ b/roles/configure_hardening/templates/01_password.j2
@@ -1,4 +1,4 @@
 #!/usr/bin/sh
 
-echo superusers="root"
+echo set superusers="root"
 echo password_pbkdf2 root {{ grub_password }}

--- a/roles/configure_hardening/vars/main.yml
+++ b/roles/configure_hardening/vars/main.yml
@@ -16,6 +16,7 @@ configure_hardening_kernel_params:
   - mce=0
   - rng_core.default_quality=500
   - lsm=apparmor,lockdown,capability,landlock,yama,bpf,integrity
+  - kvm.nx_huge_pages=auto
 
 configure_hardening_hardened_services:
   - syslog-ng

--- a/roles/configure_hardening/vars/main.yml
+++ b/roles/configure_hardening/vars/main.yml
@@ -7,7 +7,7 @@ configure_hardening_kernel_params:
   - init_on_free=1
   - slab_nomerge
   - pti=on
-  - slub_debug=ZF
+  - slub_debug=ZFP
   - randomize_kstack_offset=on
   - slab_common.usercopy_fallback=N
   - iommu=pt

--- a/roles/configure_hardening/vars/main.yml
+++ b/roles/configure_hardening/vars/main.yml
@@ -11,6 +11,7 @@ configure_hardening_kernel_params:
   - randomize_kstack_offset=on
   - slab_common.usercopy_fallback=N
   - iommu=pt
+  - intel_iommu=on
   - security=yama
   - mce=0
   - rng_core.default_quality=500

--- a/roles/configure_hardening_oscap/README.md
+++ b/roles/configure_hardening_oscap/README.md
@@ -1,0 +1,24 @@
+# configure_hardening_oscap Role
+
+This role runs an OpenSCAP XCCDF remediation after the main hardening has been applied. It must be run **after** `configure_hardening` (and `configure_hardening_physical_machine` where applicable) so that OpenSCAP can remediate any remaining non-compliant settings. `openscap` and `scap-security-guide` must be installed on the target host.
+
+## Role Variables
+
+| Variable                                 | Required | Type    | Default | Comments                                              |
+|------------------------------------------|----------|---------|---------|-------------------------------------------------------|
+| configure_hardening_oscap_ds_file        | Yes      | String  |         | Path to the SCAP data stream file on the target host  |
+| configure_hardening_oscap_profile        | Yes      | String  |         | XCCDF profile ID to apply                             |
+| configure_hardening_oscap_tailoring_file | No       | String  |         | Path to an optional XCCDF tailoring file on the host  |
+| revert                                   | No       | Boolean | false   | When true, skip the remediation                       |
+
+## Example Playbook
+
+```yaml
+- name: Run OpenSCAP remediation
+  become: true
+  hosts:
+    - cluster_machines
+    - standalone_machine
+  roles:
+    - configure_hardening_oscap
+```

--- a/roles/configure_hardening_oscap/meta/main.yml
+++ b/roles/configure_hardening_oscap/meta/main.yml
@@ -1,0 +1,13 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+---
+galaxy_info:
+  author: "Seapath"
+  description: OpenSCAP remediation for SEAPATH hardened systems
+  license: Apache-2.0
+  min_ansible_version: 2.9.10
+  platforms:
+    - name: Debian
+      versions:
+        - all
+dependencies: []

--- a/roles/configure_hardening_oscap/tasks/main.yml
+++ b/roles/configure_hardening_oscap/tasks/main.yml
@@ -1,0 +1,21 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Run OpenSCAP ANSSI BP28 High remediation
+  ansible.builtin.command:
+    cmd: >
+      oscap xccdf eval
+      --remediate
+      --fetch-remote-resources
+      --results /tmp/oscap-results.xml
+      --report /tmp/oscap-report.html
+      --profile {{ configure_hardening_oscap_profile }}
+      {{ configure_hardening_oscap_ds_file }}
+  register: configure_hardening_oscap_remediation
+  failed_when: configure_hardening_oscap_remediation.rc not in [0, 2]
+  changed_when: configure_hardening_oscap_remediation.rc == 2
+  when:
+    - not revert
+    - configure_hardening_oscap_ds_file is defined
+    - configure_hardening_oscap_profile is defined

--- a/roles/configure_hardening_oscap/tasks/main.yml
+++ b/roles/configure_hardening_oscap/tasks/main.yml
@@ -11,6 +11,9 @@
       --results /tmp/oscap-results.xml
       --report /tmp/oscap-report.html
       --profile {{ configure_hardening_oscap_profile }}
+      {% if configure_hardening_oscap_tailoring_file is defined %}
+      --tailoring-file {{ configure_hardening_oscap_tailoring_file }}
+      {% endif %}
       {{ configure_hardening_oscap_ds_file }}
   register: configure_hardening_oscap_remediation
   failed_when: configure_hardening_oscap_remediation.rc not in [0, 2]

--- a/roles/deploy_cukinia_tests/cukinia-tests/cukinia/common_security_tests.d/hardening.conf.j2
+++ b/roles/deploy_cukinia_tests/cukinia-tests/cukinia/common_security_tests.d/hardening.conf.j2
@@ -65,7 +65,7 @@ GRUB_CFG_FILE="/boot/grub2/grub.cfg"
 {% endif %}
 
 test_id "SEAPATH-00202" as "grub root superuser is set in $GRUB_CFG_FILE" \
-	cukinia_cmd grep -q "^superusers=root$" $GRUB_CFG_FILE
+	cukinia_cmd grep -q "^set superusers=root$" $GRUB_CFG_FILE
 test_id "SEAPATH-00203" as "grub root superuser is password protected" \
 	cukinia_cmd grep -q "^password_pbkdf2 root grub.pbkdf2.sha512.65536.*$" $GRUB_CFG_FILE
 test_id "SEAPATH-00204" as "main menuentry is unrestricted in $GRUB_CFG_FILE" \

--- a/roles/deploy_cukinia_tests/cukinia-tests/cukinia/common_security_tests.d/hardening.conf.j2
+++ b/roles/deploy_cukinia_tests/cukinia-tests/cukinia/common_security_tests.d/hardening.conf.j2
@@ -79,7 +79,7 @@ test_id "SEAPATH-00206" as "TMPDIR is set with 700 mode and $USER as owner and g
 	"$(bash -l -c 'stat $TMPDIR -c "%a %U %G"')" = "700 $USER $USER"
 
 test_id "SEAPATH-00225" as "Umask is set correctly set" \
-  cukinia_test "$(sh -c 'umask')" = "0027"
+  cukinia_test "$(sh -c 'umask')" = "0077"
 
 test_id "SEAPATH-00227" as "AppArmor processes are confined in enforce mode" \
   cukinia_test aa-status | grep "0 processes are unconfined"

--- a/roles/deploy_cukinia_tests/cukinia-tests/cukinia/common_security_tests.d/sudo.conf.j2
+++ b/roles/deploy_cukinia_tests/cukinia-tests/cukinia/common_security_tests.d/sudo.conf.j2
@@ -15,8 +15,8 @@ test_id "SEAPATH-00148" as "sudoers files include directive requiretty " \
     cukinia_cmd grep -q "^Defaults.*requiretty" $SUDOERS_FILES
 test_id "SEAPATH-00148" as "sudoers files include directive use_pty " \
     cukinia_cmd grep -q "^Defaults.*use_pty" $SUDOERS_FILES
-test_id "SEAPATH-00148" as "sudoers files include directive umask=0027 " \
-    cukinia_cmd grep -q "^Defaults.*umask=0027" $SUDOERS_FILES
+test_id "SEAPATH-00148" as "sudoers files include directive umask=0077 " \
+    cukinia_cmd grep -q "^Defaults.*umask=0077" $SUDOERS_FILES
 test_id "SEAPATH-00148" as "sudoers files include directive ignore_dot " \
     cukinia_cmd grep -q "^Defaults.*ignore_dot" $SUDOERS_FILES
 test_id "SEAPATH-00148" as "sudoers files include directive env_reset " \

--- a/roles/deploy_cukinia_tests/cukinia-tests/cukinia/common_security_tests.d/systemd.conf.j2
+++ b/roles/deploy_cukinia_tests/cukinia-tests/cukinia/common_security_tests.d/systemd.conf.j2
@@ -38,6 +38,7 @@ systemd-update-utmp|\
 wtmpdb-update-boot"
 
 ESSENTIAL_SERVICES_SLES="\
+aidecheck|\
 dracut-shutdown|\
 iscsi|\
 kbdsettings|\

--- a/roles/deploy_cukinia_tests/cukinia-tests/cukinia/hypervisor_security_tests.d/kernel.conf
+++ b/roles/deploy_cukinia_tests/cukinia-tests/cukinia/hypervisor_security_tests.d/kernel.conf
@@ -8,4 +8,4 @@ test_id "SEAPATH-00008" as "Slab merging is disabled on cmdline" cukinia_cmd \
 test_id "SEAPATH-00009" as "Kernel Page Table Isolation is always enabled on cmdline" cukinia_cmd \
     grep -q "pti=on" /proc/cmdline
 test_id "SEAPATH-00010" as "SLUB redzoning and sanity checking enabled on cmdline" cukinia_cmd \
-    grep -q "slub_debug=ZF" /proc/cmdline
+    grep -q "slub_debug=ZFP" /proc/cmdline

--- a/vars/SLES_hardening.yml
+++ b/vars/SLES_hardening.yml
@@ -7,3 +7,5 @@ configure_hardening_login_defs_file: /etc/login.defs.d/hardening.defs
 configure_hardening_grub_update_command: grub2-mkconfig -o /boot/grub2/grub.cfg
 configure_hardening_sshd_has_lastlog: false
 configure_hardening_physical_machine_snmp_user_name: snmp
+configure_hardening_oscap_profile: xccdf_org.ssgproject.content_profile_anssi_bp28_high
+configure_hardening_oscap_ds_file: /usr/share/xml/scap/ssg/content/ssg-sle16-ds.xml

--- a/vars/SLES_hardening.yml
+++ b/vars/SLES_hardening.yml
@@ -7,5 +7,6 @@ configure_hardening_login_defs_file: /etc/login.defs.d/hardening.defs
 configure_hardening_grub_update_command: grub2-mkconfig -o /boot/grub2/grub.cfg
 configure_hardening_sshd_has_lastlog: false
 configure_hardening_physical_machine_snmp_user_name: snmp
-configure_hardening_oscap_profile: xccdf_org.ssgproject.content_profile_anssi_bp28_high
+configure_hardening_oscap_profile: xccdf_org.ssgproject.content_profile_anssi_bp28_high_customized
 configure_hardening_oscap_ds_file: /usr/share/xml/scap/ssg/content/ssg-sle16-ds.xml
+configure_hardening_oscap_tailoring_file: /usr/share/xml/scap/ssg/content/ssg-sle16-ds-tailoring.xml


### PR DESCRIPTION
This pull request adds support for OpenSCAP remediation, which will be used on SEAPATH SLES16 to complement the default hardening currently implemented in SEAPATH.

After applying the OpenSCAP remediation, it appeared that some hardening configurations present in Ansible did not match the ANSSI BP28 requirements. These configurations have been updated in this PR to avoid the hardening being applied twice.