### PR TITLE
timemaster: render PTP custom options one per line

### DIFF
--- a/roles/timemaster/templates/timemaster.conf.j2
+++ b/roles/timemaster/templates/timemaster.conf.j2
@@ -70,7 +70,9 @@ clockClass               248
 tx_timestamp_timeout    10
 
 {% if timemaster_ptp_custom_options is not none %}
-{%- for line in timemaster_ptp_custom_options %}{{ line }}{% endfor %}
+{% for line in timemaster_ptp_custom_options %}
+{{ line }}
+{% endfor %}
 {% endif %}
 
 [chronyd]


### PR DESCRIPTION
The {% endfor %} inlined after {{ line }} made every iteration emit the
option without a newline (trim_blocks eats the one after the for tag),
so all custom options were concatenated on a single configuration line.