### PR TITLE
cyclictest: add variables to set CPU affinity and priority

### DIFF
--- a/roles/cyclictest/README.md
+++ b/roles/cyclictest/README.md
@@ -12,6 +12,8 @@ no requirement.
 |--------------------------|----------|--------|---------|----------------------------------------|
 | cyclictest_result_folder | No       | String | ..      | Path where cyclictest result is stored |
 | cyclictest_duration      | No       | Int    | 20      | Duration of the test in seconds        |
+| cyclictest_priority      | No       | Int    | 90      | Priority of the threads                |
+| cyclictest_affinity      | No       | String | smp     | CPU affinity of the threads, if smp use `-S` |
 
 ## Example Playbook
 

--- a/roles/cyclictest/defaults/main.yml
+++ b/roles/cyclictest/defaults/main.yml
@@ -4,3 +4,5 @@
 ---
 cyclictest_result_folder: ".."
 cyclictest_duration: 20
+cyclictest_priority: 90
+cyclictest_affinity: "smp"

--- a/roles/cyclictest/files/run_cyclictest.py
+++ b/roles/cyclictest/files/run_cyclictest.py
@@ -7,15 +7,21 @@ import argparse
 parser = argparse.ArgumentParser(description="Run cyclictest command.")
 parser.add_argument('output_file', type=str, help='File to output the result.')
 parser.add_argument('-d', '--duration', type=int, help='Test duration in seconds.', default=20)
+parser.add_argument('-p', '--priority', type=int, help='Priority of the threads.', default=90)
+parser.add_argument('-a', '--affinity', type=str, help='CPU affinity', nargs='?', const="", default="smp")
 args = parser.parse_args()
 
 interval = 200  # In microseconds
 cycles = (args.duration * 10**6) // interval
+cpu_arg = "-S"
+if args.affinity != "smp":
+    cpu_arg = f"-a {args.affinity} -t"
 
-cyclic_test_cmd = f"cyclictest -l{cycles} -m -Sp90 -i{interval} -h400 -q"
+cyclic_test_cmd = f"cyclictest -l{cycles} -m {cpu_arg} -p{args.priority} -i{interval} -h400 -q"
 print(f"Will run command: {cyclic_test_cmd}")
 
 result = subprocess.run(cyclic_test_cmd.split(), capture_output=True, text=True)
 
 with open(args.output_file, 'w') as f:
+    f.write(cyclic_test_cmd)
     f.write(result.stdout)

--- a/roles/cyclictest/tasks/main.yml
+++ b/roles/cyclictest/tasks/main.yml
@@ -8,7 +8,11 @@
   register: cyclictest_tmp_test_dir
 
 - name: Execute cyclitect script
-  ansible.builtin.script: run_cyclictest.py -d {{ cyclictest_duration }} '{{ cyclictest_tmp_test_dir.path }}/cyclictest.txt'
+  ansible.builtin.script: run_cyclictest.py
+    -d {{ cyclictest_duration }}
+    -p {{ cyclictest_priority }}
+    -a {{ cyclictest_affinity }}
+    '{{ cyclictest_tmp_test_dir.path }}/cyclictest.txt'
 - name: Fetch results
   ansible.builtin.fetch:
     src: "{{ cyclictest_tmp_test_dir.path }}/cyclictest.txt"


### PR DESCRIPTION
Add variables to set the CPU affinity and priority of cyclictest's threads. This replaces `-S` by `-a <cpu-set> -t` to select which core is used.

They are controlled by the cyclictest_affinity and cyclictest_priority variables.
cyclictest_affinity can take two kind of values:
- "smp" : use `-S`, the default
- "cpu-set" : use `-a <cpu-set> -t`