### PR TITLE
Fix extra_modules template

### DIFF
--- a/roles/configure_physical_machine/templates/extra_modules.conf.j2
+++ b/roles/configure_physical_machine/templates/extra_modules.conf.j2
@@ -1,2 +1,3 @@
 {% for module in (extra_kernel_modules | default([])) + (configure_physical_machine_distro_extra_modules | default([])) %}
-{{ module }}{% endfor %}
+{{ module }}
+{% endfor %}


### PR DESCRIPTION
It ran all the configured modules together, instead of listing one module per line as [the specification requires](https://www.freedesktop.org/software/systemd/man/latest/modules-load.d.html#Configuration%20Format).