### PR TITLE
Integrate OpenSCAP analysis results in CI and report

### DIFF
--- a/.cqfd/docker/Dockerfile
+++ b/.cqfd/docker/Dockerfile
@@ -17,6 +17,7 @@ RUN set -x \
         git \
         podman \
         python3-full \
+        python3-junitparser \
         python3-matplotlib \
         rstcheck \
         rsync \

--- a/.github/test-report/oscap2junit.py
+++ b/.github/test-report/oscap2junit.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+#
+# oscap2junit.py — Convert an OpenSCAP XCCDF result XML file to JUnit XML
+# so it can be fed into test-report-pdf as a test input.
+#
+# Usage:
+#   ./oscap2junit.py oscap-result.xml -o output_dir/
+
+import argparse
+import os
+import sys
+import xml.etree.ElementTree as ET
+from junitparser import Failure, JUnitXml, Properties, Property, Skipped, TestCase, TestSuite
+
+XCCDF_NS = "http://checklists.nist.gov/xccdf/1.2"
+NS = {"x": XCCDF_NS}
+
+# XCCDF result values → JUnit outcome
+# notselected: rule was not part of the selected profile subset — excluded by default
+# notapplicable: rule does not apply to this platform → skipped
+# notchecked: no check could be performed → skipped
+RESULT_MAP = {
+    "pass": "pass",
+    "fail": "fail",
+    "notapplicable": "skipped",
+    "notchecked": "skipped",
+    "error": "fail",
+    "unknown": "skipped",
+    "informational": "skipped",
+    "fixed": "pass",
+}
+
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        prog="oscap2junit",
+        description=(
+            "Convert an OpenSCAP XCCDF result XML file to JUnit XML files "
+            "compatible with compile.py."
+        ),
+    )
+    p.add_argument("xccdf_result", help="Path to the XCCDF result XML file.")
+    p.add_argument(
+        "-o",
+        "--output_dir",
+        default="oscap-junit",
+        help="Directory to write JUnit XML file(s) into. Created if absent. "
+        "Default: oscap-junit/",
+    )
+    p.add_argument(
+        "--include-notselected",
+        action="store_true",
+        default=False,
+        help="Include 'notselected' rules as skipped tests (noisy; off by default).",
+    )
+    p.add_argument(
+        "--severity",
+        choices=["low", "medium", "high"],
+        default=None,
+        help="Only include rules at or above this severity level.",
+    )
+    return p.parse_args()
+
+
+SEVERITY_RANK = {"low": 0, "medium": 1, "high": 2, "unknown": -1}
+
+
+def severity_ok(rule_severity, min_severity):
+    if min_severity is None:
+        return True
+    return SEVERITY_RANK.get(rule_severity, -1) >= SEVERITY_RANK[min_severity]
+
+def get_elem_base_tag(elem):
+    """
+    Given an XML element with a tag like "{namespace}TagName", return "TagName".
+    If no namespace, return the tag as-is.
+    """
+    tag = elem.tag
+    if "}" in tag:
+        return tag.split("}")[-1]
+
+    return tag
+
+def get_elem_text(elem, default=""):
+    """
+    Return the text content of an XML element, or a default value if the element is None or has no text.
+    """
+    if elem is not None and elem.text:
+        return elem.text.strip()
+
+    return default
+
+def build_rule_titles_map(root):
+    """
+    Walk the benchmark tree and return a dict:
+        rule_id → title
+    """
+    rule_titles = {}
+
+    def walk(elem, group_title="Ungrouped"):
+
+        local = get_elem_base_tag(elem)
+
+        if local == "Rule":
+            rule_id = elem.get("id", "")
+            rule_title = get_elem_text(elem.find("x:title", NS), rule_id)
+
+            rule_titles[rule_id] = rule_title
+        else:
+            for child in elem:
+                walk(child, group_title)
+
+    walk(root)
+    return rule_titles
+
+
+def escape_xml(text):
+    return (
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("'", "&apos;")
+    )
+
+
+def write_junit(suites, output_path, target):
+    """
+    suites: dict of group_title → list of {title, result, severity, idref}
+    Writes a single JUnit XML file with one <testsuite> per group.
+    """
+    xml = JUnitXml()
+
+    for suite_name, tests in sorted(suites.items()):
+        suite = TestSuite(suite_name)
+        suite.hostname = target
+
+        for t in tests:
+            case = TestCase(t["title"])
+            case.classname = target
+            properties = Properties()
+            properties.add_property(Property("rule_id", t["idref"]))
+            properties.add_property(Property("raw_result", t["result_raw"]))
+            properties.add_property(Property("severity", t["severity"]))
+            case.append(properties)
+
+            if t["result"] == "fail":
+                case.result = [
+                    Failure(
+                        f'Rule: {t["idref"]}\nSeverity: {t["severity"]}',
+                        "SecurityPolicyViolation",
+                    )
+                ]
+            elif t["result"] == "skipped":
+                case.result = [Skipped(t["result_raw"])]
+
+            suite.add_testcase(case)
+
+        xml.add_testsuite(suite)
+
+    xml.write(output_path, pretty=True)
+
+
+def main():
+    args = parse_args()
+
+    print(f"Parsing {args.xccdf_result} ...")
+    try:
+        tree = ET.parse(args.xccdf_result)
+    except ET.ParseError as e:
+        print(f"ERROR: Failed to parse XML: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    root = tree.getroot()
+
+    print("Building rule title/group map ...")
+    rule_titles = build_rule_titles_map(root)
+    print(f"  Found {len(rule_titles)} rules in benchmark.")
+
+    test_result = root.find("x:TestResult", NS)
+    if test_result is None:
+        print("ERROR: No <TestResult> element found in the file.", file=sys.stderr)
+        sys.exit(1)
+
+    result_id = test_result.get("id", "oscap")
+    target = get_elem_text(test_result.find("x:target", NS), "unknown")
+    result_title = get_elem_text(test_result.find("x:title", NS), "OpenSCAP tests")
+    rule_results = test_result.findall("x:rule-result", NS)
+
+    print(f"  TestResult target: {target}")
+    print(f"  Found {len(rule_results)} rule-result entries.")
+
+    results = []
+    skipped_count = 0
+
+    # Associate rule names to test results
+    for rr in rule_results:
+        idref = rr.get("idref", "")
+
+        result_raw = get_elem_text(rr.find("x:result", NS), "unknown")
+        if result_raw == "notselected" and not args.include_notselected:
+            skipped_count += 1
+            continue
+
+        severity = rr.get("severity", "unknown")
+        if not severity_ok(severity, args.severity):
+            continue
+
+        outcome = RESULT_MAP.get(result_raw, "skipped")
+
+        results.append(
+            {
+                "title": rule_titles.get(idref, idref),
+                "idref": idref,
+                "result": outcome,
+                "result_raw": result_raw,
+                "severity": severity,
+            }
+        )
+
+    print(
+        f"Included: {len(results)} rules "
+        f"(excluded {skipped_count} 'notselected')."
+    )
+
+    # Generate JUnitXML file
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    safe_name = result_id.replace("/", "_").replace(":", "_") + ".xml"
+    output_path = os.path.join(args.output_dir, safe_name)
+
+    print(f"Writing JUnit XML to {output_path} ...")
+    write_junit({result_title: results}, output_path, target)
+
+
+    all_tests = [t for t in results]
+    passed = sum(1 for t in all_tests if t["result"] == "pass")
+    failed = sum(1 for t in all_tests if t["result"] == "fail")
+    skipped = sum(1 for t in all_tests if t["result"] == "skipped")
+    print(f"\nSummary: {passed} passed, {failed} failed, {skipped} skipped/notapplicable")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/test-report/prerequisites.adoc
+++ b/.github/test-report/prerequisites.adoc
@@ -1,9 +1,0 @@
-<<<
-== Introduction
-The purpose of this document is to certify the correct operation of the open source real-time operating system for virtualizing IEDs: SEAPATH, a project under the governance of the Linux Foundation Energy.
-
-A series of tests has been carried out on a range of equipment from several vendors, in order to certify SEAPATH on them. Certified in virtualization functions, security, real-time functionality and network latency of IEC61850 Sampled Values.
-
-<<<
-== System Information
-include::system_info.adoc[]

--- a/.github/test-report/prerequisites.adoc.j2
+++ b/.github/test-report/prerequisites.adoc.j2
@@ -1,0 +1,28 @@
+<<<
+== Introduction
+The purpose of this document is to certify the correct operation of the open source real-time operating system for virtualizing IEDs: SEAPATH, a project under the governance of the Linux Foundation Energy.
+
+A series of tests has been carried out on a range of equipment from several vendors, in order to certify SEAPATH on them. Certified in virtualization functions, security, real-time functionality and network latency of IEC61850 Sampled Values.
+
+{% if env.get("HAS_OSCAP_RESULTS", "false") == 'true' %}
+This report includes results of an OpenSCAP analysis with an ANSSI BP28 profile after application of the relevant and compatible remediation.
+Theses results are currently indicative as OpenSCAP is not yet fully integrated within SEAPATH.
+The SEAPATH system tests still represent the main certification results.
+Additional work is necessary to fully integrate the OpenSCAP BP28 analysis within SEAPATH.
+
+OpenSCAP tests marked as "FAIL" may be due to:
+
+* A hardening requirement not yet implemented in SEAPATH.
+* A hardening requirement conflicting with a stricter similar requirement already applied by SEAPATH Ansible.
+** Example: OpenSCAP BP28 profile expects the bash timeout to be set to 600 seconds, while SEAPATH Ansible sets it to 300 seconds.
+* A hardening requirement not yet implemented in SEAPATH that needs to be reviewed because it can have an impact on performances.
+* A false negative due to a non-matching string or an unexpected file name.
+* A hardening requirement that is not met by a component configured outside of SEAPATH.
+** Example: mssing kernel configuration in the kernel package for SEAPATH Debian or SEAPATH SLES.
+
+OpenSCAP tests marked as "SKIPPED" are either not applicable to or not checkable on the SEAPATH flavor.
+{% endif %}
+
+<<<
+== System Information
+include::system_info.adoc[]

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -178,6 +178,7 @@ jobs:
             ${{ inputs.hyp-inventories }} \
             --limit "standalone_machine,cluster_machines" \
             --extra-vars "cukinia_test_prefix=/results" \
+            --extra-vars "oscap_test_prefix=/results" \
             --extra-vars "cyclictest_result_folder=/results" \
             --extra-vars "cyclictest_duration=${{ env.CYCLICTEST_DURATION }}" \
 
@@ -372,6 +373,16 @@ jobs:
           include-hidden-files: true
           retention-days: 1
           if-no-files-found: error
+
+      - name: Process OpenSCAP analysis results
+        working-directory: ansible
+        run: |
+          for f in $(find ${{ env.RESULTS_FOLDER }} -name "oscap-results*.xml"); do
+            cqfd exec .github/test-report/oscap2junit.py -o /results /results/$(basename $f)
+
+            # Remove original OpenSCAP XML file to prevent it from being included by test-report-pdf
+            rm $f
+          done
 
       - name: Checkout test-report-pdf
         uses: actions/checkout@v6

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -377,12 +377,16 @@ jobs:
       - name: Process OpenSCAP analysis results
         working-directory: ansible
         run: |
+          HAS_OSCAP_RESULTS="false"
           for f in $(find ${{ env.RESULTS_FOLDER }} -name "oscap-results*.xml"); do
             cqfd exec .github/test-report/oscap2junit.py -o /results /results/$(basename $f)
 
             # Remove original OpenSCAP XML file to prevent it from being included by test-report-pdf
             rm $f
+
+            HAS_OSCAP_RESULTS="true"
           done
+          echo "HAS_OSCAP_RESULTS=$HAS_OSCAP_RESULTS" >> "$GITHUB_ENV"
 
       - name: Checkout test-report-pdf
         uses: actions/checkout@v6
@@ -397,7 +401,6 @@ jobs:
 
           mkdir include
           cp -r ${{ env.RESULTS_FOLDER }}/* include/
-          cp ../ansible/.github/test-report/prerequisites.adoc include/
 
           latency_tests_duration=$(python3 -c "import datetime; print(datetime.timedelta(seconds=${{ env.PCAP_LOOP }}))")
           echo "LATENCY_TESTS_DURATION=$latency_tests_duration" >> "$GITHUB_ENV"
@@ -431,6 +434,14 @@ jobs:
               -o "include/cyclictest_${vm}.png" \
               -l "${{ env.LATENCY_MAXIMAL_VM }}"
           done
+
+      - name: Templatize prerequisites information
+        uses: cuchi/jinja2-action@8bd801365a8d36a0b20f45ee969161685de7785a # v1.3.0
+        with:
+          template: ansible/.github/test-report/prerequisites.adoc.j2
+          output_file: test-report-pdf/include/prerequisites.adoc
+          strict: true
+          # uses env variables to populate the document
 
       - name: Templatize system information
         uses: cuchi/jinja2-action@8bd801365a8d36a0b20f45ee969161685de7785a # v1.3.0

--- a/.github/workflows/ci-sles.yml
+++ b/.github/workflows/ci-sles.yml
@@ -35,6 +35,7 @@ jobs:
       hyp-test-playbooks: >-
         playbooks/test_deploy_cukinia_tests.yaml
         playbooks/ci_all_machines_tests.yaml
+        playbooks/test_run_oscap_tests.yaml
       vms-inventories: ${{ matrix.vms-inventories }}
       vms-deploy-playbooks: >-
         playbooks/ci_vms_standalone_ptp.yaml

--- a/playbooks/test_run_oscap_tests.yaml
+++ b/playbooks/test_run_oscap_tests.yaml
@@ -1,0 +1,43 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Get distribution variables
+  hosts:
+    - cluster_machines
+    - standalone_machine
+  roles:
+    - detect_seapath_distro
+  tasks:
+    - name: Load distribution-specific variables
+      ansible.builtin.include_vars: "../vars/{{ seapath_distro }}_hardening.yml"
+
+- name: OpenSCAP analysis tests
+  hosts:
+    - cluster_machines
+    - standalone_machine
+  gather_facts: true
+  become: true
+  pre_tasks:
+    - name: Create temporary directory for result files
+      ansible.builtin.tempfile:
+        state: directory
+      register: oscap_result_dir
+  roles:
+    - role: configure_hardening_oscap
+      vars:
+        configure_hardening_oscap_apply_remediation: false
+        configure_hardening_oscap_results_dir: "{{ oscap_result_dir.path }}"
+  post_tasks:
+    - name: Fetch HTML report file
+      ansible.builtin.fetch:
+        src: "{{ oscap_result_dir.path }}/oscap-report.html"
+        dest: "{{ oscap_test_prefix | default('..') }}/oscap-report-{{ inventory_hostname }}.html"
+        flat: true
+        fail_on_missing: false  # Prevents failing when a host doesn't not provide any OpenSCAP test file
+    - name: Fetch XML result file
+      ansible.builtin.fetch:
+        src: "{{ oscap_result_dir.path }}/oscap-results.xml"
+        dest: "{{ oscap_test_prefix | default('..') }}/oscap-results-{{ inventory_hostname }}.xml"
+        flat: true
+        fail_on_missing: false  # Prevents failing when a host doesn't not provide any OpenSCAP test file

--- a/roles/configure_hardening_oscap/README.md
+++ b/roles/configure_hardening_oscap/README.md
@@ -9,6 +9,8 @@ This role runs an OpenSCAP XCCDF remediation after the main hardening has been a
 | configure_hardening_oscap_ds_file        | Yes      | String  |         | Path to the SCAP data stream file on the target host  |
 | configure_hardening_oscap_profile        | Yes      | String  |         | XCCDF profile ID to apply                             |
 | configure_hardening_oscap_tailoring_file | No       | String  |         | Path to an optional XCCDF tailoring file on the host  |
+| configure_hardening_oscap_apply_remediation | No    | Boolean | true    | Set to false to only run tests                        |
+| configure_hardening_oscap_results_dir    | No       | String  | /tmp    | Directory where OpenSCAP result files are stored      |
 | revert                                   | No       | Boolean | false   | When true, skip the remediation                       |
 
 ## Example Playbook

--- a/roles/configure_hardening_oscap/defaults/main.yml
+++ b/roles/configure_hardening_oscap/defaults/main.yml
@@ -1,0 +1,6 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+configure_hardening_oscap_apply_remediation: true
+configure_hardening_oscap_results_dir: "/tmp"

--- a/roles/configure_hardening_oscap/tasks/main.yml
+++ b/roles/configure_hardening_oscap/tasks/main.yml
@@ -6,10 +6,12 @@
   ansible.builtin.command:
     cmd: >
       oscap xccdf eval
+      {% if configure_hardening_oscap_apply_remediation %}
       --remediate
+      {% endif %}
       --fetch-remote-resources
-      --results /tmp/oscap-results.xml
-      --report /tmp/oscap-report.html
+      --results {{ configure_hardening_oscap_results_dir }}/oscap-results.xml
+      --report {{ configure_hardening_oscap_results_dir }}/oscap-report.html
       --profile {{ configure_hardening_oscap_profile }}
       {% if configure_hardening_oscap_tailoring_file is defined %}
       --tailoring-file {{ configure_hardening_oscap_tailoring_file }}

--- a/roles/configure_hardening_oscap/tasks/main.yml
+++ b/roles/configure_hardening_oscap/tasks/main.yml
@@ -21,6 +21,6 @@
   failed_when: configure_hardening_oscap_remediation.rc not in [0, 2]
   changed_when: configure_hardening_oscap_remediation.rc == 2
   when:
-    - not revert
+    - revert is not defined or not revert
     - configure_hardening_oscap_ds_file is defined
     - configure_hardening_oscap_profile is defined


### PR DESCRIPTION
* Allow running the OpenSCAP analysis without applying any remediation.
* Create a playbook to run an OpenSCAP analysis and fetch results
* Create a script to convert OpenSCAP results in XCCDF format to a JUnit file that can be process by test-report-pdf.
* Run and integrate OpenSCAP analysis results to report in CI

This PR should be merged after https://github.com/seapath/ansible/pull/968