### PR TITLE
workflows/ci-debian.yml: serialize standalone/cluster jobs per PR

### DIFF
--- a/.github/workflows/ci-debian.yml
+++ b/.github/workflows/ci-debian.yml
@@ -30,6 +30,9 @@ jobs:
               --inventory inventories_private/vm13cluster.yml
             vms-deployment-playbooks: >-
               playbooks/deploy_vms_cluster.yaml
+    concurrency:
+      group: ci-debian-${{ matrix.name }}
+      cancel-in-progress: false
     uses: ./.github/workflows/_tests.yml
     name: Run tests on ${{ matrix.name }}
     with:


### PR DESCRIPTION
Two concurrent CI runs (from different PRs) could otherwise both land on the same shared test hardware (standalone13 or cluster13), since both matrix jobs use the same runner-label pool.