### PR TITLE
cephadm_install: detect the ceph image version from local images

### DIFF
--- a/roles/cephadm_install/README.md
+++ b/roles/cephadm_install/README.md
@@ -2,6 +2,19 @@
 
 This role installs the cephadm binary, prerequisites (users, groups, sudo), pulls required container images, and starts the local Podman registry before the cephadm cluster is set up. Cluster provisioning is handled by the `cephadm` role.
 
+## Ceph version detection
+
+When `cephadm_release` is not set in the inventory, the role detects the version of the `quay.io/ceph/ceph` container image already present on the nodes (the SEAPATH Debian ISO pre-embeds it) and uses it as `cephadm_release` for the whole deployment. Setting `cephadm_release` in the inventory disables the detection entirely: the inventory is the place to pin a version, not to repair a broken default.
+
+Detection rules:
+
+- The versions are read from the tags of the local `quay.io/ceph/ceph` images (`podman image ls`). Other images, including the `localhost:5000/ceph` tags pushed by this role, are ignored.
+- The deployment fails if a node holds several ceph image versions, or if two nodes hold different versions. The error message lists the version found on each node; fix the images or pin `cephadm_release` to resolve it.
+- If some nodes hold an image and others none, the nodes without image adopt the detected version and pull it.
+- If no image is found on any node (image pulled at deploy time), the default version below is used and a warning is printed.
+
+The detected version is set as a host fact, so it also applies to the `cephadm` role (bootstrap, `--image` flags) in later plays of the same run.
+
 ## Role Variables
 
 | Variable                          | Required | Type    | Default                        | Comments                                                                                   |

--- a/roles/cephadm_install/tasks/detect_release.yml
+++ b/roles/cephadm_install/tasks/detect_release.yml
@@ -1,0 +1,67 @@
+# Copyright (C) 2026 RTE
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: List local ceph container images
+  ansible.builtin.command: podman image ls --format json quay.io/ceph/ceph
+  register: cephadm_install_local_images
+  changed_when: false
+
+- name: Extract ceph versions from local images
+  ansible.builtin.set_fact:
+    cephadm_install_detected_versions: >-
+      {{
+        cephadm_install_local_images.stdout | from_json
+        | selectattr('Names', 'defined')
+        | map(attribute='Names') | flatten
+        | select('match', '^quay\.io/ceph/ceph:v')
+        | map('regex_replace', '^quay\.io/ceph/ceph:v', '')
+        | unique | list
+      }}
+
+- name: Check that a single ceph image version is present on this node
+  ansible.builtin.assert:
+    that: cephadm_install_detected_versions | length <= 1
+    fail_msg: >-
+      Several ceph container image versions found on
+      {{ inventory_hostname }}: {{ cephadm_install_detected_versions | join(', ') }}.
+      Remove the unused images or set cephadm_release in the inventory to
+      select one.
+
+- name: Gather ceph image versions found across the cluster
+  ansible.builtin.set_fact:
+    cephadm_install_cluster_versions: >-
+      {{
+        ansible_play_hosts
+        | map('extract', hostvars, 'cephadm_install_detected_versions')
+        | flatten | unique | list
+      }}
+
+- name: Check that all cluster nodes have the same ceph image version
+  ansible.builtin.assert:
+    that: cephadm_install_cluster_versions | length <= 1
+    fail_msg: >-
+      The cluster nodes do not have the same ceph container image version:
+      {{
+        ansible_play_hosts
+        | zip(ansible_play_hosts | map('extract', hostvars, 'cephadm_install_detected_versions'))
+        | map('join', '=')
+        | join(', ')
+      }}.
+      Align the images on every node or set cephadm_release in the inventory.
+  run_once: true
+
+# The fact is named without the role prefix on purpose: it must override the
+# cephadm_release default used by the cephadm role in later plays.
+- name: Use the detected ceph image version # noqa: var-naming[no-role-prefix]
+  ansible.builtin.set_fact:
+    cephadm_release: "{{ cephadm_install_cluster_versions[0] }}"
+  when: cephadm_install_cluster_versions | length == 1
+
+- name: Warn that no local ceph image was found
+  ansible.builtin.debug:
+    msg: >-
+      No ceph container image found on the cluster nodes, falling back to the
+      default version {{ cephadm_install_release }}.
+  when: cephadm_install_cluster_versions | length == 0
+  run_once: true

--- a/roles/cephadm_install/tasks/main.yml
+++ b/roles/cephadm_install/tasks/main.yml
@@ -3,6 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
+- name: Detect the ceph container image version when not set in the inventory
+  ansible.builtin.include_tasks: detect_release.yml
+  when: cephadm_release is not defined
+
 - name: Ensure group "cephadm" exists
   ansible.builtin.group:
     name: cephadm


### PR DESCRIPTION
build_debian_iso now embeds the latest cephadm container image, so the hardcoded cephadm_release default can diverge from the image actually present on the nodes and break the deployment.

When cephadm_release is not set in the inventory, detect the version of the quay.io/ceph/ceph image already present on the nodes and use it for the whole deployment. The detection fails if a node holds several ceph image versions or if two nodes hold different versions. When no image is found anywhere, fall back to the default version. Setting cephadm_release in the inventory disables the detection and pins the version.