### PR TITLE
cephadm_install: derive the Ceph release name from the release version

### DIFF
--- a/roles/cephadm_install/README.md
+++ b/roles/cephadm_install/README.md
@@ -8,7 +8,8 @@ This role installs the cephadm binary, prerequisites (users, groups, sudo), pull
 |-----------------------------------|----------|---------|--------------------------------|--------------------------------------------------------------------------------------------|
 | seapath_distro                    | No       | String  | Not set                        | SEAPATH distribution                                                                       |
 | cephadm_install_release           | No       | String  | "20.2.0"                       | Version of the cephadm binary to download (fallback: `cephadm_release`)                    |
-| cephadm_install_release_name      | No       | String  | "tentacle"                     | Name of the ceph release for repo install (fallback: `cephadm_release_name`)               |
+| cephadm_install_release_names     | No       | Dict    | quincy … umbrella              | Ceph release name for each major version, used to derive `cephadm_install_release_name`    |
+| cephadm_install_release_name      | No       | String  | Derived from `cephadm_install_release` | Name of the ceph release for repo install; set it to override the derivation (fallback: `cephadm_release_name`) |
 | cephadm_install_downloadbinary    | No       | Boolean | false                          | Download cephadm to /tmp/cephadm (fallback: `cephadm_downloadbinary`)                      |
 | cephadm_install_binary            | No       | Boolean | false                          | Copy cephadm from /tmp to /usr/local/bin (fallback: `cephadm_installbinary`)               |
 | cephadm_install_repo              | No       | Boolean | false                          | Install cephadm repo with "cephadm add-repo" (fallback: `cephadm_installrepo`)             |

--- a/roles/cephadm_install/defaults/main.yml
+++ b/roles/cephadm_install/defaults/main.yml
@@ -4,7 +4,19 @@
 
 ---
 cephadm_install_release: "{{ cephadm_release | default('20.2.0') }}"
-cephadm_install_release_name: "{{ cephadm_release_name | default('tentacle') }}"
+# "cephadm add-repo" takes a release name while the binary download URL takes a
+# version number, so both have to designate the same Ceph release. Derive the
+# name from the major version instead of pinning it separately.
+cephadm_install_release_names:
+  "17": "quincy"
+  "18": "reef"
+  "19": "squid"
+  "20": "tentacle"
+  "21": "umbrella"
+cephadm_install_release_name: >-
+  {{ cephadm_release_name | default(
+       cephadm_install_release_names[cephadm_install_release.split('.')[0]]
+       | default('')) }}
 cephadm_install_downloadbinary: "{{ cephadm_downloadbinary | default(false) }}"
 cephadm_install_binary: "{{ cephadm_installbinary | default(false) }}"
 cephadm_install_repo: "{{ cephadm_installrepo | default(false) }}"

--- a/roles/cephadm_install/tasks/main.yml
+++ b/roles/cephadm_install/tasks/main.yml
@@ -55,6 +55,15 @@
     remote_src: true
   when: cephadm_install_binary is true
 
+- name: Check the Ceph release name is known
+  ansible.builtin.assert:
+    that: cephadm_install_release_name | length > 0
+    fail_msg: >-
+      No Ceph release name is known for version {{ cephadm_install_release }}.
+      Add its major version to cephadm_install_release_names, or set
+      cephadm_install_release_name explicitly.
+  when: cephadm_install_repo is true
+
 - name: Install cephadm repository
   ansible.builtin.command: "{{ '/tmp/cephadm' if not cephadm_install_binary else 'cephadm' }} add-repo --release {{ cephadm_install_release_name }}"
   changed_when: true


### PR DESCRIPTION
"cephadm add-repo" takes a release name while the cephadm download URL takes a version number. Both were pinned separately, so bumping cephadm_install_release alone silently left the repo on the previous release, mixing a binary from one Ceph version with packages from another.

Derive the name from the major version through a lookup table, and assert before add-repo that a name is known, so an unlisted version fails with an explicit message instead of installing the wrong repo. Setting cephadm_install_release_name explicitly still overrides the derivation.