### PR TITLE
configure_hypervisor: add rbd helpers for quadlet containers

### DIFF
--- a/roles/configure_hypervisor/files/seapath-rbd-mount
+++ b/roles/configure_hypervisor/files/seapath-rbd-mount
@@ -1,0 +1,210 @@
+#!/bin/bash
+# Copyright (C) 2026 RTE
+# SPDX-License-Identifier: Apache-2.0
+#
+# seapath-rbd-mount - map a Ceph RBD image and mount it.
+#
+# Usage: seapath-rbd-mount <image-name> [<size>]
+#
+# Maps rbd/<image-name> and mounts it at /mnt/rbd/<image-name>.
+#
+# Wraps the full lifecycle needed before a container can use an RBD-backed
+# volume: dirty-state cleanup, image creation on first use, device mapping,
+# filesystem creation on first use, and mounting.
+#
+# The script is idempotent: calling it again while the image is already
+# correctly mapped and mounted is a no-op, and it is safe to call from
+# ExecStartPre= even if a previous service run was interrupted partway
+# through (e.g. crash between mount and umount).
+#
+# Arguments:
+#   image-name   Name of the RBD image (pool: rbd, mountpoint: /mnt/rbd/<name>)
+#   size         Image size passed to rbd create, only used if the image does
+#                not yet exist (default: 1G, accepts any rbd suffix: M, G, T)
+#
+# Filesystem: ext4.  The device is formatted only once, on first use, when
+# blkid reports no existing filesystem signature.
+#
+# Requires: rbd, jq, blkid, mkfs.ext4, findmnt, mount, and coreutils
+# (readlink, wc, tr).
+#
+# Exit: 0 on success, non-zero on any failure in the map/format/mount steps.
+# The individual cleanup commands are best-effort, but the script aborts if the
+# mountpoint or the device mappings cannot be cleared, rather than stacking a
+# second mount or mapping on top of ones still in use.
+
+set -euo pipefail
+
+IMAGE="${1:?Usage: seapath-rbd-mount <image-name> [<size>]}"
+SIZE="${2:-1G}"
+
+POOL="rbd"
+RBD_IMAGE="${POOL}/${IMAGE}"
+MOUNTPOINT="/mnt/rbd/${IMAGE}"
+DEV_PATH="/dev/rbd/${POOL}/${IMAGE}"
+
+log() { echo "seapath-rbd-mount: $*" >&2; }
+die() { log "$*"; exit 1; }
+count_lines() { printf '%s\n' "$1" | wc -l; }
+
+command -v jq > /dev/null 2>&1 || die "jq is required but not installed"
+
+# ---------------------------------------------------------------------------
+# mapped_devices - print the device node of every kernel mapping of this image
+#
+# `rbd device list --format json` returns one object per mapping:
+#
+#   [{"id":"0","pool":"rbd","namespace":"","image":"foo",
+#     "snap":"-","device":"/dev/rbd0"}]
+#
+# All four identity fields are matched rather than the image name alone, so a
+# different pool or namespace holding an image of the same name is never
+# touched.  snap == "-" selects read-write mappings, the only kind these
+# helpers ever create: a snapshot mapping of the same image was made by
+# something else and is none of our business.
+#
+# Enumerating the list is required because the stable symlink
+# /dev/rbd/<pool>/<image> points only to the most recent mapping.  Earlier
+# stale mappings from interrupted runs accumulate as /dev/rbdN and can only be
+# found here.
+# ---------------------------------------------------------------------------
+
+mapped_devices() {
+    rbd device list --format json 2> /dev/null | jq -r \
+        --arg pool "$POOL" --arg image "$IMAGE" '
+            .[]
+            | select(.pool == $pool and .namespace == ""
+                     and .image == $image and .snap == "-")
+            | .device
+        '
+}
+
+# ---------------------------------------------------------------------------
+# is_already_mounted - true when the image is mapped exactly once and the
+# mountpoint is served by that very device.
+#
+# Guards a re-run against a healthy, in-use mount (ExecStartPre= firing again
+# before ExecStopPost= tore anything down): the cleanup below would unmount it
+# from under the running container.  Anything ambiguous (no mapping, several
+# mappings, stacked mounts, mounted from a stale device) returns false and
+# goes through the cleanup.
+#
+# Both sides are resolved with readlink -f because findmnt may report either
+# the stable symlink or /dev/rbdN, and the resolved value must be non-empty:
+# comparing two failed resolutions would otherwise match.
+# ---------------------------------------------------------------------------
+
+is_already_mounted() {
+    local devs mount_src mounted_real mapped_real
+
+    devs="$1"
+    [ -n "$devs" ] && [ "$(count_lines "$devs")" -eq 1 ] || return 1
+
+    mount_src="$(findmnt -rn -o SOURCE "$MOUNTPOINT" 2> /dev/null || true)"
+    [ -n "$mount_src" ] && [ "$(count_lines "$mount_src")" -eq 1 ] || return 1
+
+    mounted_real="$(readlink -f "$mount_src" 2> /dev/null || true)"
+    mapped_real="$(readlink -f "$devs" 2> /dev/null || true)"
+    [ -n "$mounted_real" ] && [ "$mounted_real" = "$mapped_real" ]
+}
+
+# Tolerate a failing rbd/jq here: the guard is only an optimisation, and a
+# broken rbd must surface on the map step below, not as a silent early exit.
+current_devs="$(mapped_devices || true)"
+
+if is_already_mounted "$current_devs"; then
+    log "$RBD_IMAGE already mapped and mounted at $MOUNTPOINT, nothing to do"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Dirty-state cleanup
+#
+# If a previous run of the service was interrupted (OOM kill, SIGKILL, host
+# crash with /run on tmpfs + late umount ordering), the device may still be
+# mapped and/or the mountpoint may still be active.  Clean that up before
+# proceeding so the rest of the script is deterministic.
+#
+# The individual commands are best-effort; the check right after them verifies
+# the state is actually clear and aborts if it is not.
+# ---------------------------------------------------------------------------
+
+while findmnt -rn "$MOUNTPOINT" > /dev/null 2>&1; do
+    log "$MOUNTPOINT still mounted, unmounting (dirty cleanup)"
+    umount "$MOUNTPOINT" || break
+done
+
+while IFS= read -r stale_dev; do
+    log "unmapping stale $stale_dev (dirty cleanup)"
+    rbd unmap "$stale_dev" || true
+done < <(mapped_devices)
+
+# ---------------------------------------------------------------------------
+# Refuse to stack if the cleanup did not clear the state
+#
+# rbd map does not refuse a second mapping of the same image, and mount does
+# not refuse an over-mount.  So a cleanup blocked by a busy device or
+# mountpoint (a process still holding files open) would otherwise be followed
+# by a silent second mapping and a second, shadowing mount.  Abort instead.
+# ---------------------------------------------------------------------------
+
+if findmnt -rn "$MOUNTPOINT" > /dev/null 2>&1; then
+    die "$MOUNTPOINT still mounted after cleanup, refusing to stack a second mount"
+fi
+
+remaining="$(mapped_devices || true)"
+if [ -n "$remaining" ]; then
+    die "$RBD_IMAGE still mapped after cleanup" \
+        "($(printf '%s' "$remaining" | tr '\n' ' ')), refusing to stack a second mapping"
+fi
+
+# ---------------------------------------------------------------------------
+# Create the RBD image on first use
+#
+# rbd info exits non-zero when the image does not exist.  We create it with
+# the layering feature (required for clone/snapshot, harmless otherwise) and
+# the caller-supplied size.  On subsequent runs the image already exists and
+# this block is skipped entirely.
+# ---------------------------------------------------------------------------
+
+if ! rbd info "$RBD_IMAGE" > /dev/null 2>&1; then
+    log "creating RBD image $RBD_IMAGE (size $SIZE)"
+    rbd create "$RBD_IMAGE" --size "$SIZE" --image-feature layering
+fi
+
+# ---------------------------------------------------------------------------
+# Map the block device
+#
+# After a successful rbd map, the kernel exposes the device both as
+# /dev/rbdN (dynamically assigned number) and as the stable symlink
+# /dev/rbd/<pool>/<image>, which we use throughout this script.
+# ---------------------------------------------------------------------------
+
+rbd map "$RBD_IMAGE"
+
+# ---------------------------------------------------------------------------
+# Ensure mountpoint exists
+# ---------------------------------------------------------------------------
+
+mkdir -p "$MOUNTPOINT"
+
+# ---------------------------------------------------------------------------
+# Format on first use
+#
+# blkid exits non-zero when the device has no recognisable filesystem
+# signature, which is exactly the case for a freshly created RBD image.
+# We format with ext4 (quiet mode to suppress the progress output).
+# On subsequent runs the filesystem already exists and this step is skipped.
+# ---------------------------------------------------------------------------
+
+if ! blkid "$DEV_PATH" > /dev/null 2>&1; then
+    log "no filesystem on $DEV_PATH, formatting ext4"
+    mkfs.ext4 -q "$DEV_PATH"
+fi
+
+# ---------------------------------------------------------------------------
+# Mount
+# ---------------------------------------------------------------------------
+
+mount "$DEV_PATH" "$MOUNTPOINT"
+log "$RBD_IMAGE mounted at $MOUNTPOINT"

--- a/roles/configure_hypervisor/files/seapath-rbd-unmount
+++ b/roles/configure_hypervisor/files/seapath-rbd-unmount
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Copyright (C) 2026 RTE
+# SPDX-License-Identifier: Apache-2.0
+#
+# seapath-rbd-unmount - unmount a filesystem and force-unmap all RBD device
+# mappings for a given image.
+#
+# Usage: seapath-rbd-unmount <image-name>
+#
+# Unmounts /mnt/rbd/<image-name> (if mounted) and then force-unmaps every
+# kernel RBD device node currently mapped read-write to rbd/<image-name>.
+#
+# Force-unmapping (-o force) is required because devices left over from a
+# container crash may still be held by udevd, blkid, or other kernel
+# references even after the filesystem is unmounted.
+#
+# All steps are best-effort and exit 0, so the script is safe to use from
+# ExecStopPost=.
+#
+# Arguments:
+#   image-name   Name of the RBD image (mountpoint: /mnt/rbd/<image-name>)
+#
+# Requires: rbd, jq, findmnt, umount.
+
+IMAGE="${1:?Usage: seapath-rbd-unmount <image-name>}"
+
+POOL="rbd"
+MOUNTPOINT="/mnt/rbd/${IMAGE}"
+
+log() { echo "seapath-rbd-unmount: $*" >&2; }
+
+# ---------------------------------------------------------------------------
+# mapped_devices - print the device node of every kernel mapping of this image
+#
+# Same selection as seapath-rbd-mount, deliberately kept identical: match on
+# pool, namespace, image and snap rather than on the image name alone, so
+# neither a same-named image in another pool/namespace nor a snapshot mapping
+# made by something else is force-unmapped from under its user.
+#
+# Enumerating the list is required because the stable symlink
+# /dev/rbd/<pool>/<image> points only to the most recent mapping, while
+# repeated interrupted starts leave several /dev/rbdN behind.
+# ---------------------------------------------------------------------------
+
+mapped_devices() {
+    rbd device list --format json 2> /dev/null | jq -r \
+        --arg pool "$POOL" --arg image "$IMAGE" '
+            .[]
+            | select(.pool == $pool and .namespace == ""
+                     and .image == $image and .snap == "-")
+            | .device
+        '
+}
+
+# Interrupted previous runs can stack several mounts on the same path, so
+# unmount until findmnt reports the mountpoint clear.
+while findmnt -rn "$MOUNTPOINT" > /dev/null 2>&1; do
+    umount "$MOUNTPOINT" || break
+    log "$MOUNTPOINT unmounted"
+done
+
+if ! command -v jq > /dev/null 2>&1; then
+    log "jq is not installed, cannot enumerate mappings, skipping unmap"
+    exit 0
+fi
+
+while IFS= read -r dev; do
+    log "unmapping $dev"
+    rbd unmap -o force "$dev" 2> /dev/null || rbd unmap "$dev" || true
+done < <(mapped_devices)
+
+exit 0

--- a/roles/configure_hypervisor/tasks/main.yml
+++ b/roles/configure_hypervisor/tasks/main.yml
@@ -21,6 +21,11 @@
   ansible.builtin.import_tasks: irqbalance.yml
 - name: Apply libvirt configurations
   ansible.builtin.import_tasks: libvirt.yml
+# On Yocto the root filesystem is read-only: the helpers must be shipped by
+# the image itself (meta-seapath).
+- name: Install RBD volume helpers for quadlet containers
+  ansible.builtin.import_tasks: rbd_helpers.yml
+  when: seapath_distro != "Yocto"
 
 - name: SEAPATH Debian specific hypervisor configuration
   when: seapath_distro == "Debian"

--- a/roles/configure_hypervisor/tasks/rbd_helpers.yml
+++ b/roles/configure_hypervisor/tasks/rbd_helpers.yml
@@ -1,0 +1,18 @@
+# Copyright (C) 2026 RTE
+# SPDX-License-Identifier: Apache-2.0
+---
+- name: Install seapath-rbd-mount helper
+  ansible.builtin.copy:
+    src: seapath-rbd-mount
+    dest: /usr/local/bin/seapath-rbd-mount
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Install seapath-rbd-unmount helper
+  ansible.builtin.copy:
+    src: seapath-rbd-unmount
+    dest: /usr/local/bin/seapath-rbd-unmount
+    owner: root
+    group: root
+    mode: "0755"


### PR DESCRIPTION
Context
-------
SEAPATH containers (Podman quadlets) that use Ceph RBD for persistent storage
must today embed a long sequence of ExecStartPre= and ExecStopPost= steps
directly in the quadlet file.  A typical unit needs to:

  1. Detect and clean up dirty state from a previous interrupted run
     (unmount stale mountpoints, unmap all stale RBD device mappings).
  2. Create the RBD image on first use (rbd create).
  3. Map the block device (rbd map).
  4. Create the mountpoint directory if absent.
  5. Detect and format the device on first use (mkfs.ext4).
  6. Mount the device.
  7. On stop: unmount all stacked mounts and unmap all device mappings.

This boilerplate is identical across every container that uses RBD, only the
image name changes.  Writing it by hand is error-prone (especially the
dirty-state cleanup) and produces quadlet files that are hard to read and
maintain.

What this commit adds
---------------------
Two bash scripts installed to /usr/local/bin/ by the configure_hypervisor role.
Both take only the image name; pool (rbd) and mountpoint (/mnt/rbd/<name>) are
fixed by convention.

  seapath-rbd-mount <image-name> [<size>]

    Idempotent mount script.  Handles the full lifecycle:

    - Early exit when the image is already mapped exactly once and the
      mountpoint is served by that very device: nothing to do.

    - Dirty-state cleanup: loops umount until the mountpoint is fully clear
      (interrupted previous runs can stack multiple mounts at the same path),
      then unmaps every device node still mapped to the image.

    - Refusal to stack: if the mountpoint or the mappings could not be cleared,
      the script aborts rather than mapping and mounting again on top.

    - First-use image creation: calls rbd create with --image-feature layering
      and the caller-supplied size (default 1G) only if rbd info reports the
      image does not exist.

    - Device mapping: rbd map creates both /dev/rbdN and the stable symlink
      /dev/rbd/rbd/<image>.

    - First-use filesystem: blkid is used to detect whether a filesystem
      already exists.  If not (freshly created image), mkfs.ext4 -q formats it
      silently.  Subsequent runs skip this step.

    - Mount.

  seapath-rbd-unmount <image-name>

    Best-effort unmount/unmap script for ExecStopPost=.  Loops umount until the
    mountpoint is fully clear (handles stacked mounts from repeated interrupted
    starts), then force-unmaps (-o force) all device nodes still mapped to the
    image.  Force-unmapping handles devices held by udevd, blkid, or other
    kernel references after a container crash.  Exits 0 regardless.

Idempotency
-----------
The mount script runs from ExecStartPre=, so it must cope with any starting
state, including one where the previous run's mount is still healthy and in
use.

is_already_mounted() runs first: it returns true when the image has exactly one
kernel mapping and the mountpoint has exactly one mount entry whose source
resolves to that device.  The script then logs and exits 0 without touching
anything, because falling through to the cleanup would unmount a live
mountpoint from under a running container.  Both sides are resolved with
readlink -f (findmnt may report either the stable symlink or /dev/rbdN) and the
resolved values must be non-empty, so that two failed resolutions cannot
compare equal.

After the cleanup, the script checks that the state is actually clear and
aborts if it is not.  rbd map does not refuse a second mapping of the same
image, and mount does not refuse an over-mount, so a cleanup blocked by a busy
device or mountpoint (a process still holding files open) would otherwise be
followed by a silent second mapping and a second, shadowing mount, reported as
a success.  The individual cleanup commands stay best-effort; it is the
post-condition that is enforced.

The enumeration used by the first guard tolerates a failing rbd or jq: that
guard is only an optimisation, and a broken rbd must surface on the map step
rather than as a silent early exit.

Enumerating the device mappings
-------------------------------
Both scripts need the list of kernel mappings for an image, because the stable
symlink /dev/rbd/<pool>/<image> points only to the most recent mapping: earlier
stale mappings from interrupted runs accumulate as /dev/rbdN and can only be
found by enumerating the device list.

That enumeration is done with rbd device list --format json filtered by jq, in
a mapped_devices() helper that is deliberately identical in both scripts:

    rbd device list --format json | jq -r --arg pool ... --arg image ... '
        .[]
        | select(.pool == $pool and .namespace == ""
                 and .image == $image and .snap == "-")
        | .device
    '

Selecting on the structured output rather than on column positions matters for
correctness, not only for readability.  All four identity fields are matched:

  - pool and namespace, so a same-named image in another pool or namespace is
    never unmapped from under its user.

  - snap == "-", which selects read-write mappings, the only kind these helpers
    ever create.  A snapshot mapping of the same image was made by something
    else (an admin, a backup job) and must not be force-unmapped.

jq is already part of the expected package set on SEAPATH images and is already
used to parse Ceph JSON output elsewhere in the tree (deploy_cephfs
wait-for-mds.sh), so it introduces no new dependency.  seapath-rbd-mount still
checks for it explicitly and fails with a clear message if it is missing,
rather than silently enumerating zero devices and skipping the cleanup.

Usage in a quadlet
------------------
The ExecStartPre / ExecStopPost block in the quadlet file is reduced to:

  ExecStartPre=/usr/local/bin/seapath-rbd-mount mycontainer
  ExecStopPost=/usr/local/bin/seapath-rbd-unmount mycontainer

Any app-specific subdirectories that the container needs inside the mountpoint
are the caller's responsibility (mkdir -p in a separate ExecStartPre= line),
they are inherently application-specific and out of scope for a generic helper.

Deployment
----------
The two scripts are installed by a new rbd_helpers.yml task file included from
configure_hypervisor/tasks/main.yml, following the same pattern as the other
helpers in that role (ansible.builtin.copy, mode 0755).

The task is skipped on Yocto (seapath_distro != "Yocto"): the root filesystem
is read-only there, so the scripts must be shipped by the image itself.
Porting them to meta-seapath is required before quadlets relying on these
helpers can be used on Yocto.
