### PR TITLE
backup_restore: back up and restore VM additional disks

### DIFF
--- a/roles/backup_restore/README.md
+++ b/roles/backup_restore/README.md
@@ -1,6 +1,27 @@
 # Backup-restore Role
 
-This role installs the backup-restore utility
+This role installs the backup-restore utility on cluster machines. The
+utility backs up VMs stored in Ceph RBD (cluster mode only) to a remote
+server, and restores them.
+
+For each guest, the backup covers:
+
+- the system disk (`system_<guest>` RBD image);
+- its additional disks (`data_<guest>_<n>` RBD images), if any;
+- the libvirt XML and all RBD image metadata of the system disk.
+
+Full backups export every disk as a qcow2 image; incremental backups export
+RBD diffs against the latest snapshot. On restore, the VM is recreated with
+`vm-mgr create` (including its additional disks), diffs are re-applied up to
+the chosen date, and metadata is restored.
+
+Note: an additional disk added to a VM after the latest full backup cannot
+be backed up incrementally; the incremental backup skips it with a warning
+until a new full backup is made.
+
+The tool is configured through `/etc/backup-restore.conf` (managed by the
+`backup-restore.sh` menu). `include_vm` and `exclude_vm` are extended
+regular expressions matched against guest names.
 
 ## Requirements
 

--- a/roles/backup_restore/files/scripts/backup-restore.sh
+++ b/roles/backup_restore/files/scripts/backup-restore.sh
@@ -3,44 +3,32 @@
 # SPDX-License-Identifier: Apache-2.0
 
 conffile=/etc/backup-restore.conf
-# clean screen proportion
-clear
-for i in 50 100; do
-   echo $i
-   sleep 0.1
-done | whiptail --gauge "Doing something" 10 50 0
 
-function addExitToArray {
-  local -n myarray=$1
-  myarray+=("(exit)")
-  myarray+=(" ")
-}
-function addIndexToArray {
-  local -n myarray=$1
-  for idx in `seq 1 ${#myarray[@]}`; do
-    arrVar+=($idx")")
-    arrVar+=("${myarray[$(($idx-1))]}")
+# Display a whiptail menu over the given items and print the (0-based) index
+# of the selected one. Returns 1 if the user chose "back", 2 for "(exit)".
+function menuChooseIndex {
+  local title=$1 prompt=$2
+  shift 2
+  local items=("$@")
+  local args=() idx choice
+  for idx in "${!items[@]}"; do
+    args+=("$((idx + 1)))" "${items[$idx]}")
   done
+  args+=("(exit)" " ")
+  choice=$(whiptail --title "$title" --cancel-button "back" --menu "$prompt" 22 115 14 \
+           "${args[@]}" 3>&2 2>&1 1>&3) || return 1
+  [[ "$choice" == "(exit)" ]] && return 2
+  echo "$((${choice%")"} - 1))"
 }
+
 function getVars {
-  source ${conffile}
+  source "$conffile"
   include_vm=${include_vm:-".*"}
   exclude_vm=${exclude_vm:-NonExistingGuestNameForDefault}
 }
-function getVarsOld {
-  readVar local_dir
-  local_dir=$value
-  readVar remote_serv
-  remote_serv=$value
-  readVar remote_dir
-  remote_dir=$value
-  readVar local_tmp_dir
-  local_tmp_dir=$value
-  readVar remote_shell
-  remote_shell=$value
-}
+
 function restoreVMChooseFullDate {
-  while [ 1 ]
+  while true
   do
     getVars
     [ -z "$local_tmp_dir" ] && { whiptail --msgbox "var local_tmp_dir empty" 10 50; break; }
@@ -49,142 +37,92 @@ function restoreVMChooseFullDate {
     [ -z "$remote_shell" ] && { whiptail --msgbox "var remote_shell empty" 10 50; break; }
 
     local listFullDate=($($remote_shell $remote_serv "cd $remote_dir ; ls"))
-    local arrVar=()
-    addIndexToArray listFullDate
-    addExitToArray arrVar
-    CHOICE=$(
-    whiptail --title "restore vm" --cancel-button "back" --menu "Choose full backup date:" 22 115 14 \
-          "${arrVar[@]}" \
-          3>&2 2>&1 1>&3
-    )
-    [[ "$?" = 1 ]] && break
-    [[ $CHOICE == "(exit)" ]] && exit
-    c=`echo $CHOICE | sed "s/)//"`
-    c=$((($c-1)*2+1))
-    fulldate=${arrVar[$c]}
+    local idx
+    idx=$(menuChooseIndex "restore vm" "Choose full backup date:" "${listFullDate[@]}")
+    case $? in 1) break ;; 2) exit ;; esac
+    fulldate=${listFullDate[$idx]}
     restoreVMChooseVM
   done
 }
+
 function restoreVMChooseVM {
-  while [ 1 ]
+  while true
   do
     local listVM=($($remote_shell $remote_serv "cd $remote_dir ; cd $fulldate; ls *.qcow2 | grep -E "^system_" | cut -d"_" -f 2 | sort -u"))
-    local arrVar=()
-    addIndexToArray listVM
-    addExitToArray arrVar
-    CHOICE=$(
-    whiptail --title "restore vm" --cancel-button "back" --menu "Choose VM:" 22 115 14 \
-          "${arrVar[@]}" \
-          3>&2 2>&1 1>&3
-    )
-    [[ "$?" = 1 ]] && break
-    [[ $CHOICE == "(exit)" ]] && exit
-    c=`echo $CHOICE | sed "s/)//"`
-    c=$((($c-1)*2+1))
-    vm=${arrVar[$c]}
+    local idx
+    idx=$(menuChooseIndex "restore vm" "Choose VM:" "${listVM[@]}")
+    case $? in 1) break ;; 2) exit ;; esac
+    vm=${listVM[$idx]}
     restoreVMChooseIncDate
   done
 }
+
 function restoreVMChooseIncDate {
   local listIncDateRaw=($($remote_shell $remote_serv "cd $remote_dir ; cd $fulldate; ls *_""$vm""-*.xml | cut -d- -f2 | cut -d. -f1"))
-  local listIncDate=()
-  for idx in ${listIncDateRaw[@]}; do
-    e=`echo "$idx" | sed 's/./&-/4;s/./&-/7;s/./& /10;s/./&:/13'`
-    listIncDate+=("$e")
+  local listIncDate=() rawdate
+  for rawdate in "${listIncDateRaw[@]}"; do
+    listIncDate+=("$(echo "$rawdate" | sed 's/./&-/4;s/./&-/7;s/./& /10;s/./&:/13')")
   done
-  local arrVar=()
-  addIndexToArray listIncDate
-  addExitToArray arrVar
-  CHOICE=$(
-  whiptail --title "restore vm" --cancel-button "back" --menu "Choose Incremental backup:" 22 115 14 \
-        "${arrVar[@]}" \
-        3>&2 2>&1 1>&3
-  )
-  [[ "$?" = 1 ]] && return
-  [[ $CHOICE == "(exit)" ]] && exit
-  c=`echo $CHOICE | sed "s/)//"`
-  #d=$((($c-1)*2+1))
-  #incdate=${arrVar[$d]}
-  d=$(($c-1))
-  incdate=${listIncDateRaw[$d]}
-  /usr/local/bin/restore_vm.sh $local_tmp_dir "$remote_shell" $remote_serv:$remote_dir $fulldate $vm $incdate
+  local idx
+  idx=$(menuChooseIndex "restore vm" "Choose Incremental backup:" "${listIncDate[@]}")
+  case $? in 1) return ;; 2) exit ;; esac
+  incdate=${listIncDateRaw[$idx]}
+  /usr/local/bin/restore_vm.sh "$local_tmp_dir" "$remote_shell" "$remote_serv:$remote_dir" "$fulldate" "$vm" "$incdate"
 }
+
 function writeVar {
-  key=$1
-  value=$2
-  valuesed=`echo $value | sed -e 's/\//\\\\\//g'`
-  grep -q -E "^${key}=" ${conffile} && sed -i "s/^${key}=.*$/${key}=${valuesed}/" ${conffile} || echo "${key}=${value}" >> ${conffile}
-  sort -u -t= -k1,1 ${conffile} -o ${conffile}
+  local key=$1 value=$2
+  local valuesed=$(echo "$value" | sed -e 's/\//\\\//g')
+  grep -q -E "^${key}=" "$conffile" && sed -i "s/^${key}=.*$/${key}=${valuesed}/" "$conffile" || echo "${key}=${value}" >> "$conffile"
+  sort -u -t= -k1,1 "$conffile" -o "$conffile"
 }
-function readVar {
-  key=$1
-  value=`grep -E "^${key}=" ${conffile} | cut -d"=" -f2`
-}
+
 function backupFull {
   getVars
   [ -z "$remote_dir" ] && { whiptail --msgbox "var remote_dir empty" 10 50; return; }
   [ -z "$remote_shell" ] && { whiptail --msgbox "var remote_shell empty" 10 50; return; }
   [ -z "$remote_serv" ] && { whiptail --msgbox "var remote_serv empty" 10 50; return; }
-  /usr/local/bin/backup_full.sh $local_dir "$remote_shell" $remote_serv":"$remote_dir "$include_vm" "$exclude_vm"
+  /usr/local/bin/backup_full.sh "$local_dir" "$remote_shell" "$remote_serv:$remote_dir" "$include_vm" "$exclude_vm"
 }
+
 function backupInc {
   getVars
   [ -z "$remote_dir" ] && { whiptail --msgbox "var remote_dir empty" 10 50; return; }
   [ -z "$remote_shell" ] && { whiptail --msgbox "var remote_shell empty" 10 50; return; }
   [ -z "$remote_serv" ] && { whiptail --msgbox "var remote_serv empty" 10 50; return; }
-  /usr/local/bin/backup_inc.sh $local_dir "$remote_shell" $remote_serv":"$remote_dir "$include_vm" "$exclude_vm"
+  /usr/local/bin/backup_inc.sh "$local_dir" "$remote_shell" "$remote_serv:$remote_dir" "$include_vm" "$exclude_vm"
 }
+
 function getValueForVar {
-   var=$1
-   val=$(whiptail --inputbox "Enter value for $var" 10 30 3>&1 1>&2 2>&3)
-   [[ "$?" = 1 ]] && return
-   writeVar $var $val
+  local var=$1 val
+  val=$(whiptail --inputbox "Enter value for $var" 10 30 3>&1 1>&2 2>&3) || return
+  writeVar "$var" "$val"
 }
+
 function settings {
-  while [ 1 ]
+  local vars=(local_dir remote_serv remote_dir local_tmp_dir remote_shell include_vm exclude_vm)
+  while true
   do
-    touch ${conffile}
-    source ${conffile}
-    CHOICE=$(
-    whiptail --title "change settings" --cancel-button "back" --menu "Make your choice" 22 115 14 \
-          "1)" "change value local_dir, currently \"$local_dir\""   \
-          "2)" "change value remote_serv, currently \"$remote_serv\""   \
-          "3)" "change value remote_dir, currently \"$remote_dir\""   \
-          "4)" "change value local_tmp_dir, currently \"$local_tmp_dir\""   \
-          "5)" "change value remote_shell, currently \"$remote_shell\""   \
-          "6)" "change value include_vm, currently \"$include_vm\""   \
-          "7)" "change value exclude_vm, currently \"$exclude_vm\""   \
-          3>&2 2>&1 1>&3
-    )
-    [[ "$?" = 1 ]] && break
-    case $CHOICE in
-      "1)") getValueForVar local_dir
-      ;;
-      "2)") getValueForVar remote_serv
-      ;;
-      "3)") getValueForVar remote_dir
-      ;;
-      "4)") getValueForVar local_tmp_dir
-      ;;
-      "5)") getValueForVar remote_shell
-      ;;
-      "6)") getValueForVar include_vm
-      ;;
-      "7)") getValueForVar exclude_vm
-      ;;
-    esac
+    touch "$conffile"
+    source "$conffile"
+    local items=() v idx
+    for v in "${vars[@]}"; do
+      items+=("change value $v, currently \"${!v}\"")
+    done
+    idx=$(menuChooseIndex "change settings" "Make your choice" "${items[@]}")
+    case $? in 1) break ;; 2) exit ;; esac
+    getValueForVar "${vars[$idx]}"
   done
 }
 
 function estimate {
-    getVars
-    CMD="/usr/local/bin/backup_du.py \"${include_vm}\" \"${exclude_vm}\""
-    echo "Estimating backup volume, please wait"
-    echo
-    whiptail --title "Estimated Volume for a FULL Backup" --msgbox "$(${CMD})" --scrolltext 15 78
+  getVars
+  echo "Estimating backup volume, please wait"
+  whiptail --title "Estimated Volume for a FULL Backup" \
+    --msgbox "$(/usr/local/bin/backup_du.py "$include_vm" "$exclude_vm")" --scrolltext 15 78
 }
 
-while [ 1 ]
+while true
 do
   CHOICE=$(
   whiptail --title "backup-restore" --cancel-button "exit" --menu "Make your choice" 22 100 14 \
@@ -194,8 +132,7 @@ do
     "4)" "change settings"   \
     "5)" "estimate backup volume"   \
     3>&2 2>&1 1>&3
-  )
-  [[ "$?" = 1 ]] && break
+  ) || break
 
   case $CHOICE in
     "1)") backupFull

--- a/roles/backup_restore/files/scripts/backup_du.py
+++ b/roles/backup_restore/files/scripts/backup_du.py
@@ -6,6 +6,7 @@
 ## Estimating volume Backup
 ## ------------------------------
 from subprocess import check_output
+import re
 import sys
 
 FMT_LIG = "%-20s %10d"
@@ -41,26 +42,38 @@ def pr_table(d):
     print()
     pr_lig(" Estimating En GB",  int((total/1000)+0.5), " GB" )
 
+def image_to_guest(name):
+    """Map an image name (system_<guest> or data_<guest>_<n>) to its guest."""
+    if '@' in name:
+        name = name[0:name.index('@')]
+    if name.startswith("system_"):
+        return name[len("system_"):]
+    if name.startswith("data_"):
+        return name[len("data_"):].rsplit("_", 1)[0]
+    return None
+
 def read_du_rbd(data):
     volume={}
-    cmd = '/usr/bin/rbd du 2>/dev/null | grep system_'
-    if data["include_vm"] and data["include_vm"] != '""':
-        cmd += '| grep -E "(%s)"' % data["include_vm"].replace('"', '')
-    if data["exclude_vm"] and data["exclude_vm"] != '""':
-        cmd += '| grep -v -E "(%s)"' % data["exclude_vm"].replace('"', '')
+    include_vm = data["include_vm"].replace('"', '') or ".*"
+    exclude_vm = data["exclude_vm"].replace('"', '')
+    cmd = '/usr/bin/rbd du 2>/dev/null | grep -E "^(system|data)_"'
 
     out = check_output(cmd, shell=True, text=True, universal_newlines=True)
     for l in out.split('\n'):
         if l:
             name, prov, punit, used, uunit = l.split()
-            name = name.replace("system_","")
-            if '@' in name:
-                name = name[0:name.index('@')]
+            guest = image_to_guest(name)
+            if guest is None:
+                continue
+            if not re.search(include_vm, guest):
+                continue
+            if exclude_vm and re.search(exclude_vm, guest):
+                continue
             t = convert_mo(convert_size(used, uunit))
-            if name in volume:
-                volume[name] += t
+            if guest in volume:
+                volume[guest] += t
             else:
-                volume[name] = t
+                volume[guest] = t
     return volume
 
 

--- a/roles/backup_restore/files/scripts/backup_full.sh
+++ b/roles/backup_restore/files/scripts/backup_full.sh
@@ -2,11 +2,13 @@
 # Copyright (C) 2024 RTE
 # SPDX-License-Identifier: Apache-2.0
 
-local_dir=$1
-remote_shell=$2
-remote_dir=$3
-include_vm=$4
-exclude_vm=$5
+set -u
+
+local_dir=${1:-}
+remote_shell=${2:-}
+remote_dir=${3:-}
+include_vm=${4:-}
+exclude_vm=${5:-}
 
 [ -z "$local_dir" ] && { echo "var local_dir empty"; exit 1; }
 [ -z "$remote_shell" ] && { echo "var remote_shell empty"; exit 2; }
@@ -22,39 +24,39 @@ echo "------------------------------------"
 echo "List of Guests to backup: " $LIST_GUESTS
 echo "------------------------------------"
 echo Removing old full backups local dirs
-echo rm -rf "$local_dir"*, press enter to proceed
-read
-rm -rf "$local_dir"*
+echo "rm -rf ${local_dir}*, press enter to proceed"
+read -r
+rm -rf "${local_dir:?}"*
 
-d=`date +%Y%m%d%H%M`
-f="$local_dir""$d"
-mkdir -p $f
+d=$(date +%Y%m%d%H%M)
+f="$local_dir$d"
+mkdir -p "$f"
 for guest in $LIST_GUESTS
 do
   images="system_$guest $(rbd list | grep -E "^data_${guest}_[0-9]+$")"
   for i in $images
   do
-    echo $i
+    echo "$i"
     echo sparsifying
-    rbd sparsify $i
+    rbd sparsify "$i"
     echo purging snapshots
-    rbd snap purge rbd/$i
+    rbd snap purge "rbd/$i"
     echo creating base snapshot
-    rbd snap create rbd/$i@$d
+    rbd snap create "rbd/$i@$d"
     echo backuping snapshot
-    qemu-img convert -f raw -O qcow2 rbd:rbd/$i@$d $f/$i"_"$d.qcow2
+    qemu-img convert -f raw -O qcow2 "rbd:rbd/$i@$d" "$f/${i}_$d.qcow2"
   done
   i=system_$guest
   echo backuping vm xml
-  rbd image-meta get rbd/$i xml > $f/$i-$d.xml
+  rbd image-meta get "rbd/$i" xml > "$f/$i-$d.xml"
   echo backuping metadata all
-  rbd image-meta list rbd/$i > $f/$i-metaall-$d.txt
+  rbd image-meta list "rbd/$i" > "$f/$i-metaall-$d.txt"
   echo backuping metadata one by one
-  for j in `python3 /usr/local/bin/get_metadata.py $guest`
+  for j in $(python3 /usr/local/bin/get_metadata.py "$guest")
   do
-    echo "   " $j
-    rbd image-meta get rbd/$i $j > $f/$i-meta-$j-$d.txt
+    echo "    $j"
+    rbd image-meta get "rbd/$i" "$j" > "$f/$i-meta-$j-$d.txt"
   done
   echo ----
 done
-rsync -ave "$remote_shell" --progress $f $remote_dir
+rsync -ave "$remote_shell" --progress "$f" "$remote_dir"

--- a/roles/backup_restore/files/scripts/backup_full.sh
+++ b/roles/backup_restore/files/scripts/backup_full.sh
@@ -12,11 +12,14 @@ exclude_vm=$5
 [ -z "$remote_shell" ] && { echo "var remote_shell empty"; exit 2; }
 [ -z "$remote_dir" ] && { echo "var remote_dir empty"; exit 3; }
 
+# Guests are identified by their system disk (system_<guest>). Their
+# additional disks (data_<guest>_<n>) are backed up along with them.
+LIST_GUESTS=$( rbd list | grep -E "^system_" | sed -e "s/^system_//" | grep -E "($include_vm)" | grep -E -v "($exclude_vm)" )
+
 echo "Include VM : $include_vm"
 echo "Exclude VM : $exclude_vm"
 echo "------------------------------------"
-L_VM=$( rbd list | grep -E "($include_vm)"  | grep -E -v "($exclude_vm)" | sed -e "s/system_//g" )
-echo "List of Guests to backup: " $L_VM
+echo "List of Guests to backup: " $LIST_GUESTS
 echo "------------------------------------"
 echo Removing old full backups local dirs
 echo rm -rf "$local_dir"*, press enter to proceed
@@ -26,31 +29,32 @@ rm -rf "$local_dir"*
 d=`date +%Y%m%d%H%M`
 f="$local_dir""$d"
 mkdir -p $f
-#rbd list | while read i
-CMD="rbd list"
-LIST_VM=$( $CMD | grep -E "($include_vm)"  | grep -E -v "($exclude_vm)" )
-for i in $LIST_VM
+for guest in $LIST_GUESTS
 do
-  echo $i
-  echo sparsifying
-  rbd sparsify $i
-  echo purging snapshots
-  rbd snap purge rbd/$i
-  echo creating base snapshot
-  rbd snap create rbd/$i@$d
+  images="system_$guest $(rbd list | grep -E "^data_${guest}_[0-9]+$")"
+  for i in $images
+  do
+    echo $i
+    echo sparsifying
+    rbd sparsify $i
+    echo purging snapshots
+    rbd snap purge rbd/$i
+    echo creating base snapshot
+    rbd snap create rbd/$i@$d
+    echo backuping snapshot
+    qemu-img convert -f raw -O qcow2 rbd:rbd/$i@$d $f/$i"_"$d.qcow2
+  done
+  i=system_$guest
   echo backuping vm xml
   rbd image-meta get rbd/$i xml > $f/$i-$d.xml
   echo backuping metadata all
   rbd image-meta list rbd/$i > $f/$i-metaall-$d.txt
   echo backuping metadata one by one
-  guest=$(echo $i | sed s/^system_//)
   for j in `python3 /usr/local/bin/get_metadata.py $guest`
   do
     echo "   " $j
     rbd image-meta get rbd/$i $j > $f/$i-meta-$j-$d.txt
   done
-  echo backuping snapshot
-  qemu-img convert -f raw -O qcow2 rbd:rbd/$i@$d $f/$i"_"$d.qcow2
   echo ----
 done
 rsync -ave "$remote_shell" --progress $f $remote_dir

--- a/roles/backup_restore/files/scripts/backup_inc.sh
+++ b/roles/backup_restore/files/scripts/backup_inc.sh
@@ -2,18 +2,20 @@
 # Copyright (C) 2024 RTE
 # SPDX-License-Identifier: Apache-2.0
 
-local_dir=$1
-remote_shell=$2
-remote_dir=$3
-include_vm=$4
-exclude_vm=$5
+set -u
+
+local_dir=${1:-}
+remote_shell=${2:-}
+remote_dir=${3:-}
+include_vm=${4:-}
+exclude_vm=${5:-}
 
 [ -z "$local_dir" ] && { echo "var local_dir empty"; exit 1; }
 [ -z "$remote_shell" ] && { echo "var remote_shell empty"; exit 2; }
 [ -z "$remote_dir" ] && { echo "var remote_dir empty"; exit 3; }
 
-d=`date +%Y%m%d%H%M`
-latest_full=`ls -d "$local_dir"* | tail -n 1`
+d=$(date +%Y%m%d%H%M)
+latest_full=$(ls -d "$local_dir"* | tail -n 1)
 [ ! -d "$latest_full" ] && { echo "latest full backup not found"; exit 3; }
 
 # Guests are identified by their system disk (system_<guest>). Their
@@ -26,7 +28,7 @@ echo "------------------------------------"
 echo "List of Guests to backup: " $LIST_GUESTS
 echo "------------------------------------"
 echo "press enter to proceed"
-read
+read -r
 
 not_in_full=""
 for guest in $LIST_GUESTS
@@ -34,28 +36,28 @@ do
   images="system_$guest $(rbd list | grep -E "^data_${guest}_[0-9]+$")"
   for i in $images
   do
-    echo $i
-    latest=`rbd snap list rbd/$i | tail -n 1 | awk '{ print $2 }'`
+    echo "$i"
+    latest=$(rbd snap list "rbd/$i" | tail -n 1 | awk '{ print $2 }')
     if [ -z "$latest" ]; then
       echo "WARNING: rbd/$i has no snapshot: it is not part of the latest full backup and cannot be backed up incrementally"
       not_in_full="$not_in_full $i"
       continue
     fi
     echo creating new snapshot
-    rbd snap create rbd/$i@$d
+    rbd snap create "rbd/$i@$d"
     echo creating diff
-    rbd export-diff --from-snap $latest rbd/$i@$d $latest_full/"$i"_"$latest"_"$d".diff
+    rbd export-diff --from-snap "$latest" "rbd/$i@$d" "$latest_full/${i}_${latest}_${d}.diff"
   done
   i=system_$guest
   echo backuping vm xml
-  rbd image-meta get rbd/$i xml > $latest_full/$i-$d.xml
+  rbd image-meta get "rbd/$i" xml > "$latest_full/$i-$d.xml"
   echo backuping metadata all
-  rbd image-meta list rbd/$i > $latest_full/$i-metaall-$d.txt
+  rbd image-meta list "rbd/$i" > "$latest_full/$i-metaall-$d.txt"
   echo backuping metadata one by one
-  for j in `python3 /usr/local/bin/get_metadata.py $guest`
+  for j in $(python3 /usr/local/bin/get_metadata.py "$guest")
   do
-    echo "   " $j
-    rbd image-meta get rbd/$i $j > $latest_full/$i-meta-$j-$d.txt
+    echo "    $j"
+    rbd image-meta get "rbd/$i" "$j" > "$latest_full/$i-meta-$j-$d.txt"
   done
 done
 if [ -n "$not_in_full" ]; then
@@ -65,4 +67,4 @@ if [ -n "$not_in_full" ]; then
   echo "Run a new full backup to include them."
   echo "------------------------------------"
 fi
-rsync -ave "$remote_shell" --progress $latest_full $remote_dir
+rsync -ave "$remote_shell" --progress "$latest_full" "$remote_dir"

--- a/roles/backup_restore/files/scripts/backup_inc.sh
+++ b/roles/backup_restore/files/scripts/backup_inc.sh
@@ -12,44 +12,57 @@ exclude_vm=$5
 [ -z "$remote_shell" ] && { echo "var remote_shell empty"; exit 2; }
 [ -z "$remote_dir" ] && { echo "var remote_dir empty"; exit 3; }
 
-#local_dir="/data2/backup_ceph_"
-#remote_shell="ssh -p 22"
-#remote_dir="cephbackup@ip:/mnt/nasopf/seapath/backups_ceph_cluster_proj/"
-
 d=`date +%Y%m%d%H%M`
 latest_full=`ls -d "$local_dir"* | tail -n 1`
 [ ! -d "$latest_full" ] && { echo "latest full backup not found"; exit 3; }
 
+# Guests are identified by their system disk (system_<guest>). Their
+# additional disks (data_<guest>_<n>) are backed up along with them.
+LIST_GUESTS=$( rbd list | grep -E "^system_" | sed -e "s/^system_//" | grep -E "($include_vm)" | grep -E -v "($exclude_vm)" )
+
 echo "Include VM : $include_vm"
 echo "Exclude VM : $exclude_vm"
 echo "------------------------------------"
-L_VM=$( rbd list | grep -E "($include_vm)"  | grep -E -v "($exclude_vm)" | sed -e "s/system_//g" )
-echo "List of Guests to backup: " $L_VM
+echo "List of Guests to backup: " $LIST_GUESTS
 echo "------------------------------------"
 echo "press enter to proceed"
 read
 
-#rbd list | while read i
-CMD="rbd list"
-LIST_VM=$( $CMD | grep -E "($include_vm)"  | grep -E -v "($exclude_vm)" )
-for i in $LIST_VM
+not_in_full=""
+for guest in $LIST_GUESTS
 do
-  echo $i
-  latest=`rbd snap list rbd/$i | tail -n 1 | awk '{ print $2 }'`
-  echo creating new snapshot
-  rbd snap create rbd/$i@$d
-  echo creating diff
-  rbd export-diff --from-snap $latest rbd/$i@$d $latest_full/"$i"_"$latest"_"$d".diff
+  images="system_$guest $(rbd list | grep -E "^data_${guest}_[0-9]+$")"
+  for i in $images
+  do
+    echo $i
+    latest=`rbd snap list rbd/$i | tail -n 1 | awk '{ print $2 }'`
+    if [ -z "$latest" ]; then
+      echo "WARNING: rbd/$i has no snapshot: it is not part of the latest full backup and cannot be backed up incrementally"
+      not_in_full="$not_in_full $i"
+      continue
+    fi
+    echo creating new snapshot
+    rbd snap create rbd/$i@$d
+    echo creating diff
+    rbd export-diff --from-snap $latest rbd/$i@$d $latest_full/"$i"_"$latest"_"$d".diff
+  done
+  i=system_$guest
   echo backuping vm xml
   rbd image-meta get rbd/$i xml > $latest_full/$i-$d.xml
   echo backuping metadata all
   rbd image-meta list rbd/$i > $latest_full/$i-metaall-$d.txt
   echo backuping metadata one by one
-  guest=$(echo $i | sed s/^system_//)
   for j in `python3 /usr/local/bin/get_metadata.py $guest`
   do
     echo "   " $j
     rbd image-meta get rbd/$i $j > $latest_full/$i-meta-$j-$d.txt
   done
 done
+if [ -n "$not_in_full" ]; then
+  echo "------------------------------------"
+  echo "WARNING: the following disks are missing from the latest full backup"
+  echo "and were NOT backed up:$not_in_full"
+  echo "Run a new full backup to include them."
+  echo "------------------------------------"
+fi
 rsync -ave "$remote_shell" --progress $latest_full $remote_dir

--- a/roles/backup_restore/files/scripts/edit_metadata.sh
+++ b/roles/backup_restore/files/scripts/edit_metadata.sh
@@ -2,79 +2,64 @@
 # Copyright (C) 2024 RTE
 # SPDX-License-Identifier: Apache-2.0
 
-function addIndexToArray {
-  local -n myarray=$1
-  for idx in `seq 1 ${#myarray[@]}`; do
-    arrVar+=($idx")")
-    arrVar+=("${myarray[$(($idx-1))]}")
+# Display a whiptail menu over the given items and print the (0-based) index
+# of the selected one. Returns 1 if the user chose "back", 2 for "(exit)".
+function menuChooseIndex {
+  local title=$1 prompt=$2
+  shift 2
+  local items=("$@")
+  local args=() idx choice
+  for idx in "${!items[@]}"; do
+    args+=("$((idx + 1)))" "${items[$idx]}")
   done
+  args+=("(exit)" " ")
+  choice=$(whiptail --title "$title" --cancel-button "back" --menu "$prompt" 22 115 14 \
+           "${args[@]}" 3>&2 2>&1 1>&3) || return 1
+  [[ "$choice" == "(exit)" ]] && return 2
+  echo "$((${choice%")"} - 1))"
 }
+
 function editKey {
-  key=$1
-  extension=$2
+  local key=$1 extension=$2
+  local file old_metadata new_metadata
   file=$(mktemp)$extension
-  rbd image-meta get rbd/system_$guest $key >"$file"
+  rbd image-meta get "rbd/system_$guest" "$key" >"$file"
   old_metadata=$(ls -li --full-time "$file")
   "${VISUAL:-"${EDITOR:-vi}"}" "$file"
   new_metadata=$(ls -li --full-time "$file")
   if [ "$new_metadata" = "$old_metadata" ]; then
     echo nothing changed
   else
-    rbd image-meta set rbd/system_$guest $key "`cat $file`"
+    rbd image-meta set "rbd/system_$guest" "$key" "$(cat "$file")"
     if (whiptail --title "disable/enable guest" --yesno "Can we disable and enable this guest to take the change into account?" 8 78); then
-      vm-mgr disable -n $guest
-      vm-mgr enable -n $guest
+      vm-mgr disable -n "$guest"
+      vm-mgr enable -n "$guest"
     fi
   fi
 }
+
 function editGuest {
-  while [ 1 ]
+  while true
   do
-    arrVar0=()
-    arrVar=()
-    for i in `python3 /usr/local/bin/get_metadata.py $guest`
-    do
-      arrVar0+=("$i")
-    done
-    addIndexToArray arrVar0
-    CHOICE=$(
-    whiptail --title "edit metadata vm $guest" --cancel-button "back" --menu "select key to edit:" 22 115 14 \
-          "${arrVar[@]}" \
-          3>&2 2>&1 1>&3
-    )
-    [[ "$?" = 1 ]] && return 1
-    c=`echo $CHOICE | sed "s/)//"`
-    c=$((($c-1)*2+1))
-    key=${arrVar[$c]}
-    if [[ "$key" =~ xml$ ]]; then
-      extension=".xml"
-    fi
-    editKey $key $extension
+    local keys=($(python3 /usr/local/bin/get_metadata.py "$guest"))
+    local idx key extension
+    idx=$(menuChooseIndex "edit metadata vm $guest" "select key to edit:" "${keys[@]}")
+    case $? in 1) return ;; 2) exit ;; esac
+    key=${keys[$idx]}
+    extension=""
+    [[ "$key" =~ xml$ ]] && extension=".xml"
+    editKey "$key" "$extension"
   done
 }
 
-guest=$1
-[ -z $guest ] || { editGuest; exit; }
+guest=${1:-}
+[ -n "$guest" ] && { editGuest; exit; }
 
-while [ 1 ]
+while true
 do
-  arrVar0=()
-  arrVar=()
-  for i in `rbd list | grep -E "^system_" | sed s/^system_//`
-  do
-    arrVar0+=("$i")
-  done
-  addIndexToArray arrVar0
-  CHOICE=$(
-  whiptail --title "edit metadata vm" --cancel-button "exit" --menu "select guest to edit:" 22 115 14 \
-        "${arrVar[@]}" \
-        3>&2 2>&1 1>&3
-  )
-  [[ "$?" = 1 ]] && break
-  c=`echo $CHOICE | sed "s/)//"`
-  c=$((($c-1)*2+1))
-  guest=${arrVar[$c]}
+  guests=($(rbd list | grep -E "^system_" | sed s/^system_//))
+  idx=$(menuChooseIndex "edit metadata vm" "select guest to edit:" "${guests[@]}")
+  case $? in 1) break ;; 2) exit ;; esac
+  guest=${guests[$idx]}
   editGuest
 done
-
-

--- a/roles/backup_restore/files/scripts/edit_vmxml.sh
+++ b/roles/backup_restore/files/scripts/edit_vmxml.sh
@@ -2,18 +2,19 @@
 # Copyright (C) 2024 RTE
 # SPDX-License-Identifier: Apache-2.0
 
-guest=$1
-file=$(mktemp)".xml"
-rbd image-meta get rbd/system_$guest xml >"$file"
+guest=${1:-}
+[ -z "$guest" ] && { echo "usage: $0 <guest>"; exit 1; }
+file=$(mktemp).xml
+rbd image-meta get "rbd/system_$guest" xml >"$file"
 old_metadata=$(ls -li --full-time "$file")
 "${VISUAL:-"${EDITOR:-vi}"}" "$file"
 new_metadata=$(ls -li --full-time "$file")
 if [ "$new_metadata" = "$old_metadata" ]; then
   echo nothing changed
 else
-  rbd image-meta set rbd/system_$guest xml "`cat $file`"
+  rbd image-meta set "rbd/system_$guest" xml "$(cat "$file")"
   if (whiptail --title "disable/enable guest" --yesno "Can we disable and enable this guest to take the change into account?" 8 78); then
-    vm-mgr disable -n $guest
-    vm-mgr enable -n $guest
+    vm-mgr disable -n "$guest"
+    vm-mgr enable -n "$guest"
   fi
 fi

--- a/roles/backup_restore/files/scripts/get_metadata.py
+++ b/roles/backup_restore/files/scripts/get_metadata.py
@@ -1,12 +1,25 @@
 #!/usr/bin/env python3
 # Copyright (C) 2024 RTE
 # SPDX-License-Identifier: Apache-2.0
-import rbd,rados,sys
+"""Print the RBD image metadata keys of a guest's system disk."""
+import sys
+
+import rados
+import rbd
+
+if len(sys.argv) != 2:
+    print(f"usage: {sys.argv[0]} <guest>", file=sys.stderr)
+    sys.exit(1)
+
 cluster = rados.Rados(conffile='/etc/ceph/ceph.conf')
 cluster.connect()
-ioctx = cluster.open_ioctx('rbd')
-image = rbd.Image(ioctx, "system_"+sys.argv[1])
-k = dict(image.metadata_list()).keys()
-for i in k:
-  print(i)
-
+try:
+    ioctx = cluster.open_ioctx('rbd')
+    try:
+        with rbd.Image(ioctx, "system_" + sys.argv[1]) as image:
+            for key, _ in image.metadata_list():
+                print(key)
+    finally:
+        ioctx.close()
+finally:
+    cluster.shutdown()

--- a/roles/backup_restore/files/scripts/restore_vm.sh
+++ b/roles/backup_restore/files/scripts/restore_vm.sh
@@ -16,9 +16,6 @@ incdate=$6
 [ -z "$guest" ] && { echo "var guest empty"; exit 5; }
 [ -z "$incdate" ] && { echo "var incdate empty"; exit 6; }
 
-f="$local_tmp_dir""$d"
-mkdir -p $f
-
 #called with : ./restore_vm.sh /data2/tmp "ssh -p 22" cephbackup@ip:/mnt/nasopf/seapath/backups_ceph_cluster_lot1/ backup_ceph_202203110733 VM1 202203110836
 #local_tmp_dir=/data2/tmp
 #remote_dir=cephbackup@ip:/mnt/nasopf/seapath/backups_ceph_cluster/
@@ -50,21 +47,35 @@ echo creating vm xml with no disk
 echo python3 /usr/local/bin/remove_disk_xml.py $local_tmp_dir/system_"$guest"-"$incdate".xml $local_tmp_dir/system_"$guest"-"$incdate"-nodisk.xml
 python3 /usr/local/bin/remove_disk_xml.py $local_tmp_dir/system_"$guest"-"$incdate".xml $local_tmp_dir/system_"$guest"-"$incdate"-nodisk.xml
 echo
-echo creating base vm
-echo vm-mgr create -n $guest --force --disable --xml $local_tmp_dir/system_"$guest"-"$incdate"-nodisk.xml -i $local_tmp_dir/system_"$guest"_"$fulldate".qcow2
-vm-mgr create -n $guest --force --disable --xml $local_tmp_dir/system_"$guest"-"$incdate"-nodisk.xml -i $local_tmp_dir/system_"$guest"_"$fulldate".qcow2
-echo
-echo creating base snapshot
-echo rbd snap create system_"$guest"@$fulldate
-rbd snap create system_"$guest"@$fulldate
-echo
-for difffile in `ls $local_tmp_dir/*.diff`
+# Additional disks (data_<guest>_<n>) are restored from their full backup
+# qcow2, in index order so vm-mgr recreates them under their original names
+data_images=$(cd $local_tmp_dir && ls data_"$guest"_*_"$fulldate".qcow2 2>/dev/null | sed -e "s/_$fulldate\.qcow2$//" | sort -t_ -k3 -n)
+additional_disk_args=()
+for img in $data_images
 do
-  datediff=`echo $difffile | sed -e s/.*_// -e s/\.diff//`
+  additional_disk_args+=(--additional-disk "$local_tmp_dir/${img}_${fulldate}.qcow2")
+done
+echo creating base vm
+echo vm-mgr create -n $guest --force --disable --xml $local_tmp_dir/system_"$guest"-"$incdate"-nodisk.xml -i $local_tmp_dir/system_"$guest"_"$fulldate".qcow2 "${additional_disk_args[@]}"
+vm-mgr create -n $guest --force --disable --xml $local_tmp_dir/system_"$guest"-"$incdate"-nodisk.xml -i $local_tmp_dir/system_"$guest"_"$fulldate".qcow2 "${additional_disk_args[@]}"
+echo
+echo creating base snapshots
+for img in system_"$guest" $data_images
+do
+  echo rbd snap create "$img"@$fulldate
+  rbd snap create "$img"@$fulldate
+done
+echo
+for difffile in `ls $local_tmp_dir/*.diff 2>/dev/null`
+do
+  diffname=`basename $difffile .diff`
+  # diff files are named <image>_<from date>_<to date>.diff
+  image=`echo $diffname | sed -E "s/_[0-9]{12}_[0-9]{12}$//"`
+  datediff=`echo $diffname | sed -e s/.*_//`
   if [ $datediff -le $incdate ]; then
     echo $difffile
-    echo rbd import-diff $difffile rbd/system_"$guest"
-    rbd import-diff $difffile rbd/system_"$guest"
+    echo rbd import-diff $difffile rbd/$image
+    rbd import-diff $difffile rbd/$image
   fi
 done
 echo

--- a/roles/backup_restore/files/scripts/restore_vm.sh
+++ b/roles/backup_restore/files/scripts/restore_vm.sh
@@ -1,13 +1,18 @@
 #!/bin/bash
 # Copyright (C) 2024 RTE
 # SPDX-License-Identifier: Apache-2.0
+#
+# Usage: restore_vm.sh <local_tmp_dir> <remote_shell> <remote_dir> <full backup dir> <guest> <inc date>
+# e.g.: restore_vm.sh /data2/tmp "ssh -p 22" cephbackup@ip:/backups/ backup_ceph_202203110733 VM1 202203110836
 
-local_tmp_dir=$1
-remote_shell=$2
-remote_dir=$3
-fulldatedir=$4
-guest=$5
-incdate=$6
+set -u
+
+local_tmp_dir=${1:-}
+remote_shell=${2:-}
+remote_dir=${3:-}
+fulldatedir=${4:-}
+guest=${5:-}
+incdate=${6:-}
 
 [ -z "$local_tmp_dir" ] && { echo "var local_tmp_dir empty"; exit 1; }
 [ -z "$remote_shell" ] && { echo "var remote_shell empty"; exit 2; }
@@ -16,79 +21,72 @@ incdate=$6
 [ -z "$guest" ] && { echo "var guest empty"; exit 5; }
 [ -z "$incdate" ] && { echo "var incdate empty"; exit 6; }
 
-#called with : ./restore_vm.sh /data2/tmp "ssh -p 22" cephbackup@ip:/mnt/nasopf/seapath/backups_ceph_cluster_lot1/ backup_ceph_202203110733 VM1 202203110836
-#local_tmp_dir=/data2/tmp
-#remote_dir=cephbackup@ip:/mnt/nasopf/seapath/backups_ceph_cluster/
-#fulldatedir=backup_ceph_202203110733
-#guest=VM2
-#incdate=202203110836
+# Print the command before running it
+function run {
+  echo "$@"
+  "$@"
+}
 
-echo $local_tmp_dir
-echo $remote_shell
-echo $remote_dir
-echo $fulldatedir
-echo $guest
-echo $incdate
+echo "local_tmp_dir : $local_tmp_dir"
+echo "remote_shell  : $remote_shell"
+echo "remote_dir    : $remote_dir"
+echo "fulldatedir   : $fulldatedir"
+echo "guest         : $guest"
+echo "incdate       : $incdate"
 
-fulldate=`echo $fulldatedir | sed -e "s/backup_ceph_//"`
+fulldate=${fulldatedir#backup_ceph_}
 
 echo Removing tmp local dir
-echo rm -rf "$local_tmp_dir"/*, press enter to proceed
-read
-rm -rf "$local_tmp_dir"/*
+echo "rm -rf $local_tmp_dir/*, press enter to proceed"
+read -r
+rm -rf "${local_tmp_dir:?}"/*
 echo
 echo copying files locally
-echo rsync -ave "$remote_shell" --progress $remote_dir$fulldatedir/*_"$guest"-* $local_tmp_dir/
-rsync -ave "$remote_shell" --progress $remote_dir$fulldatedir/*_"$guest"-* $local_tmp_dir/
-echo rsync -ave "$remote_shell" --progress $remote_dir$fulldatedir/*_"$guest"_* $local_tmp_dir/
-rsync -ave "$remote_shell" --progress $remote_dir$fulldatedir/*_"$guest"_* $local_tmp_dir/
+run rsync -ave "$remote_shell" --progress "$remote_dir$fulldatedir/*_${guest}-*" "$local_tmp_dir/"
+run rsync -ave "$remote_shell" --progress "$remote_dir$fulldatedir/*_${guest}_*" "$local_tmp_dir/"
 echo
 echo creating vm xml with no disk
-echo python3 /usr/local/bin/remove_disk_xml.py $local_tmp_dir/system_"$guest"-"$incdate".xml $local_tmp_dir/system_"$guest"-"$incdate"-nodisk.xml
-python3 /usr/local/bin/remove_disk_xml.py $local_tmp_dir/system_"$guest"-"$incdate".xml $local_tmp_dir/system_"$guest"-"$incdate"-nodisk.xml
+run python3 /usr/local/bin/remove_disk_xml.py "$local_tmp_dir/system_$guest-$incdate.xml" "$local_tmp_dir/system_$guest-$incdate-nodisk.xml"
 echo
 # Additional disks (data_<guest>_<n>) are restored from their full backup
 # qcow2, in index order so vm-mgr recreates them under their original names
-data_images=$(cd $local_tmp_dir && ls data_"$guest"_*_"$fulldate".qcow2 2>/dev/null | sed -e "s/_$fulldate\.qcow2$//" | sort -t_ -k3 -n)
+data_images=$(cd "$local_tmp_dir" && ls data_"$guest"_*_"$fulldate".qcow2 2>/dev/null | sed -e "s/_$fulldate\.qcow2$//" | sort -t_ -k3 -n)
 additional_disk_args=()
 for img in $data_images
 do
   additional_disk_args+=(--additional-disk "$local_tmp_dir/${img}_${fulldate}.qcow2")
 done
 echo creating base vm
-echo vm-mgr create -n $guest --force --disable --xml $local_tmp_dir/system_"$guest"-"$incdate"-nodisk.xml -i $local_tmp_dir/system_"$guest"_"$fulldate".qcow2 "${additional_disk_args[@]}"
-vm-mgr create -n $guest --force --disable --xml $local_tmp_dir/system_"$guest"-"$incdate"-nodisk.xml -i $local_tmp_dir/system_"$guest"_"$fulldate".qcow2 "${additional_disk_args[@]}"
+run vm-mgr create -n "$guest" --force --disable --xml "$local_tmp_dir/system_$guest-$incdate-nodisk.xml" \
+    -i "$local_tmp_dir/system_${guest}_${fulldate}.qcow2" "${additional_disk_args[@]}"
 echo
 echo creating base snapshots
 for img in system_"$guest" $data_images
 do
-  echo rbd snap create "$img"@$fulldate
-  rbd snap create "$img"@$fulldate
+  run rbd snap create "$img@$fulldate"
 done
 echo
-for difffile in `ls $local_tmp_dir/*.diff 2>/dev/null`
+for difffile in "$local_tmp_dir"/*.diff
 do
-  diffname=`basename $difffile .diff`
+  [ -e "$difffile" ] || continue
+  diffname=$(basename "$difffile" .diff)
   # diff files are named <image>_<from date>_<to date>.diff
-  image=`echo $diffname | sed -E "s/_[0-9]{12}_[0-9]{12}$//"`
-  datediff=`echo $diffname | sed -e s/.*_//`
-  if [ $datediff -le $incdate ]; then
-    echo $difffile
-    echo rbd import-diff $difffile rbd/$image
-    rbd import-diff $difffile rbd/$image
+  image=$(echo "$diffname" | sed -E "s/_[0-9]{12}_[0-9]{12}$//")
+  datediff=${diffname##*_}
+  if [ "$datediff" -le "$incdate" ]; then
+    run rbd import-diff "$difffile" "rbd/$image"
   fi
 done
 echo
 echo Restoring metadata
-for metafile in $(ls $local_tmp_dir/system_${guest}-meta-*-${incdate}.txt)
+for metafile in "$local_tmp_dir"/system_"$guest"-meta-*-"$incdate".txt
 do
-  key=$(echo $metafile | sed -e s/.*system_${guest}-meta-// -e s/-${incdate}.txt//)
-  echo "metadata name = " $key
-  echo rbd image-meta set system_${guest} $key "$(cat $metafile)"
-  rbd image-meta set system_${guest} $key "$(cat $metafile)"
+  [ -e "$metafile" ] || continue
+  key=$(basename "$metafile" "-${incdate}.txt")
+  key=${key#system_${guest}-meta-}
+  echo "metadata name = $key"
+  run rbd image-meta set "system_$guest" "$key" "$(cat "$metafile")"
 done
 echo
 echo Starting VM
-echo vm-mgr enable -n $guest
-vm-mgr enable -n $guest
-exit
+run vm-mgr enable -n "$guest"


### PR DESCRIPTION
The backup-restore scripts predate VM additional disks (`data_<guest>_<n>`
RBD images) and mishandled them badly:

- the image loop in the backup scripts happened to iterate over data disks,
  producing metadata errors and empty files;
- restore never recreated them: `vm-mgr create` was called without
  `--additional-disk` while the restored xml metadata still referenced the
  missing data images, leaving the VM unable to start;
- worse, the diff import loop applied every rsynced diff to the system
  image, so an incremental restore of a VM with data disks could silently
  corrupt its system disk, since all images share the same snapshot names.

## Changes

**Back up and restore additional disks** (first commit)

- Iterate per guest (identified by its `system_<guest>` image) and back up
  its data disks along with it.
- On restore, pass the data disk qcow2 images to `vm-mgr create
  --additional-disk` in index order, create the base snapshot on every
  image, and import each diff into the image encoded in its file name.
- An additional disk created after the latest full backup has no base to
  diff against: the incremental backup now skips it with a warning instead
  of failing, until a new full backup is made.
- `backup_du.py` now also counts data disks in its per-guest volume
  estimate.
- `include_vm`/`exclude_vm` are now matched against guest names everywhere,
  matching what the configuration examples always suggested.

**Script cleanup** (second commit, no functional change intended)

- Quote all variable expansions, `$()` instead of backticks; the batch
  scripts now run under `set -u` and guard the `rm -rf` of the local
  directories with `${var:?}`.
- Factor the copy-pasted whiptail menu logic into a `menuChooseIndex`
  helper; Esc is now treated like the cancel button instead of falling
  through with an empty choice.
- Drop dead code (`getVarsOld`/`readVar`, cosmetic startup gauge,
  commented-out leftovers, an unused directory created from a never-set
  variable in `restore_vm.sh`).
- Fix `edit_metadata.sh` reusing the `.xml` editor extension for every key
  edited after an xml one.
- Close the rados ioctx and cluster handles in `get_metadata.py` and fail
  with a usage message when the guest argument is missing.
