### PR TITLE
configure_libvirt/physical_machine: fix libvirtd restart

### DIFF
--- a/roles/configure_hypervisor/handlers/main.yml
+++ b/roles/configure_hypervisor/handlers/main.yml
@@ -11,7 +11,7 @@
 - name: Start new slices
   ansible.builtin.systemd:
     name: "{{ item }}.slice"
-    state: restarted
+    state: started
     daemon_reload: true
   with_items:
     - "machine-rt"

--- a/roles/configure_libvirt/templates/libvirtd.conf.j2
+++ b/roles/configure_libvirt/templates/libvirtd.conf.j2
@@ -11,5 +11,6 @@ unix_sock_rw_perms = "0770"
 # Allow members of the libvirt group to access the socket
 unix_sock_group = "libvirt"
 
-# Set a UUID if the dmidecode command is unavailable
-host_uuid = "{{ inventory_hostname | to_uuid }}"
+# Derive the host UUID from /etc/machine-id for a stable identity across
+# libvirtd restarts without depending on dmidecode or inventory-computed values.
+host_uuid_source = "machine-id"

--- a/roles/configure_physical_machine/handlers/main.yml
+++ b/roles/configure_physical_machine/handlers/main.yml
@@ -22,3 +22,8 @@
     state: restarted
     daemon_reload: true
     name: ovs-vswitchd
+
+- name: Restart libvirtd
+  ansible.builtin.systemd:
+    name: libvirtd.service
+    state: restarted

--- a/roles/configure_physical_machine/tasks/libvirt.yml
+++ b/roles/configure_physical_machine/tasks/libvirt.yml
@@ -9,7 +9,4 @@
     regexp: "^#?host_uuid_source ="
     line: "host_uuid_source = \"machine-id\""
     state: present
-- name: Restart libvirtd
-  ansible.builtin.systemd:
-    name: libvirtd.service
-    state: restarted
+  notify: Restart libvirtd


### PR DESCRIPTION
Every playbook run restarted libvirtd on every node, even when nothing changed.

Root cause: two roles fought over /etc/libvirt/libvirtd.conf.

  configure_libvirt rendered its template without host_uuid_source, so it always removed the line that configure_physical_machine had added in the previous run.

  configure_physical_machine detected the missing line on the next run (lineinfile: changed), then restarted libvirtd unconditionally, there was no notify/handler mechanism guarding the restart.

Fix:

  configure_libvirt/templates/libvirtd.conf.j2
    Replace the inventory-computed host_uuid with host_uuid_source = "machine-id".  This is the correct source for a stable Pacemaker cluster identity and is what configure_physical_machine was trying to enforce. Using machine-id also avoids dmidecode failures on hosts where the DMI table is unavailable.

  configure_physical_machine/tasks/libvirt.yml
  configure_physical_machine/handlers/main.yml
    Move the restart to a 'Restart libvirtd' handler notified by the lineinfile task, so libvirtd is only restarted when the line actually changes. After the template fix above, lineinfile will always find the line present and the restart will never fire on stable systems.

  configure_hypervisor/handlers/main.yml
    Change 'Start new slices' handler from state: restarted to
    state: started.  Restarting a systemd slice kills every process in it, including QEMU. A daemon-reload with state: started propagates new AllowedCPUs to the existing cgroup without terminating anything.