### PR TITLE
workflows/ci-debian.yml: pin each matrix job to its own runner label

### DIFF
--- a/.github/workflows/ci-debian.yml
+++ b/.github/workflows/ci-debian.yml
@@ -17,6 +17,7 @@ jobs:
       matrix:
         include:
           - name: Standalone
+            runner-label: runner-RTE-13-standalone
             hyp-inventories: >-
               --inventory inventories_private/standalone13.yml
             vms-inventories: >-
@@ -24,21 +25,19 @@ jobs:
             vms-deployment-playbooks: >-
               playbooks/deploy_vms_standalone.yaml
           - name: Cluster
+            runner-label: runner-RTE-13-cluster
             hyp-inventories: >-
               --inventory inventories_private/cluster13.yml
             vms-inventories: >-
               --inventory inventories_private/vm13cluster.yml
             vms-deployment-playbooks: >-
               playbooks/deploy_vms_cluster.yaml
-    concurrency:
-      group: ci-debian-${{ matrix.name }}
-      cancel-in-progress: false
     uses: ./.github/workflows/_tests.yml
     name: Run tests on ${{ matrix.name }}
     with:
       seapath-flavor: "Debian ${{ matrix.name }}"
       compliance_matrices_folder: debian
-      runner-label: "runner-RTE-13"
+      runner-label: ${{ matrix.runner-label }}
       inventories-repository: "git@github.com:insatomcat/seapath_inventories_ci.git"
       ansible_ssh_keyfile: "inventories_private/ci_rsa"
       skip_cyclictest: true # the inventories don't have the expected skip_cyclictest variables


### PR DESCRIPTION
The concurrency group added to serialize the standalone and cluster jobs on the shared test hardware had an unwanted side effect: GitHub only keeps one pending job per concurrency group, and a newly queued job evicts the one already waiting, which is then reported as cancelled. With cancel-in-progress set to false the running job is protected, but the pending one is not, and this is not configurable.

Three overlapping runs were enough to trigger it. In run 30283299611 the cluster job was queued at 16:14:32 behind a job from an older run, then cancelled at 16:15:07 when another run reached the same group.

The two Debian runners now carry a dedicated label each, so the runner queue itself serializes the jobs per hardware: jobs pile up instead of being cancelled, and a job can no longer land on the machine dedicated to the other topology. The concurrency group is therefore no longer needed.