### PR TITLE
workflows: fail early and keep the debugging material

### DIFF
--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -107,6 +107,7 @@ jobs:
           path: ansible
 
       - name: Prepare Ansible
+        id: prepare
         working-directory: ansible
         run: |
           git clone -q -b ${{ inputs.inventories-repository-branch }} "${{ inputs.inventories-repository }}" inventories_private
@@ -366,13 +367,19 @@ jobs:
 
       - name: Upload raw results # used for debugging
         id: raw-results-artifact
+        # Those results are the only material available to investigate a run
+        # that broke in the middle, so upload them even when an earlier step
+        # failed. They only require the results folder to have been created.
+        if: "${{ !cancelled() && steps.prepare.conclusion == 'success' }}"
         uses: actions/upload-artifact@v7
         with:
           name: raw-results-${{ inputs.seapath-flavor }}
           path: ${{ env.RESULTS_FOLDER }}
           include-hidden-files: true
           retention-days: 1
-          if-no-files-found: error
+          # An early failure can leave the folder empty. Do not report that as
+          # yet another failure on top of the one being investigated.
+          if-no-files-found: warn
 
       - name: Process OpenSCAP analysis results
         working-directory: ansible

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -213,7 +213,11 @@ jobs:
       - name: Deploy SEAPATH VMs
         id: deploy-vms
         working-directory: ansible
-        if: "${{ inputs.vms-inventories != '' }}"
+        # A failing test does not fail its own step, it only raises FAILED.
+        # Check it here so that a red hypervisor stage skips the VM stage
+        # instead of spending another ten minutes on a run already known to
+        # fail. The report is still generated with the hypervisor results.
+        if: "${{ inputs.vms-inventories != '' && env.FAILED != 'true' }}"
         run: |
           echo "::group::VM deployment playbooks"
 
@@ -412,7 +416,11 @@ jobs:
           latency_tests_duration=$(python3 -c "import datetime; print(datetime.timedelta(seconds=${{ env.PCAP_LOOP }}))")
           echo "LATENCY_TESTS_DURATION=$latency_tests_duration" >> "$GITHUB_ENV"
 
-          echo "$INVENTORY_HYP" "$INVENTORY_VMS" | jq --slurp '{hypervisors: .[0], vms: .[1]}' > ${{ env.RESULTS_FOLDER }}/data.json
+          # INVENTORY_VMS is unset when the VM stage did not run. Default it to
+          # an empty object, otherwise the DO_CYCLIC_TESTS query below fails on
+          # "Cannot iterate over null" and silently drops the cyclictest
+          # section from the report.
+          echo "$INVENTORY_HYP" "$INVENTORY_VMS" | jq --slurp '{hypervisors: .[0], vms: (.[1] // {})}' > ${{ env.RESULTS_FOLDER }}/data.json
 
           echo "DO_CYCLIC_TESTS=$(jq \
             'any(.vms[]; .skip_cyclictest == false and .rt == true)


### PR DESCRIPTION
The CI keeps running long after it knows the verdict, and drops the debugging material in the one case where it matters. Starting point: run 30336112801, where `Launch system tests` failed on OracleLinux and the runner went on to `Launch VM tests` anyway.

Two independent changes.

`workflows/_tests.yml: always upload the raw results`

The raw results artifact exists to investigate broken runs, but its step had no condition and inherited the implicit `if: success()`. When a step failed hard, for instance a playbook erroring out in the middle of `Test hypervisors`, the job stopped before the upload and no cukinia XML, no OpenSCAP result and no cyclictest log was kept.

Upload as soon as the results folder exists, unless the run was cancelled. `if-no-files-found` goes from `error` to `warn` because an early failure can leave the folder empty, and that must not stack a second misleading failure on top of the real one.

`workflows/_tests.yml: skip the VM stage when hypervisor tests failed`

A failing cukinia test or an out of bounds latency does not fail its own step, it only sets `FAILED`, which is read at the very end by `Fail if needed`. A hypervisor failure known at minute 10 therefore still deployed and tested the VMs and built the report. On the Debian cluster job of run 30336112801 that is the span between 07:25 and 07:35, about ten minutes of hardware runner time on a settled verdict.

The VM deployment is now gated on `FAILED`. The VM test and latency steps already depend on the deployment outcome, so they follow. The report is still generated with the hypervisor results and the job still turns red at the end.

This commit also fixes an existing bug that the change makes reachable for every flavor. When the VM stage does not run, `INVENTORY_VMS` is unset and `data.json` gets `"vms": null`, so the `DO_CYCLIC_TESTS` query fails on `Cannot iterate over null`. The error is swallowed by the command substitution, the variable ends up empty and the cyclictest section is silently dropped from the report. Yocto Aaeon, which declares no VM inventory, already loses its cyclictest results this way today.
