### PR TITLE
ci-sles-weekly: remove unused inputs

### DIFF
--- a/.github/workflows/ci-sles-weekly.yml
+++ b/.github/workflows/ci-sles-weekly.yml
@@ -19,6 +19,3 @@ permissions:
 jobs:
   call-workflow:
     uses: ./.github/workflows/ci-sles.yml
-    with:
-      pcap_loop: 900 # 15 min
-      weekly: true


### PR DESCRIPTION
These inputs are not needed and trigger an error as there are not existing on the target ci-sles workflow. Remove them.