### PR TITLE
workflows/ci-oraclelinux.yml: use the shared test workflow

### DIFF
--- a/.github/workflows/ci-oraclelinux.yml
+++ b/.github/workflows/ci-oraclelinux.yml
@@ -3,9 +3,6 @@
 
 name: CI OracleLinux
 
-env:
-  WORK_DIR: /tmp/seapath_ci_${{ github.run_id }}_${{ github.run_attempt }}_${{ github.sha }}
-
 on:
   workflow_call:
   workflow_dispatch:
@@ -14,45 +11,45 @@ permissions:
   checks: write
 
 jobs:
-  Integration-tests:
-    runs-on: [self-hosted, runner-RTE-OL9]
-    steps:
-
-      - name: Initialize sources
-        run: mkdir ${{ env.WORK_DIR }}; cd ${{ env.WORK_DIR }};
-             git clone -q --depth 1 --recurse-submodules -b main https://github.com/seapath/ci ci;
-             echo "CI sources downloaded successfully";
-             ci/launch-oraclelinux.sh init;
-
-      - name: Configure OracleLinux
-        id: conf
-        run: cd ${{ env.WORK_DIR }};
-             ci/launch-oraclelinux.sh conf;
-
-      - name: Launch system tests
-        if: ${{ always() && steps.conf.conclusion == 'success' }}
-        run: cd ${{ env.WORK_DIR }};
-             ci/launch-oraclelinux.sh system;
-
-      - name: Launch VM tests
-        if: ${{ always() && steps.conf.conclusion == 'success' }}
-        run: cd ${{ env.WORK_DIR }};
-             ci/launch-oraclelinux.sh vm;
-
-      - name: Generate test report
-        if: ${{ always() && steps.conf.conclusion == 'success' }}
-        run: cd ${{ env.WORK_DIR }};
-             git -C ci/test-report-pdf checkout 0156f2d35ba7d5983f22b6054aa83f92a42f0f2d;
-             ci/launch-oraclelinux.sh report;
-
-      - name: Upload test report
-        if: ${{ always() && steps.conf.conclusion == 'success' }}
-        uses: actions/upload-artifact@v7
-        with:
-            name: seapath-test-report-oraclelinux-cluster
-            path: ${{ env.WORK_DIR }}/seapath-test-report.pdf
-            if-no-files-found: error
-
-      - name: Clean
-        if: always()
-        run: rm -rf $WORK_DIR;
+  call-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Cluster
+            runner-label: runner-RTE-OL9-cluster
+            hyp-inventories: >-
+              --inventory inventories_private/clusterol9.yml
+            vms-inventories: >-
+              --inventory inventories_private/vmol9cluster.yml
+            vms-deployment-playbooks: >-
+              playbooks/deploy_vms_cluster.yaml
+          - name: Standalone
+            runner-label: runner-RTE-OL9-standalone
+            hyp-inventories: >-
+              --inventory inventories_private/standaloneol9.yml
+            vms-inventories: >-
+              --inventory inventories_private/vmol9standalone.yml
+            vms-deployment-playbooks: >-
+              playbooks/deploy_vms_standalone.yaml
+    uses: ./.github/workflows/_tests.yml
+    name: Run tests on ${{ matrix.name }}
+    with:
+      seapath-flavor: "OracleLinux ${{ matrix.name }}"
+      runner-label: ${{ matrix.runner-label }}
+      inventories-repository: "git@github.com:insatomcat/seapath_inventories_ci.git"
+      ansible_ssh_keyfile: "inventories_private/ci_rsa"
+      skip_cyclictest: true # ci_test.yaml does not run cyclictests
+      hyp-inventories: ${{ matrix.hyp-inventories }}
+      hyp-configure-playbooks: >-
+        playbooks/ci_configure.yaml
+      hyp-test-playbooks: >-
+        playbooks/ci_test.yaml
+      vms-inventories: ${{ matrix.vms-inventories }}
+      vms-deploy-playbooks: ${{ matrix.vms-deployment-playbooks }}
+      vms-configure-playbooks: >-
+        playbooks/seapath_setup_prerequisitesdebian.yaml
+        playbooks/seapath_setup_hardening.yaml
+        playbooks/ci_prepare_VMs.yaml
+      vms-test-playbooks: >-
+        playbooks/ci_test.yaml


### PR DESCRIPTION
OracleLinux was the last flavor still driven by `launch-oraclelinux.sh` from the `seapath/ci` repository. It read its configuration at run time from `/etc/seapath-ci.conf` on the runner, so the repository had no idea which machines were being tested, and every improvement made to `_tests.yml` had to be reimplemented by hand in the script or was simply missing. The fail fast fix in #991 is a good example: Debian, SLES and Yocto got it for free, OracleLinux needed its own commit.

This calls `_tests.yml` like the other three flavors do. The playbooks are unchanged, they are the ones the script already ran: `ci_configure.yaml` to configure, `ci_test.yaml` to test, and for the VMs `seapath_setup_prerequisitesdebian`, `seapath_setup_hardening` and `ci_prepare_VMs` before `ci_test.yaml` again.

## Why a matrix

The script tested the cluster and the standalone in a single job by loading both inventories at once. That cannot be expressed with `_tests.yml`, which takes a single `vms-inventories` and a single `vms-deploy-playbooks`. Both deployment playbooks iterate over the whole `VMs` group, so a merged VM inventory would try to deploy the standalone VMs on the cluster.

Hence one job per machine set, each pinned to its own runner label, `runner-RTE-OL9-cluster` and `runner-RTE-OL9-standalone`. This matches what `ci-debian.yml` does and what #990 refines for it.

## What changes for the results

Beside no longer maintaining the same logic twice, OracleLinux gains what the shared workflow already provides: the raw results artifact, the OpenSCAP integration, the compliance matrices, and the cyclictest and latency test support. `skip_cyclictest` is set for now because `ci_test.yaml` does not run cyclictests.

The report is now split in two PDFs, one per machine set, in place of the single OracleLinux report.

## Notes

`launch-oraclelinux.sh` becomes unused once this lands and can be removed from `seapath/ci`. That is a separate repository, so it is not part of this PR.

This overlaps with #991, which also touches `ci-oraclelinux.yml` to make the old steps fail fast. Whichever lands second will need a trivial resolution: if #991 goes first, its change to this file is superseded here, since the file no longer has any step of its own.
