### PR TITLE
ansible-requirements: fetch config_template from the GitHub mirror

### DIFF
--- a/ansible-requirements.yaml
+++ b/ansible-requirements.yaml
@@ -12,6 +12,9 @@ collections:
   - name: "ansible.posix"
   - name: "ansible.utils"
   - name: openstack.config_template
-    source: https://opendev.org/openstack/ansible-config_template
+    # GitHub mirror of https://opendev.org/openstack/ansible-config_template.
+    # Both serve the same commits, but opendev suffers from regular outages
+    # that break the CI, while GitHub is already a hard requirement here.
+    source: https://github.com/openstack/ansible-config_template
     type: git
     version: 2.1.1


### PR DESCRIPTION
Cloning `openstack.config_template` from opendev.org fails intermittently on the CI runners: the server answers with an HTML page instead of the git protocol, so `prepare.sh` dies before any test runs.

```
fatal: .../info/refs not valid: could not determine hash algorithm; is this a git repository?
ERROR! Failed to clone a Git repository from `https://opendev.org/openstack/ansible-config_template`
```

It broke every `ci-sles` and `ci-yocto` job for several hours today (#986), then cleared up on its own. The cause is unknown, so waiting it out is always an option, but it costs a CI cycle each time and nothing says when it comes back.

Switch to the official GitHub mirror: tag 2.1.1 resolves to the same commit (`931f6aa3`) on both remotes, so the installed code is unchanged. The collection is not published on Ansible Galaxy, so a git source remains the only option, and GitHub is already a hard requirement for the CI.