### PR TITLE
test: cover the repository's Python and enforce it in CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,40 @@
+# Copyright (C) 2026, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+#
+# Coverage scope for the Python shipped by this repository.
+# Everything listed under "source" is reported even when no test imports it,
+# so a new untested script shows up as 0% instead of silently disappearing.
+
+[run]
+branch = True
+source =
+    .github/test-report
+    plugins/modules
+    roles
+    scripts
+
+omit =
+    # Git submodules: separate upstream projects, tested in their own repos.
+    roles/deploy_cukinia/files/cukinia/*
+    roles/deploy_python3_setup_ovs/files/python3-setup-ovs/*
+    roles/deploy_vm_manager/files/vm_manager/*
+    # ctypes syscall probes run by cukinia. They are test material rather
+    # than code the project ships, and each one only exists to fail on the
+    # kernel it is pointed at.
+    roles/deploy_cukinia_tests/cukinia-tests/includes/*
+    # Three-line WSGI entrypoint whose body is an import of the vm_manager
+    # Flask app; there is nothing to assert that the submodule does not
+    # already cover.
+    roles/vmmgrapi/files/wsgi.py
+
+[report]
+# None of the directories above are importable packages: the scripts are
+# deployed as plain files. Without this, coverage prunes every subdirectory
+# that has no __init__.py, and an untested script silently vanishes from the
+# report instead of showing up at 0%.
+include_namespace_packages = True
+exclude_lines =
+    pragma: no cover
+    if __name__ == .__main__.:
+show_missing = True
+precision = 1

--- a/.github/workflows/ci-unit.yml
+++ b/.github/workflows/ci-unit.yml
@@ -1,0 +1,47 @@
+# Copyright (C) 2026, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+name: Unit
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    name: Python Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      # No submodules: they are upstream projects tested in their own repos,
+      # and .coveragerc omits them from the report.
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install tox
+        run: pip install tox
+
+      - name: Run unit tests with coverage
+        run: tox -e unit
+
+      - name: Publish coverage summary
+        if: always()
+        run: |
+          pip install coverage
+          {
+            echo "## Python coverage"
+            echo
+            coverage report --format=markdown
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload coverage reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-python
+          path: |
+            coverage.xml
+            htmlcov/
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,12 @@ jobs:
   ci-qa:
     uses: ./.github/workflows/ci-qa.yml
 
-  ci-molecule:
+  ci-unit:
     needs: ci-qa
+    uses: ./.github/workflows/ci-unit.yml
+
+  ci-molecule:
+    needs: ci-unit
     uses: ./.github/workflows/ci-molecule.yml
 
   ci-debian:

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,14 @@ inventories/*
 __pycache__/
 .pyc
 
+# Python test and coverage artefacts
+.pytest_cache/
+.tox/
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/
+
 # Module documentation
 module_documentation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,10 @@
 
 ## Testing
 
+- **Python unit tests**: `tox -e unit` runs the `tests/` suite with statement and
+  branch coverage. Fails below the `COV_FAIL_UNDER` ratchet in `tox.ini` (99%);
+  raise it when coverage improves, never lower it. Writes `coverage.xml` and
+  `htmlcov/` at the repo root. Scope and exclusions live in `.coveragerc`.
 - **Run all molecule tests**: `tox -m molecule`
 - **Role tests only**: `tox -ie molecule-roles`  (runs `scripts/run-molecule-roles.sh`)
 - **Playbook tests only**: `tox -e molecule-playbooks`  (runs from `playbooks/` dir)
@@ -31,7 +35,7 @@
 ## CI Pipeline (PRs to `main`)
 
 ```
-qa (ansible-lint) → molecule → debian / yocto / centos / oraclelinux integration
+qa (ansible-lint) → unit (pytest + coverage) → molecule → debian / yocto / centos / oraclelinux integration
 ```
 
 Integration tests run on self-hosted runners and use the external `seapath/ci` repo.

--- a/roles/backup_restore/files/scripts/get_metadata.py
+++ b/roles/backup_restore/files/scripts/get_metadata.py
@@ -7,19 +7,29 @@ import sys
 import rados
 import rbd
 
-if len(sys.argv) != 2:
-    print(f"usage: {sys.argv[0]} <guest>", file=sys.stderr)
-    sys.exit(1)
 
-cluster = rados.Rados(conffile='/etc/ceph/ceph.conf')
-cluster.connect()
-try:
-    ioctx = cluster.open_ioctx('rbd')
+def print_metadata_keys(guest):
+    cluster = rados.Rados(conffile='/etc/ceph/ceph.conf')
+    cluster.connect()
     try:
-        with rbd.Image(ioctx, "system_" + sys.argv[1]) as image:
-            for key, _ in image.metadata_list():
-                print(key)
+        ioctx = cluster.open_ioctx('rbd')
+        try:
+            with rbd.Image(ioctx, "system_" + guest) as image:
+                for key, _ in image.metadata_list():
+                    print(key)
+        finally:
+            ioctx.close()
     finally:
-        ioctx.close()
-finally:
-    cluster.shutdown()
+        cluster.shutdown()
+
+
+def main(argv=None):
+    argv = sys.argv if argv is None else argv
+    if len(argv) != 2:
+        print(f"usage: {argv[0]} <guest>", file=sys.stderr)
+        sys.exit(1)
+    print_metadata_keys(argv[1])
+
+
+if __name__ == "__main__":
+    main()

--- a/roles/backup_restore/files/scripts/remove_disk_xml.py
+++ b/roles/backup_restore/files/scripts/remove_disk_xml.py
@@ -4,12 +4,21 @@
 import sys
 import lxml.etree as le
 
-s = sys.argv[1]
-d = sys.argv[2]
 
-with open(s,'r') as f:
-    doc=le.parse(f)
-    for elem in doc.xpath("//disk"):
-        parent=elem.getparent()
-        parent.remove(elem)
-    doc.write(d, pretty_print = True)
+def remove_disks(src, dst):
+    """Copy the libvirt domain XML at src to dst without its <disk> elements."""
+    with open(src, 'r') as f:
+        doc = le.parse(f)
+        for elem in doc.xpath("//disk"):
+            parent = elem.getparent()
+            parent.remove(elem)
+        doc.write(dst, pretty_print=True)
+
+
+def main(argv=None):
+    argv = sys.argv[1:] if argv is None else argv
+    remove_disks(argv[0], argv[1])
+
+
+if __name__ == "__main__":
+    main()

--- a/roles/cyclictest/files/run_cyclictest.py
+++ b/roles/cyclictest/files/run_cyclictest.py
@@ -1,27 +1,40 @@
 #!/usr/bin/env python3
 
 import subprocess
-import sys
 import argparse
 
-parser = argparse.ArgumentParser(description="Run cyclictest command.")
-parser.add_argument('output_file', type=str, help='File to output the result.')
-parser.add_argument('-d', '--duration', type=int, help='Test duration in seconds.', default=20)
-parser.add_argument('-p', '--priority', type=int, help='Priority of the threads.', default=90)
-parser.add_argument('-a', '--affinity', type=str, help='CPU affinity', nargs='?', const="", default="smp")
-args = parser.parse_args()
+INTERVAL = 200  # In microseconds
 
-interval = 200  # In microseconds
-cycles = (args.duration * 10**6) // interval
-cpu_arg = "-S"
-if args.affinity != "smp":
-    cpu_arg = f"-a {args.affinity} -t"
 
-cyclic_test_cmd = f"cyclictest -l{cycles} -m {cpu_arg} -p{args.priority} -i{interval} -h400 -q"
-print(f"Will run command: {cyclic_test_cmd}")
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description="Run cyclictest command.")
+    parser.add_argument('output_file', type=str, help='File to output the result.')
+    parser.add_argument('-d', '--duration', type=int, help='Test duration in seconds.', default=20)
+    parser.add_argument('-p', '--priority', type=int, help='Priority of the threads.', default=90)
+    parser.add_argument('-a', '--affinity', type=str, help='CPU affinity', nargs='?', const="", default="smp")
+    return parser.parse_args(argv)
 
-result = subprocess.run(cyclic_test_cmd.split(), capture_output=True, text=True)
 
-with open(args.output_file, 'w') as f:
-    f.write(cyclic_test_cmd)
-    f.write(result.stdout)
+def build_command(args):
+    cycles = (args.duration * 10**6) // INTERVAL
+    cpu_arg = "-S"
+    if args.affinity != "smp":
+        cpu_arg = f"-a {args.affinity} -t"
+
+    return f"cyclictest -l{cycles} -m {cpu_arg} -p{args.priority} -i{INTERVAL} -h400 -q"
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    cyclic_test_cmd = build_command(args)
+    print(f"Will run command: {cyclic_test_cmd}")
+
+    result = subprocess.run(cyclic_test_cmd.split(), capture_output=True, text=True)
+
+    with open(args.output_file, 'w') as f:
+        f.write(cyclic_test_cmd)
+        f.write(result.stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/roles/ptp_status_vsock/files/ptp_vsock.py
+++ b/roles/ptp_status_vsock/files/ptp_vsock.py
@@ -6,17 +6,17 @@ import socket,sys
 from time import sleep
 from _thread import start_new_thread
 
-CID = socket.VMADDR_CID_HOST
-PORT = int(sys.argv[1])
+STATUS_FILE = "/var/run/ptpstatus/ptp_state"
+DETAILS_FILE = "/var/run/ptpstatus/ptp_status"
 
 def client_handler(connection):
     data = connection.recv(2048)
     message = data.decode('utf-8')
     filename = ""
     if message == 'STATUS':
-        filename = "/var/run/ptpstatus/ptp_state"
+        filename = STATUS_FILE
     if message == 'DETAILS':
-        filename = "/var/run/ptpstatus/ptp_status"
+        filename = DETAILS_FILE
 
     ptp_data = "0"
     try:
@@ -47,4 +47,9 @@ def start_server(host, port):
         while True:
             accept_connections(s)
 
-start_server(CID, PORT)
+def main(argv=None):
+    argv = sys.argv[1:] if argv is None else argv
+    start_server(socket.VMADDR_CID_HOST, int(argv[0]))
+
+if __name__ == "__main__":
+    main()

--- a/roles/snmp/files/snmp_getdata.py
+++ b/roles/snmp/files/snmp_getdata.py
@@ -342,6 +342,9 @@ done
             command = f""" /usr/sbin/crm status --as-xml """
             title = "crm status json"
             xml_status = run_command(command)
+            # Reported as-is by the generic write below if the parsing fails,
+            # rather than whatever the previous iteration left in `data`.
+            data = xml_status
             try:
                 dict_status = xmltodict.parse(xml_status, attr_prefix='')
                 data = json.dumps(dict_status)

--- a/roles/snmp/files/snmp_getdata.py
+++ b/roles/snmp/files/snmp_getdata.py
@@ -360,7 +360,9 @@ def write_disk_replacement_status(status):
     if 1 in status.replacedisk:
         status.globalreplacedisk = "Problem on one disk"
     for i in range(1,5):
-        singlelinetooid(base_oid + ".5." + str(i), "replace disk " + str(i), status.replacedisk[i-1])
+        # The SMART and array-device checks flag a disk with the integer 1,
+        # while the RAID check stores a message, so the value is coerced here.
+        singlelinetooid(base_oid + ".5." + str(i), "replace disk " + str(i), str(status.replacedisk[i-1]))
     singlelinetooid(base_oid + ".5.5", "replace disk global",status.globalreplacedisk)
 
 def main():

--- a/roles/snmp/files/snmp_getdata.py
+++ b/roles/snmp/files/snmp_getdata.py
@@ -6,6 +6,32 @@ import subprocess,json,os,stat
 import xmltodict
 from xml.parsers.expat import ParserCreate, ExpatError, errors
 
+base_oid = ""
+snmpdata_tmp = "/tmp/snmpdata_tmp.txt"
+snmpdata = "/tmp/snmpdata.txt"
+
+# Output stream. main() opens it on snmpdata_tmp; the *tooid helpers below
+# write through it.
+f = None
+
+grep = "/usr/bin/grep"
+sort = "/usr/bin/sort"
+awk = "/usr/bin/awk"
+sed = "/usr/bin/sed"
+tr = "/usr/bin/tr"
+head = "/usr/bin/head"
+echo = "/usr/bin/echo"
+jq = "/usr/bin/jq"
+cut = "/usr/bin/cut"
+ipmitool = "/usr/bin/ipmitool"
+arcconf = "/usr/local/sbin/arcconf"
+
+# .1 --> "other" multiline values
+# .2 --> "other" monoline values
+# .3 --> raid/arcconf values
+# .4 --> ipmitool values
+# .5 --> global "disk need to be replaced" values
+
 def run_command(command):
     result = subprocess.check_output(command, shell=True, executable='/bin/bash').decode()
     return (result)
@@ -36,35 +62,6 @@ def dictarrayoid(oid,title,a):
         for k in range(0,len(d)):
             writeline(oid + "." + str(a.index(d)) + "." + str(k), d[keys[k]])
 
-base_oid = ""
-snmpdata_tmp = "/tmp/snmpdata_tmp.txt"
-snmpdata = "/tmp/snmpdata.txt"
-f = open(snmpdata_tmp, "w")
-
-grep = "/usr/bin/grep"
-sort = "/usr/bin/sort"
-awk = "/usr/bin/awk"
-sed = "/usr/bin/sed"
-tr = "/usr/bin/tr"
-head = "/usr/bin/head"
-echo = "/usr/bin/echo"
-jq = "/usr/bin/jq"
-cut = "/usr/bin/cut"
-
-# .1 --> "other" multiline values
-# .2 --> "other" monoline values
-# .3 --> raid/arcconf values
-# .4 --> ipmitool values
-# .5 --> global "disk need to be replaced" values
-
-# Disk needs to be replaced logic
-# We assume the server may have up to 4 disks, and while running this script we will keep in mind if any check is a hint the disk needs to be replaces (with the RAID tests, then the SMART tests and then the LVM tests).
-# We start with a "no pb" status and toggle to "not ok" if needed
-globalreplacedisk = "OK" # we store a global status, including a problem detected on LVM for example
-replacedisk = ["OK","OK","OK","OK"] # we store a status per disk
-
-#IPMITOOL
-ipmitool = "/usr/bin/ipmitool"
 def exist_and_is_character(filepath):
     try:
         r = stat.S_ISCHR(os.lstat(filepath)[stat.ST_MODE])
@@ -72,7 +69,24 @@ def exist_and_is_character(filepath):
         return False
     return r
 
-if exist_and_is_character("/dev/ipmi0") or exist_and_is_character("/dev/ipmi/0") or exist_and_is_character("/dev/ipmidev/0"):
+
+# Disk needs to be replaced logic
+# We assume the server may have up to 4 disks, and while running this script we will keep in mind if any check is a hint the disk needs to be replaces (with the RAID tests, then the SMART tests and then the LVM tests).
+# We start with a "no pb" status and toggle to "not ok" if needed
+class DiskStatus:
+    def __init__(self):
+        # we store a global status, including a problem detected on LVM for example
+        self.globalreplacedisk = "OK"
+        # we store a status per disk
+        self.replacedisk = ["OK","OK","OK","OK"]
+
+
+#IPMITOOL
+def collect_ipmi():
+    if not (exist_and_is_character("/dev/ipmi0")
+            or exist_and_is_character("/dev/ipmi/0")
+            or exist_and_is_character("/dev/ipmidev/0")):
+        return
     for i in range(1,5):
         if i == 1:
             command = f""" {ipmitool} sensor | {sed} -e "s/ *| */;/g" """
@@ -93,8 +107,9 @@ if exist_and_is_character("/dev/ipmi0") or exist_and_is_character("/dev/ipmi/0")
         multilinetooid(base_oid + ".4." + str(i), title, data)
 
 # RAID
-arcconf = "/usr/local/sbin/arcconf"
-if os.path.isfile(arcconf):
+def collect_raid(status):
+    if not os.path.isfile(arcconf):
+        return
     # get temperatures
     command = f""" {arcconf} GETCONFIG 1 PD | {grep} "Current Temperature" | {awk} '{{ print $4 }}' """
     data = run_command(command)
@@ -112,8 +127,8 @@ if os.path.isfile(arcconf):
         line = line.lstrip().rstrip()
         singlelinetooid(base_oid + ".3.2."+str(linenumber), "SMART Warnings disk " + str(linenumber), line)
         if line != "0":
-            replacedisk[linenumber-1] = "RAID SMART Warnings on disk"+str(linenumber)
-            globalreplacedisk = "RAID SMART Warnings on one disk"
+            status.replacedisk[linenumber-1] = "RAID SMART Warnings on disk"+str(linenumber)
+            status.globalreplacedisk = "RAID SMART Warnings on one disk"
 
     command = f""" {arcconf} GETCONFIG 1  | {grep} "S.M.A.R.T. warnings" | {awk} '{{sum += $4}} END {{print sum}}' """
     title = "ARCCONF sum of SMART WARNINGS"
@@ -121,7 +136,7 @@ if os.path.isfile(arcconf):
     data = data.lstrip().rstrip()
     singlelinetooid(base_oid + ".3.3", title, data)
     if data != "0" and data != "":
-        globalreplacedisk = "RAID SMART Warnings on one disk"
+        status.globalreplacedisk = "RAID SMART Warnings on one disk"
 
     command = f""" {arcconf} GETCONFIG 1 AR | {grep} -E "Device [0-9]" | {cut} -d":" -f2 | {awk} '{{ print $1 }}' """
     data = run_command(command)
@@ -132,7 +147,7 @@ if os.path.isfile(arcconf):
         line = line.lstrip().rstrip()
         singlelinetooid(base_oid + ".3.4."+str(linenumber), title, line)
         if line != "Present":
-            replacedisk[linenumber-1] = 1
+            status.replacedisk[linenumber-1] = 1
 
     for i in range(0,4):
         command = f""" {arcconf} GETCONFIG 1 PD 0 {i} | {grep} "S.M.A.R.T. warnings" | {awk} '{{ print $4 }}' """
@@ -140,7 +155,7 @@ if os.path.isfile(arcconf):
         data = run_command(command)
         data = data.lstrip().rstrip()
         if data != "0" and data!="":
-            replacedisk[i] = 1
+            status.replacedisk[i] = 1
         singlelinetooid(base_oid + ".3.5."+str(i+1)+".1", title, data)
 
 
@@ -153,66 +168,70 @@ if os.path.isfile(arcconf):
 
 # >.2.6 --> other monolines
 
-i = 0
-for disk in ["sda","sdb","sdc","sdd"]:
-    command = f""" /usr/sbin/smartctl -H /dev/{disk} | {grep} "SMART overall-health self-assessment test result: " | {sed} "s/SMART overall-health self-assessment test result: //" """
-    title = f"""smartctl /dev/{disk}"""
-    data = run_command(command)
-    data = data.lstrip().rstrip()
-    if data != "PASSED" and data != "":
-        replacedisk[i] = 1
-    i = i + 1
-    singlelinetooid(base_oid + ".2." + str(i), title, data)
-
-command = f""" /usr/sbin/lvs -a -o +devices,lv_health_status --reportformat json | {jq} -c .report[].lv """
-title = "lvs full status json"
-data = run_command(command)
-data = json.loads(data)
-dictarrayoid(base_oid + ".2.5", title, data)
-
-for i in range(6,11):
-    if i == 6:
-        command = f"""
-/usr/sbin/smartctl --scan | {grep} -E "^/dev/(sd|nvme)" | {awk} '{{ print $1 }}' | while read i; do /usr/sbin/smartctl -H $i | {grep} "SMART overall-health self-assessment test result: " | {grep} -v "SMART overall-health self-assessment test result: PASSED"; done | /usr/bin/wc -l """
-        title = "disk smartctl status"
+def collect_smart_health(status):
+    i = 0
+    for disk in ["sda","sdb","sdc","sdd"]:
+        command = f""" /usr/sbin/smartctl -H /dev/{disk} | {grep} "SMART overall-health self-assessment test result: " | {sed} "s/SMART overall-health self-assessment test result: //" """
+        title = f"""smartctl /dev/{disk}"""
         data = run_command(command)
         data = data.lstrip().rstrip()
-        if data == "0":
-            data = "SMARTOK"
-        else:
-            data = "SMARTPROBLEM"
-            globalreplacedisk = "SMART tests not passed"
-    elif i == 7:
-        command = f""" /usr/sbin/lvs -a -o +devices,lv_health_status --reportformat json | {jq} -c . """
-        title = "lvs full status json"
-        data = run_command(command)
-    elif i == 8:
-        command = f""" /usr/sbin/lvs -o name,lv_health_status --reportformat json | {jq} -c . """
-        title = "lvs basic status json"
-        data = run_command(command)
-    elif i == 9:
-        command = f""" /usr/sbin/lvs -o name,lv_health_status --reportformat json | {jq} -c '.report[].lv[] | select( .lv_health_status != "" )' """
-        title = "lvs sumup status"
-        data = run_command(command)
-        if data == "":
-            data = "NO LVS PROBLEM"
-        else:
-            data = "LVS PROBLEM: " + data
-            globalreplacedisk = "LVS health not OK"
-    elif i == 10:
-        command = f""" ceph status --format json-pretty | {jq} -c -r .health.status """
-        title = "ceph health status"
-        data = run_command(command)
-    singlelinetooid(base_oid + ".2." + str(i), title, data)
+        if data != "PASSED" and data != "":
+            status.replacedisk[i] = 1
+        i = i + 1
+        singlelinetooid(base_oid + ".2." + str(i), title, data)
+
+def collect_lvs():
+    command = f""" /usr/sbin/lvs -a -o +devices,lv_health_status --reportformat json | {jq} -c .report[].lv """
+    title = "lvs full status json"
+    data = run_command(command)
+    data = json.loads(data)
+    dictarrayoid(base_oid + ".2.5", title, data)
+
+def collect_monolines(status):
+    for i in range(6,11):
+        if i == 6:
+            command = f"""
+/usr/sbin/smartctl --scan | {grep} -E "^/dev/(sd|nvme)" | {awk} '{{ print $1 }}' | while read i; do /usr/sbin/smartctl -H $i | {grep} "SMART overall-health self-assessment test result: " | {grep} -v "SMART overall-health self-assessment test result: PASSED"; done | /usr/bin/wc -l """
+            title = "disk smartctl status"
+            data = run_command(command)
+            data = data.lstrip().rstrip()
+            if data == "0":
+                data = "SMARTOK"
+            else:
+                data = "SMARTPROBLEM"
+                status.globalreplacedisk = "SMART tests not passed"
+        elif i == 7:
+            command = f""" /usr/sbin/lvs -a -o +devices,lv_health_status --reportformat json | {jq} -c . """
+            title = "lvs full status json"
+            data = run_command(command)
+        elif i == 8:
+            command = f""" /usr/sbin/lvs -o name,lv_health_status --reportformat json | {jq} -c . """
+            title = "lvs basic status json"
+            data = run_command(command)
+        elif i == 9:
+            command = f""" /usr/sbin/lvs -o name,lv_health_status --reportformat json | {jq} -c '.report[].lv[] | select( .lv_health_status != "" )' """
+            title = "lvs sumup status"
+            data = run_command(command)
+            if data == "":
+                data = "NO LVS PROBLEM"
+            else:
+                data = "LVS PROBLEM: " + data
+                status.globalreplacedisk = "LVS health not OK"
+        elif i == 10:
+            command = f""" ceph status --format json-pretty | {jq} -c -r .health.status """
+            title = "ceph health status"
+            data = run_command(command)
+        singlelinetooid(base_oid + ".2." + str(i), title, data)
 
 # OTHER MULTILINES VALUES
-for i in range(1,12):
-    if i == 1:
-        command = f""" /usr/sbin/crm status"""
-        title = command
-        data = run_command(command)
-    elif i == 2:
-        command = f"""
+def collect_multilines():
+    for i in range(1,12):
+        if i == 1:
+            command = f""" /usr/sbin/crm status"""
+            title = command
+            data = run_command(command)
+        elif i == 2:
+            command = f"""
 FILE=/tmp/domstats.txt
 if [ -f $FILE ]
 then
@@ -230,10 +249,10 @@ else
 fi
 cat $FILE
 """
-        title = "virsh domstats"
-        data = run_command(command)
-    elif i == 3:
-        command = f"""
+            title = "virsh domstats"
+            data = run_command(command)
+        elif i == 3:
+            command = f"""
 FILE=/tmp/dommemstat.txt
 function create_or_rewrite {{
   /usr/bin/virsh --connect qemu:///system list --name | sed -s "/^$/d" | while read i
@@ -257,14 +276,14 @@ else
 fi
 cat $FILE
 """
-        title = "virsh dommemstat"
-        data = run_command(command)
-    elif i == 4:
-        command = f""" /usr/bin/ceph status """
-        title = "ceph status"
-        data = run_command(command)
-    elif i == 5:
-        command = f"""
+            title = "virsh dommemstat"
+            data = run_command(command)
+        elif i == 4:
+            command = f""" /usr/bin/ceph status """
+            title = "ceph status"
+            data = run_command(command)
+        elif i == 5:
+            command = f"""
 FILE=/tmp/virt-df.txt
 if [ -f $FILE ]
 then
@@ -280,18 +299,18 @@ else
 fi
 cat $FILE
 """
-        title = "virt-df"
-        data = run_command(command)
-    elif i == 6:
-        command = f""" /usr/bin/virsh -c qemu:///system list --all """
-        title = "virsh list"
-        data = run_command(command)
-    elif i == 7:
-        command = f""" /usr/bin/ceph status --format=json | {jq} -c .pgmap """
-        title = "ceph usage"
-        data = run_command(command)
-    elif i == 8:
-        command = f"""
+            title = "virt-df"
+            data = run_command(command)
+        elif i == 6:
+            command = f""" /usr/bin/virsh -c qemu:///system list --all """
+            title = "virsh list"
+            data = run_command(command)
+        elif i == 7:
+            command = f""" /usr/bin/ceph status --format=json | {jq} -c .pgmap """
+            title = "ceph usage"
+            data = run_command(command)
+        elif i == 8:
+            command = f"""
 /usr/sbin/smartctl --scan | {awk} '{{ print $1 }}' | while read i; do
   temp=$(/usr/sbin/smartctl -a $i | {grep} Temperature_Celsius | {awk} '{{ print $10 }}')
   if [ ! -z "$temp" ]
@@ -300,10 +319,10 @@ cat $FILE
   fi
 done
 """
-        title = "temperature disks"
-        data = run_command(command)
-    elif i == 9:
-        command = f"""
+            title = "temperature disks"
+            data = run_command(command)
+        elif i == 9:
+            command = f"""
 /usr/sbin/smartctl --scan | {grep} -E "^/dev/(sd|nvme)" | {awk} '{{ print $1 }}' | while read i; do
   {echo} $i
   j=$({echo} $i | {sed} "s|/dev/||")
@@ -313,36 +332,53 @@ done
   {echo} ------------------------------------------
 done
 """
-        title = "smartctl"
-        data = run_command(command)
-    elif i == 10:
-        command = f""" /usr/sbin/lvs -a -o +devices,lv_health_status """
-        title = "lvs status"
-        data = run_command(command)
-    elif i == 11:
-        command = f""" /usr/sbin/crm status --as-xml """
-        title = "crm status json"
-        xml_status = run_command(command)
-        try:
-            dict_status = xmltodict.parse(xml_status, attr_prefix='')
-            data = json.dumps(dict_status)
-            data1 = json.dumps(dict_status["crm_mon"]["summary"])
-            multilinetooid(base_oid + ".1.11.0.1", title + " summary", data1)
-            data2 = json.dumps(dict_status["crm_mon"]["nodes"])
-            multilinetooid(base_oid + ".1.11.0.2", title + " nodes", data2)
-            continue
-        except ExpatError:
-            pass
+            title = "smartctl"
+            data = run_command(command)
+        elif i == 10:
+            command = f""" /usr/sbin/lvs -a -o +devices,lv_health_status """
+            title = "lvs status"
+            data = run_command(command)
+        elif i == 11:
+            command = f""" /usr/sbin/crm status --as-xml """
+            title = "crm status json"
+            xml_status = run_command(command)
+            try:
+                dict_status = xmltodict.parse(xml_status, attr_prefix='')
+                data = json.dumps(dict_status)
+                data1 = json.dumps(dict_status["crm_mon"]["summary"])
+                multilinetooid(base_oid + ".1.11.0.1", title + " summary", data1)
+                data2 = json.dumps(dict_status["crm_mon"]["nodes"])
+                multilinetooid(base_oid + ".1.11.0.2", title + " nodes", data2)
+                continue
+            except ExpatError:
+                pass
 
 
-    multilinetooid(base_oid + ".1." + str(i), title, data)
+        multilinetooid(base_oid + ".1." + str(i), title, data)
 
-if 1 in replacedisk:
-    globalreplacedisk = "Problem on one disk"
-for i in range(1,5):
-    singlelinetooid(base_oid + ".5." + str(i), "replace disk " + str(i), replacedisk[i-1])
-singlelinetooid(base_oid + ".5.5", "replace disk global",globalreplacedisk)
+def write_disk_replacement_status(status):
+    if 1 in status.replacedisk:
+        status.globalreplacedisk = "Problem on one disk"
+    for i in range(1,5):
+        singlelinetooid(base_oid + ".5." + str(i), "replace disk " + str(i), status.replacedisk[i-1])
+    singlelinetooid(base_oid + ".5.5", "replace disk global",status.globalreplacedisk)
 
-f.close()
+def main():
+    global f
+    status = DiskStatus()
+    f = open(snmpdata_tmp, "w")
 
-os.rename(snmpdata_tmp, snmpdata)
+    collect_ipmi()
+    collect_raid(status)
+    collect_smart_health(status)
+    collect_lvs()
+    collect_monolines(status)
+    collect_multilines()
+    write_disk_replacement_status(status)
+
+    f.close()
+
+    os.rename(snmpdata_tmp, snmpdata)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/get_osd.py
+++ b/scripts/get_osd.py
@@ -42,7 +42,7 @@ def print_osd_on_host(hostname):
         print(found_ods)
 
 
-if __name__ == "__main__":
+def main(argv=None):
     parser = argparse.ArgumentParser(
         description="Print OSD daemons found inside the given machine"
     )
@@ -51,5 +51,9 @@ if __name__ == "__main__":
         help="The Machine hostname to seach OSD",
         type=str,
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     print_osd_on_host(args.hostname)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/README.md
+++ b/tests/README.md
@@ -67,20 +67,6 @@ command dispatch has to slip past the `except Exception` wrapped around it.
 globally. Where a script writes through a module-level file handle, point that
 handle at a `StringIO`.
 
-## Known defects pinned by tests
-
-Two tests assert current broken behaviour rather than desired behaviour, and
-say so in a comment. They are change detectors: fixing either defect should
-update its test in the same commit.
-
-- `test_write_disk_replacement_status_breaks_on_a_flagged_disk` -
-  `snmp_getdata.py` flags a suspect disk with the integer `1`, then calls
-  `lstrip()` on it, so the collection crashes exactly when a disk starts
-  failing.
-- `test_collect_multilines_survives_an_unparsable_crm_status` - on a parse
-  error the loop falls through with `data` still holding the previous
-  iteration's output, so OID `.1.11` repeats the lvs status.
-
 ## OpenSSF Best Practices
 
 The badge thresholds this suite answers to:

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,96 @@
+<!--
+Copyright (C) 2026, RTE (http://www.rte-france.com)
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+# Python unit tests
+
+Unit tests for every Python file this repository ships: the `cluster_vm`
+Ansible module, the scripts deployed as role `files/` payloads, and the
+OpenSCAP report converter used by the CI.
+
+## Running them
+
+```bash
+tox -e unit                     # the whole suite, with coverage
+tox -e unit -- -k snmp -v       # extra arguments go straight to pytest
+tox -e unit -- --no-cov         # skip the coverage run while iterating
+```
+
+`tox -e unit` writes `coverage.xml` and `htmlcov/` at the repository root and
+fails below the `COV_FAIL_UNDER` ratchet set in `tox.ini`. The ratchet exists
+to stop regressions: **raise it when coverage improves, never lower it**.
+`COV_FAIL_UNDER=0 tox -e unit` bypasses it locally.
+
+Without tox: `pip install -r unit_requirements.txt && pytest tests/ --cov`.
+
+The suite is hermetic. It never shells out, never opens a socket, and never
+touches a path outside `tmp_path`.
+
+## Where the numbers come from
+
+`.coveragerc` scopes the measurement to the four directories holding shipped
+Python and reports every file it finds there, so a new untested script appears
+at 0% rather than not appearing at all. Coverage skips directories without an
+`__init__.py`, and none of these are importable packages, hence
+`include_namespace_packages`.
+
+Excluded from the denominator, with the reason in `.coveragerc`: the three git
+submodules (upstream projects with their own suites), the ctypes probes under
+`deploy_cukinia_tests` (test material, not shipped code), and the three-line
+`vmmgrapi` WSGI entrypoint.
+
+Ansible roles and playbooks are not part of this measurement. They are covered
+by the molecule scenarios and the integration jobs, and there is no established
+free tool that reports statement coverage over Ansible tasks.
+
+## Conventions
+
+**Loading the code under test.** None of these files is an installable package,
+so `tests/support.py` provides `load_script("relative/path.py")`, which imports
+one by path. Every script guards its entry point with `if __name__ ==
+"__main__"`, so importing one defines its functions and does nothing else.
+
+**Stubbing what cannot be installed.** `install_stub_module(name)` registers an
+empty module so a script importing it can load: `rados` and `rbd` ship with
+Ceph, `vm_manager` lives in a submodule the unit job does not check out, and
+`ansible.module_utils` would drag ansible-core into the test environment for no
+gain. Tests then assert on the calls the code makes.
+
+Note the fake `AnsibleModule` in `test_cluster_vm.py`: its `fail_json` and
+`exit_json` raise exceptions deriving from `BaseException`, because the real
+ones raise `SystemExit`. That is load-bearing. A `fail_json` raised inside the
+command dispatch has to slip past the `except Exception` wrapped around it.
+
+**Seams.** Prefer patching the module attribute the code reads
+(`monkeypatch.setattr(snmp, "run_command", fake)`) over patching a library
+globally. Where a script writes through a module-level file handle, point that
+handle at a `StringIO`.
+
+## Known defects pinned by tests
+
+Two tests assert current broken behaviour rather than desired behaviour, and
+say so in a comment. They are change detectors: fixing either defect should
+update its test in the same commit.
+
+- `test_write_disk_replacement_status_breaks_on_a_flagged_disk` -
+  `snmp_getdata.py` flags a suspect disk with the integer `1`, then calls
+  `lstrip()` on it, so the collection crashes exactly when a disk starts
+  failing.
+- `test_collect_multilines_survives_an_unparsable_crm_status` - on a parse
+  error the loop falls through with `data` still holding the previous
+  iteration's output, so OID `.1.11` repeats the lvs status.
+
+## OpenSSF Best Practices
+
+The badge thresholds this suite answers to:
+
+| Criterion | Level | Threshold |
+|---|---|---|
+| `test_statement_coverage80` | silver | 80% statements |
+| `test_statement_coverage90` | gold | 90% statements |
+| `test_branch_coverage80` | gold | 80% branches |
+
+Current: **100% of statements, 98.7% of branches**. The remaining partial
+branches are the unreachable fall-through of the last `elif` in the three
+index-driven dispatch loops of `snmp_getdata.py`.

--- a/tests/support.py
+++ b/tests/support.py
@@ -11,9 +11,24 @@ module and one CI helper. The tests therefore import them by path.
 
 import importlib.util
 import sys
+import types
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def install_stub_module(name):
+    """
+    Register an empty module under ``name`` and return it.
+
+    Some scripts import modules that cannot exist in a test environment: the
+    rados and rbd C bindings only ship with Ceph, and vm_manager lives in a
+    git submodule that the unit job does not check out. Stubbing them lets
+    the tests drive the script's own logic and assert on the calls it makes.
+    """
+    module = types.ModuleType(name)
+    sys.modules[name] = module
+    return module
 
 
 def load_script(relpath, name=None):

--- a/tests/support.py
+++ b/tests/support.py
@@ -1,0 +1,34 @@
+# Copyright (C) 2026, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Helpers shared by the unit tests.
+
+The Python in this repository is not an installable package: it is a set of
+standalone scripts deployed as role ``files/`` payloads, plus one Ansible
+module and one CI helper. The tests therefore import them by path.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_script(relpath, name=None):
+    """
+    Import a standalone script by its path relative to the repository root.
+
+    Every script under test guards its entry point with ``if __name__ ==
+    "__main__"``, so importing one runs its definitions and nothing else.
+    """
+    path = REPO_ROOT / relpath
+    name = name or path.stem
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    # Registering before exec_module keeps the module importable from itself,
+    # which dataclasses and pickle rely on.
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module

--- a/tests/test_backup_du.py
+++ b/tests/test_backup_du.py
@@ -1,0 +1,190 @@
+# Copyright (C) 2026, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for roles/backup_restore/files/scripts/backup_du.py."""
+
+import pytest
+
+from support import load_script
+
+backup_du = load_script("roles/backup_restore/files/scripts/backup_du.py")
+
+# One line per RBD image, in the five-column layout the script splits on:
+# NAME PROVISIONED <unit> USED <unit>
+RBD_DU = """system_guest0 20 GiB 3 GiB
+data_guest0_1 10 GiB 512 MiB
+system_guest1 20 GiB 1 GiB
+"""
+
+
+@pytest.fixture
+def fake_rbd_du(monkeypatch):
+    def install(output):
+        recorded = {}
+
+        def check_output(cmd, **kwargs):
+            recorded["cmd"] = cmd
+            recorded["kwargs"] = kwargs
+            return output
+
+        monkeypatch.setattr(backup_du, "check_output", check_output)
+        return recorded
+
+    return install
+
+
+def du(include_vm='""', exclude_vm='""'):
+    return {"include_vm": include_vm, "exclude_vm": exclude_vm}
+
+
+@pytest.mark.parametrize(
+    "nb,unit,expected",
+    [
+        (1, "GiB", 1024 * 1024 * 1024),
+        (1, "MiB", 1024 * 1024),
+        (1, "KiB", 1024),
+        (2.5, "MiB", int(2.5 * 1024 * 1024)),
+        (1, "gib", 1024 * 1024 * 1024),
+        (1, "TiB", 0),
+        (1, "B", 0),
+    ],
+)
+def test_convert_size(nb, unit, expected):
+    assert backup_du.convert_size(nb, unit) == expected
+
+
+def test_convert_size_rounds_to_the_nearest_byte():
+    # 0.0000000001 GiB is 0.107 byte, which rounds down to zero.
+    assert backup_du.convert_size(0.0000000001, "GiB") == 0
+    # 0.5 KiB is 512 bytes exactly, no rounding involved.
+    assert backup_du.convert_size(0.5, "KiB") == 512
+
+
+def test_convert_mo_rounds_half_up():
+    assert backup_du.convert_mo(1_000_000) == 1
+    assert backup_du.convert_mo(1_500_000) == 2
+    assert backup_du.convert_mo(1_400_000) == 1
+    assert backup_du.convert_mo(0) == 0
+
+
+def test_pr_lig_formats_name_and_size(capsys):
+    backup_du.pr_lig("guest0", 42, " MB")
+
+    assert capsys.readouterr().out == "guest0                       42 MB\n"
+
+
+def test_pr_table_lists_every_guest_then_the_total(capsys):
+    backup_du.pr_table({"guest0": 3000, "guest1": 1000})
+
+    out = capsys.readouterr().out
+    assert "guest0" in out
+    assert "guest1" in out
+    assert "TOTAL :" in out
+    assert "4000 MB" in out
+
+
+def test_pr_table_converts_the_total_to_gigabytes(capsys):
+    backup_du.pr_table({"guest0": 1500})
+
+    out = capsys.readouterr().out
+    assert "Estimating En GB" in out
+    assert "2 GB" in out
+
+
+def test_pr_table_of_an_empty_mapping_totals_zero(capsys):
+    backup_du.pr_table({})
+
+    out = capsys.readouterr().out
+    assert "0 MB" in out
+    assert "0 GB" in out
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("system_guest0", "guest0"),
+        ("data_guest0_1", "guest0"),
+        ("data_guest0_12", "guest0"),
+        ("data_my_guest_3", "my_guest"),
+        ("system_guest0@snap1", "guest0"),
+        ("data_guest0_1@snap1", "guest0"),
+        ("rbd_other", None),
+        ("", None),
+    ],
+)
+def test_image_to_guest(name, expected):
+    assert backup_du.image_to_guest(name) == expected
+
+
+def test_read_du_rbd_sums_system_and_data_disks_per_guest(fake_rbd_du):
+    fake_rbd_du(RBD_DU)
+
+    volume = backup_du.read_du_rbd(du())
+
+    # 3 GiB is 3221 MB, 512 MiB is 537 MB.
+    assert volume == {"guest0": 3221 + 537, "guest1": 1074}
+
+
+def test_read_du_rbd_selects_the_system_and_data_images(fake_rbd_du):
+    recorded = fake_rbd_du(RBD_DU)
+
+    backup_du.read_du_rbd(du())
+
+    assert recorded["cmd"] == (
+        '/usr/bin/rbd du 2>/dev/null | grep -E "^(system|data)_"'
+    )
+    assert recorded["kwargs"]["shell"] is True
+
+
+def test_read_du_rbd_keeps_only_the_included_guests(fake_rbd_du):
+    fake_rbd_du(RBD_DU)
+
+    volume = backup_du.read_du_rbd(du(include_vm='"guest1"'))
+
+    assert list(volume) == ["guest1"]
+
+
+def test_read_du_rbd_drops_the_excluded_guests(fake_rbd_du):
+    fake_rbd_du(RBD_DU)
+
+    volume = backup_du.read_du_rbd(du(exclude_vm='"guest0"'))
+
+    assert list(volume) == ["guest1"]
+
+
+def test_read_du_rbd_treats_an_empty_include_as_everything(fake_rbd_du):
+    fake_rbd_du(RBD_DU)
+
+    volume = backup_du.read_du_rbd(du(include_vm=""))
+
+    assert sorted(volume) == ["guest0", "guest1"]
+
+
+def test_read_du_rbd_skips_images_that_map_to_no_guest(fake_rbd_du):
+    fake_rbd_du("systemd_thing 1 GiB 1 GiB\nsystem_guest0 20 GiB 1 GiB\n")
+
+    volume = backup_du.read_du_rbd(du())
+
+    assert list(volume) == ["guest0"]
+
+
+def test_read_du_rbd_ignores_blank_lines(fake_rbd_du):
+    fake_rbd_du("\n\nsystem_guest0 20 GiB 1 GiB\n\n")
+
+    volume = backup_du.read_du_rbd(du())
+
+    assert volume == {"guest0": 1074}
+
+
+def test_compute_reads_its_filters_from_the_command_line(
+    fake_rbd_du, monkeypatch, capsys
+):
+    fake_rbd_du(RBD_DU)
+    monkeypatch.setattr(backup_du.sys, "argv", ["backup_du.py", '"guest1"', '""'])
+
+    backup_du.compute()
+
+    out = capsys.readouterr().out
+    assert "guest1" in out
+    assert "guest0" not in out
+    assert "TOTAL :" in out

--- a/tests/test_cluster_vm.py
+++ b/tests/test_cluster_vm.py
@@ -1,0 +1,521 @@
+# Copyright (C) 2026, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for plugins/modules/cluster_vm.py."""
+
+import datetime
+import sys
+
+import pytest
+
+from support import install_stub_module, load_script
+
+# vm_manager lives in a git submodule the unit job does not check out, and
+# ansible-core is not a test dependency. Both are stubbed: what matters here
+# is the calls the module makes, not what they do on a real cluster.
+install_stub_module("vm_manager")
+ansible_basic = install_stub_module("ansible.module_utils.basic")
+ansible_text = install_stub_module("ansible.module_utils._text")
+ansible_basic.AnsibleModule = object
+ansible_text.to_native = str
+
+cluster_vm = load_script("plugins/modules/cluster_vm.py")
+
+# Every vm_manager entry point the module dispatches to.
+VM_MANAGER_FUNCTIONS = [
+    "list_vms", "create", "clone", "remove", "start", "stop", "disable_vm",
+    "status", "enable_vm", "create_snapshot", "purge_image", "remove_snapshot",
+    "list_snapshots", "rollback_snapshot", "list_metadata", "get_metadata",
+    "add_colocation", "add_pacemaker_remote", "remove_pacemaker_remote",
+]
+
+
+class AnsibleExit(BaseException):
+    """
+    Base of the fake module's exits.
+
+    AnsibleModule.fail_json and exit_json end the process with SystemExit,
+    which derives from BaseException and therefore slips past the
+    "except Exception" wrapped around the command dispatch. Deriving from
+    BaseException here keeps that behaviour: a fail_json raised inside the
+    try block must not be recaught and reported as an unexpected error.
+    """
+
+    def __init__(self, kwargs):
+        self.kwargs = kwargs
+        super().__init__(kwargs.get("msg", ""))
+
+
+class FailJson(AnsibleExit):
+    pass
+
+
+class ExitJson(AnsibleExit):
+    pass
+
+
+class FakeAnsibleModule:
+    def __init__(self, params, init_kwargs):
+        self.params = params
+        self.init_kwargs = init_kwargs
+
+    def fail_json(self, **kwargs):
+        raise FailJson(kwargs)
+
+    def exit_json(self, **kwargs):
+        raise ExitJson(kwargs)
+
+
+@pytest.fixture
+def vm_manager(monkeypatch):
+    """Record every vm_manager call the module makes."""
+    calls = []
+
+    def recorder(name):
+        def call(*args, **kwargs):
+            calls.append((name, args, kwargs))
+            return "{}-result".format(name)
+
+        return call
+
+    for name in VM_MANAGER_FUNCTIONS:
+        monkeypatch.setattr(
+            cluster_vm.vm_manager, name, recorder(name), raising=False
+        )
+    return calls
+
+
+@pytest.fixture
+def run(monkeypatch, vm_manager):
+    """Run the module with the given parameters and return how it exited."""
+
+    def _run(**params):
+        created = {}
+
+        def factory(**init_kwargs):
+            created["module"] = FakeAnsibleModule(params, init_kwargs)
+            return created["module"]
+
+        monkeypatch.setattr(cluster_vm, "AnsibleModule", factory)
+        # A FailJson propagates so tests can assert on it with pytest.raises;
+        # a successful run is handed back for inspection.
+        try:
+            cluster_vm.run_module()
+        except ExitJson as exc:
+            exc.module = created.get("module")
+            return exc
+        raise AssertionError("run_module() returned without calling exit_json")
+
+    return _run
+
+
+def only_call(calls):
+    assert len(calls) == 1, calls
+    return calls[0]
+
+
+# --- module wiring --------------------------------------------------------
+
+
+def test_declares_every_command_it_dispatches():
+    assert set(cluster_vm.commands_list) == {
+        "create", "remove", "start", "stop", "list_vms", "enable", "disable",
+        "status", "clone", "create_snapshot", "remove_snapshot",
+        "list_snapshots", "rollback_snapshot", "purge_image", "list_metadata",
+        "get_metadata", "define_colocation", "add_pacemaker_remote",
+        "remove_pacemaker_remote",
+    }
+
+
+def test_reports_a_missing_vm_manager(run, monkeypatch):
+    monkeypatch.setattr(cluster_vm, "HAS_VM_MANAGER", False)
+
+    with pytest.raises(FailJson) as excinfo:
+        run(command="list_vms")
+
+    assert "vm_manager" in excinfo.value.kwargs["msg"]
+
+
+def test_detects_vm_manager_at_import_time():
+    # Reloading without the stub takes the ImportError branch of the guard.
+    saved = sys.modules.pop("vm_manager")
+    try:
+        without = load_script("plugins/modules/cluster_vm.py", "cluster_vm_novmm")
+    finally:
+        sys.modules["vm_manager"] = saved
+
+    assert without.HAS_VM_MANAGER is False
+    assert cluster_vm.HAS_VM_MANAGER is True
+
+
+def test_declares_the_argument_spec_and_the_required_combinations(run):
+    result = run(command="list_vms")
+
+    init = result.module.init_kwargs
+    assert init["supports_check_mode"] is True
+    assert init["mutually_exclusive"] == [("purge_date", "purge_number")]
+    assert ("command", "create", ("name", "xml", "system_image")) in init["required_if"]
+    assert init["argument_spec"]["command"]["choices"] == cluster_vm.commands_list
+
+
+def test_main_runs_the_module(monkeypatch):
+    called = []
+    monkeypatch.setattr(cluster_vm, "run_module", lambda: called.append(True))
+
+    cluster_vm.main()
+
+    assert called == [True]
+
+
+# --- parameter checking ---------------------------------------------------
+
+
+def test_requires_a_name_for_every_command_but_list_vms(run):
+    with pytest.raises(FailJson) as excinfo:
+        run(command="start", name="")
+
+    assert excinfo.value.kwargs["msg"] == (
+        "`name` is required when `command` is `start`"
+    )
+
+
+def test_does_not_require_a_name_for_list_vms(run, vm_manager):
+    run(command="list_vms")
+
+    assert only_call(vm_manager)[0] == "list_vms"
+
+
+@pytest.mark.parametrize(
+    "params,missing",
+    [
+        ({"command": "create", "name": "vm0", "xml": "", "system_image": "i"},
+         "vm_config"),
+        ({"command": "create", "name": "vm0", "xml": "x", "system_image": ""},
+         "system_image"),
+        ({"command": "clone", "name": "vm0", "src_name": ""}, "src_name"),
+        ({"command": "get_metadata", "name": "vm0", "metadata_name": ""},
+         "metadata_name"),
+        ({"command": "create_snapshot", "name": "vm0", "snapshot_name": ""},
+         "snapshot_name"),
+        ({"command": "remove_snapshot", "name": "vm0", "snapshot_name": ""},
+         "snapshot_name"),
+        ({"command": "rollback_snapshot", "name": "vm0", "snapshot_name": ""},
+         "snapshot_name"),
+    ],
+)
+def test_reports_the_missing_parameter_of_a_command(run, params, missing):
+    with pytest.raises(FailJson) as excinfo:
+        run(**params)
+
+    assert missing in excinfo.value.kwargs["msg"]
+    assert params["command"] in excinfo.value.kwargs["msg"]
+
+
+# --- create and clone -----------------------------------------------------
+
+
+@pytest.fixture
+def image(tmp_path):
+    path = tmp_path / "system.qcow2"
+    path.write_bytes(b"")
+    return str(path)
+
+
+def test_create_passes_the_options_to_vm_manager(run, vm_manager, image):
+    run(
+        command="create", name="vm0", xml="<domain/>", system_image=image,
+        preferred_host="hyp1", priority="100", disk_bus="scsi",
+    )
+
+    name, args, _ = only_call(vm_manager)
+    assert name == "create"
+    options = args[0]
+    assert options["name"] == "vm0"
+    assert options["base_xml"] == "<domain/>"
+    assert options["image"] == image
+    assert options["preferred_host"] == "hyp1"
+    assert options["priority"] == "100"
+    assert options["disk_bus"] == "scsi"
+
+
+def test_create_defaults_the_disk_bus_to_virtio(run, vm_manager, image):
+    run(command="create", name="vm0", xml="<domain/>", system_image=image)
+
+    assert only_call(vm_manager)[1][0]["disk_bus"] == "virtio"
+
+
+def test_create_rejects_a_system_image_that_is_not_a_file(run, tmp_path):
+    with pytest.raises(FailJson) as excinfo:
+        run(
+            command="create", name="vm0", xml="<domain/>",
+            system_image=str(tmp_path / "absent.qcow2"),
+        )
+
+    assert "system_image" in excinfo.value.kwargs["msg"]
+
+
+def test_create_accepts_additional_disks_that_exist(run, vm_manager, image, tmp_path):
+    extra = tmp_path / "data.qcow2"
+    extra.write_bytes(b"")
+
+    run(
+        command="create", name="vm0", xml="<domain/>", system_image=image,
+        additional_disks=[str(extra)],
+    )
+
+    assert only_call(vm_manager)[1][0]["additional_disks"] == [str(extra)]
+
+
+def test_create_reports_which_additional_disk_is_missing(run, image, tmp_path):
+    extra = tmp_path / "data.qcow2"
+    extra.write_bytes(b"")
+
+    with pytest.raises(FailJson) as excinfo:
+        run(
+            command="create", name="vm0", xml="<domain/>", system_image=image,
+            additional_disks=[str(extra), str(tmp_path / "absent.qcow2")],
+        )
+
+    assert "additional_disks[1]" in excinfo.value.kwargs["msg"]
+
+
+def test_clone_names_the_source_and_the_destination(run, vm_manager):
+    run(command="clone", name="vm1", src_name="vm0", clear_constraint=True)
+
+    name, args, _ = only_call(vm_manager)
+    assert name == "clone"
+    assert args[0]["name"] == "vm0"
+    assert args[0]["dst_name"] == "vm1"
+    assert args[0]["clear_constraint"] is True
+
+
+def test_clone_forwards_the_pacemaker_overrides(run, vm_manager):
+    run(
+        command="clone", name="vm1", src_name="vm0",
+        pacemaker_meta={"a": "1"}, clear_pacemaker_utilization=True,
+    )
+
+    options = only_call(vm_manager)[1][0]
+    assert options["pacemaker_meta"] == {"a": "1"}
+    assert options["clear_pacemaker_utilization"] is True
+
+
+# --- lifecycle ------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command,function",
+    [
+        ("remove", "remove"),
+        ("start", "start"),
+        ("stop", "stop"),
+        ("disable", "disable_vm"),
+    ],
+)
+def test_lifecycle_commands_take_the_vm_name(run, vm_manager, command, function):
+    run(command=command, name="vm0")
+
+    assert only_call(vm_manager) == (function, ("vm0",), {})
+
+
+def test_enable_forwards_the_nostart_flag(run, vm_manager):
+    run(command="enable", name="vm0", nostart=True)
+
+    assert only_call(vm_manager) == ("enable_vm", ("vm0", True), {})
+
+
+def test_enable_defaults_nostart_to_false(run, vm_manager):
+    run(command="enable", name="vm0")
+
+    assert only_call(vm_manager) == ("enable_vm", ("vm0", False), {})
+
+
+# --- commands returning a value -------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command,key,function",
+    [
+        ("list_vms", "list_vms", "list_vms"),
+        ("status", "status", "status"),
+        ("list_snapshots", "list_snapshot", "list_snapshots"),
+        ("list_metadata", "list_metadata", "list_metadata"),
+    ],
+)
+def test_reporting_commands_return_their_result(run, command, key, function):
+    result = run(command=command, name="vm0")
+
+    assert isinstance(result, ExitJson)
+    assert result.kwargs[key] == "{}-result".format(function)
+
+
+def test_get_metadata_returns_the_value_of_one_key(run, vm_manager):
+    result = run(command="get_metadata", name="vm0", metadata_name="os")
+
+    assert only_call(vm_manager) == ("get_metadata", ("vm0", "os"), {})
+    assert result.kwargs["metadata_value"] == "get_metadata-result"
+
+
+def test_a_command_with_no_output_returns_an_empty_result(run):
+    result = run(command="start", name="vm0")
+
+    assert result.kwargs == {}
+
+
+# --- snapshots ------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command,function",
+    [
+        ("create_snapshot", "create_snapshot"),
+        ("remove_snapshot", "remove_snapshot"),
+        ("rollback_snapshot", "rollback_snapshot"),
+    ],
+)
+def test_snapshot_commands_take_the_snapshot_name(run, vm_manager, command, function):
+    run(command=command, name="vm0", snapshot_name="snap1")
+
+    assert only_call(vm_manager) == (function, ("vm0", "snap1"), {})
+
+
+# --- purge ----------------------------------------------------------------
+
+
+def test_purge_image_without_a_date_purges_by_count(run, vm_manager):
+    run(command="purge_image", name="vm0", purge_number=3)
+
+    assert only_call(vm_manager) == (
+        "purge_image", ("vm0",), {"date": None, "number": 3},
+    )
+
+
+def test_purge_image_combines_a_date_and_a_time(run, vm_manager):
+    run(
+        command="purge_image", name="vm0",
+        purge_date={"date": "2026-01-31", "time": "23:45:00"},
+    )
+
+    _, _, kwargs = only_call(vm_manager)
+    assert kwargs["date"] == datetime.datetime(2026, 1, 31, 23, 45)
+
+
+def test_purge_image_accepts_an_iso_8601_timestamp(run, vm_manager):
+    run(
+        command="purge_image", name="vm0",
+        purge_date={"iso_8601": "2026-01-31T23:45:00"},
+    )
+
+    assert only_call(vm_manager)[2]["date"] == datetime.datetime(
+        2026, 1, 31, 23, 45
+    )
+
+
+def test_purge_image_accepts_a_posix_timestamp(run, vm_manager):
+    run(command="purge_image", name="vm0", purge_date={"posix": 1769903100})
+
+    assert only_call(vm_manager)[2]["date"] == datetime.datetime.fromtimestamp(
+        1769903100
+    )
+
+
+def test_purge_image_ignores_a_purge_date_it_does_not_recognise(run, vm_manager):
+    # Neither date/time, iso_8601 nor posix: the purge falls back to the
+    # count filter instead of failing.
+    run(command="purge_image", name="vm0", purge_date={"epoch": 1769903100})
+
+    assert only_call(vm_manager)[2]["date"] is None
+
+
+@pytest.mark.parametrize(
+    "purge_date",
+    [
+        {"date": "2026-01-31"},
+        {"time": "23:45:00"},
+    ],
+)
+def test_purge_image_requires_date_and_time_together(run, purge_date):
+    with pytest.raises(FailJson) as excinfo:
+        run(command="purge_image", name="vm0", purge_date=purge_date)
+
+    assert "date and time must be" in excinfo.value.kwargs["msg"]
+
+
+@pytest.mark.parametrize(
+    "purge_date",
+    [
+        {"date": "2026-01-31", "time": "23:45:00", "posix": 1769903100},
+        {"date": "2026-01-31", "time": "23:45:00", "iso_8601": "2026-01-31"},
+        {"posix": 1769903100, "iso_8601": "2026-01-31T23:45:00"},
+    ],
+)
+def test_purge_image_rejects_two_ways_of_saying_when(run, purge_date):
+    with pytest.raises(FailJson) as excinfo:
+        run(command="purge_image", name="vm0", purge_date=purge_date)
+
+    assert "mutually exclusive" in excinfo.value.kwargs["msg"]
+
+
+# --- pacemaker constraints ------------------------------------------------
+
+
+def test_define_colocation_passes_the_peers_and_the_strength(run, vm_manager):
+    run(
+        command="define_colocation", name="vm0",
+        colocated_vms=["vm1", "vm2"], strong=True,
+    )
+
+    assert only_call(vm_manager) == (
+        "add_colocation", ("vm0", "vm1", "vm2"), {"strong": True},
+    )
+
+
+def test_define_colocation_needs_at_least_one_peer(run):
+    with pytest.raises(FailJson) as excinfo:
+        run(command="define_colocation", name="vm0", colocated_vms=[])
+
+    assert excinfo.value.kwargs["msg"] == "No colocated VM defined"
+
+
+def test_add_pacemaker_remote_forwards_the_endpoint(run, vm_manager):
+    run(
+        command="add_pacemaker_remote", name="vm0", remote_name="vm0-remote",
+        remote_address="10.0.0.5", remote_port="3121", remote_timeout="60",
+    )
+
+    assert only_call(vm_manager) == (
+        "add_pacemaker_remote",
+        ("vm0", "vm0-remote", "10.0.0.5"),
+        {"remote_node_port": "3121", "remote_node_timeout": "60"},
+    )
+
+
+def test_remove_pacemaker_remote_takes_the_vm_name(run, vm_manager):
+    run(command="remove_pacemaker_remote", name="vm0")
+
+    assert only_call(vm_manager) == ("remove_pacemaker_remote", ("vm0",), {})
+
+
+# --- error handling -------------------------------------------------------
+
+
+def test_rejects_a_command_it_does_not_implement(run):
+    with pytest.raises(FailJson) as excinfo:
+        run(command="frobnicate", name="vm0")
+
+    assert excinfo.value.kwargs["msg"] == (
+        "frobnicate `command` is not implemented yet"
+    )
+
+
+def test_reports_a_vm_manager_failure_with_its_traceback(run, monkeypatch):
+    def boom(_name):
+        raise RuntimeError("libvirt is unreachable")
+
+    monkeypatch.setattr(cluster_vm.vm_manager, "start", boom, raising=False)
+
+    with pytest.raises(FailJson) as excinfo:
+        run(command="start", name="vm0")
+
+    assert excinfo.value.kwargs["msg"] == "libvirt is unreachable"
+    assert "RuntimeError" in excinfo.value.kwargs["exception"]

--- a/tests/test_get_metadata.py
+++ b/tests/test_get_metadata.py
@@ -1,0 +1,174 @@
+# Copyright (C) 2026, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for roles/backup_restore/files/scripts/get_metadata.py."""
+
+import pytest
+
+from support import install_stub_module, load_script
+
+# rados and rbd are the Ceph C bindings; they only exist on a deployed node.
+install_stub_module("rados")
+install_stub_module("rbd")
+
+get_metadata = load_script("roles/backup_restore/files/scripts/get_metadata.py")
+
+
+class FakeImage:
+    def __init__(self, ioctx, name, keys=(), error=None):
+        self.ioctx = ioctx
+        self.name = name
+        self.keys = keys
+        self.error = error
+        self.closed = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        self.closed = True
+
+    def metadata_list(self):
+        if self.error:
+            raise self.error
+        return [(key, "value") for key in self.keys]
+
+
+class FakeIoctx:
+    def __init__(self, pool):
+        self.pool = pool
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+class FakeCluster:
+    def __init__(self, conffile=None):
+        self.conffile = conffile
+        self.connected = False
+        self.shutdown_called = False
+        self.ioctx = None
+
+    def connect(self):
+        self.connected = True
+
+    def open_ioctx(self, pool):
+        self.ioctx = FakeIoctx(pool)
+        return self.ioctx
+
+    def shutdown(self):
+        self.shutdown_called = True
+
+
+@pytest.fixture
+def ceph(monkeypatch):
+    """Wire the rados/rbd stubs to fakes and hand back what they recorded."""
+    state = {}
+
+    def install(keys=("os", "role"), error=None):
+        def rados_ctor(conffile=None):
+            state["cluster"] = FakeCluster(conffile)
+            return state["cluster"]
+
+        def image_ctor(ioctx, name):
+            state["image"] = FakeImage(ioctx, name, keys, error)
+            return state["image"]
+
+        monkeypatch.setattr(get_metadata.rados, "Rados", rados_ctor, raising=False)
+        monkeypatch.setattr(get_metadata.rbd, "Image", image_ctor, raising=False)
+        return state
+
+    return install
+
+
+def test_prints_every_metadata_key(ceph, capsys):
+    ceph(keys=("os", "role", "seapath"))
+
+    get_metadata.print_metadata_keys("guest0")
+
+    assert capsys.readouterr().out == "os\nrole\nseapath\n"
+
+
+def test_prints_nothing_when_the_image_has_no_metadata(ceph, capsys):
+    ceph(keys=())
+
+    get_metadata.print_metadata_keys("guest0")
+
+    assert capsys.readouterr().out == ""
+
+
+def test_opens_the_system_image_of_the_guest(ceph):
+    state = ceph()
+
+    get_metadata.print_metadata_keys("guest0")
+
+    assert state["image"].name == "system_guest0"
+    assert state["image"].ioctx is state["cluster"].ioctx
+
+
+def test_reads_the_rbd_pool_through_the_default_configuration(ceph):
+    state = ceph()
+
+    get_metadata.print_metadata_keys("guest0")
+
+    assert state["cluster"].conffile == "/etc/ceph/ceph.conf"
+    assert state["cluster"].connected is True
+    assert state["cluster"].ioctx.pool == "rbd"
+
+
+def test_closes_the_image_the_context_and_the_cluster(ceph):
+    state = ceph()
+
+    get_metadata.print_metadata_keys("guest0")
+
+    assert state["image"].closed is True
+    assert state["cluster"].ioctx.closed is True
+    assert state["cluster"].shutdown_called is True
+
+
+def test_releases_the_cluster_even_when_the_image_fails(ceph):
+    state = ceph(error=RuntimeError("image is gone"))
+
+    with pytest.raises(RuntimeError):
+        get_metadata.print_metadata_keys("guest0")
+
+    assert state["cluster"].ioctx.closed is True
+    assert state["cluster"].shutdown_called is True
+
+
+def test_main_passes_the_guest_name_through(ceph, capsys):
+    state = ceph()
+
+    get_metadata.main(["get_metadata.py", "guest1"])
+
+    assert state["image"].name == "system_guest1"
+    assert capsys.readouterr().out == "os\nrole\n"
+
+
+def test_main_falls_back_to_sys_argv(ceph, monkeypatch):
+    state = ceph()
+    monkeypatch.setattr(
+        get_metadata.sys, "argv", ["get_metadata.py", "guest2"]
+    )
+
+    get_metadata.main()
+
+    assert state["image"].name == "system_guest2"
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["get_metadata.py"],
+        ["get_metadata.py", "guest0", "extra"],
+    ],
+)
+def test_main_rejects_a_wrong_argument_count(ceph, capsys, argv):
+    ceph()
+
+    with pytest.raises(SystemExit) as excinfo:
+        get_metadata.main(argv)
+
+    assert excinfo.value.code == 1
+    assert "usage: get_metadata.py <guest>" in capsys.readouterr().err

--- a/tests/test_get_osd.py
+++ b/tests/test_get_osd.py
@@ -1,0 +1,120 @@
+# Copyright (C) 2026, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for scripts/get_osd.py."""
+
+import json
+
+import pytest
+
+from support import load_script
+
+get_osd = load_script("scripts/get_osd.py")
+
+
+class FakeCompletedProcess:
+    def __init__(self, stdout=b""):
+        self.stdout = stdout
+
+
+@pytest.fixture
+def fake_run(monkeypatch):
+    """Record subprocess.run calls and feed a crushmap back to the script."""
+    calls = []
+
+    def runner(crushmap):
+        def _run(args, **kwargs):
+            calls.append((args, kwargs))
+            if args[0] == "crushtool":
+                return FakeCompletedProcess(json.dumps(crushmap).encode("UTF-8"))
+            return FakeCompletedProcess()
+
+        monkeypatch.setattr(get_osd.subprocess, "run", _run)
+        return calls
+
+    return runner
+
+
+def crushmap(*buckets):
+    return {"buckets": list(buckets)}
+
+
+def host(name, *osd_ids):
+    return {
+        "type_name": "host",
+        "name": name,
+        "items": [{"id": i} for i in osd_ids],
+    }
+
+
+def test_prints_the_osd_ids_of_the_host(fake_run, capsys):
+    fake_run(crushmap(host("hypervisor1", 0, 3, 7)))
+
+    get_osd.print_osd_on_host("hypervisor1")
+
+    assert capsys.readouterr().out == "0,3,7\n"
+
+
+def test_dumps_the_crushmap_before_decoding_it(fake_run):
+    calls = fake_run(crushmap(host("hypervisor1", 1)))
+
+    get_osd.print_osd_on_host("hypervisor1")
+
+    dump, decode = calls
+    assert dump[0] == "ceph osd getcrushmap > ./crushmap"
+    assert dump[1]["shell"] is True
+    assert dump[1]["check"] is True
+    assert decode[0] == [
+        "crushtool", "-d", "./crushmap", "-f", "json", "--dump", "-o", "/dev/null",
+    ]
+    assert decode[1]["shell"] is False
+
+
+def test_prints_nothing_when_the_host_is_absent(fake_run, capsys):
+    fake_run(crushmap(host("hypervisor2", 0)))
+
+    get_osd.print_osd_on_host("hypervisor1")
+
+    assert capsys.readouterr().out == ""
+
+
+def test_prints_nothing_when_the_host_has_no_osd(fake_run, capsys):
+    fake_run(crushmap(host("hypervisor1")))
+
+    get_osd.print_osd_on_host("hypervisor1")
+
+    assert capsys.readouterr().out == ""
+
+
+def test_ignores_a_non_host_bucket_of_the_same_name(fake_run, capsys):
+    root = {"type_name": "root", "name": "hypervisor1", "items": [{"id": 9}]}
+    fake_run(crushmap(root, host("hypervisor1", 4)))
+
+    get_osd.print_osd_on_host("hypervisor1")
+
+    assert capsys.readouterr().out == "4\n"
+
+
+def test_stops_at_the_first_matching_host(fake_run, capsys):
+    fake_run(crushmap(host("hypervisor1", 1), host("hypervisor1", 2)))
+
+    get_osd.print_osd_on_host("hypervisor1")
+
+    assert capsys.readouterr().out == "1\n"
+
+
+def test_main_passes_the_hostname_argument_through(fake_run, capsys):
+    fake_run(crushmap(host("hypervisor3", 5)))
+
+    get_osd.main(["hypervisor3"])
+
+    assert capsys.readouterr().out == "5\n"
+
+
+def test_main_rejects_a_missing_hostname(fake_run):
+    fake_run(crushmap())
+
+    with pytest.raises(SystemExit) as excinfo:
+        get_osd.main([])
+
+    assert excinfo.value.code == 2

--- a/tests/test_oscap2junit.py
+++ b/tests/test_oscap2junit.py
@@ -1,0 +1,382 @@
+# Copyright (C) 2026, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for .github/test-report/oscap2junit.py."""
+
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from support import load_script
+
+oscap2junit = load_script(".github/test-report/oscap2junit.py")
+
+# An XCCDF result document small enough to reason about, but carrying one
+# rule-result per branch of the conversion: every outcome of RESULT_MAP, a
+# rule missing from the benchmark, a rule without a title, and a rule with
+# no severity attribute at all.
+XCCDF = """<?xml version="1.0" encoding="UTF-8"?>
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2" id="benchmark_seapath">
+  <title>SEAPATH hardening benchmark</title>
+  <Group id="group_partitions">
+    <title>Partitions</title>
+    <Rule id="rule_pass" severity="high">
+      <title>/tmp is a separate partition</title>
+    </Rule>
+    <Rule id="rule_fail" severity="medium">
+      <title>nodev is set on /tmp</title>
+    </Rule>
+  </Group>
+  <Rule id="rule_notitle" severity="low"/>
+  <Rule id="rule_notapplicable" severity="low">
+    <title>Rule that does not apply here</title>
+  </Rule>
+  <TestResult id="xccdf_result_stig:1/2">
+    <title>SEAPATH hardening</title>
+    <target>hypervisor1</target>
+    <rule-result idref="rule_pass" severity="high">
+      <result>pass</result>
+    </rule-result>
+    <rule-result idref="rule_fail" severity="medium">
+      <result>fail</result>
+    </rule-result>
+    <rule-result idref="rule_notapplicable" severity="low">
+      <result>notapplicable</result>
+    </rule-result>
+    <rule-result idref="rule_notitle" severity="low">
+      <result>notselected</result>
+    </rule-result>
+    <rule-result idref="rule_absent_from_benchmark">
+      <result>error</result>
+    </rule-result>
+    <rule-result idref="rule_no_result" severity="high"/>
+  </TestResult>
+</Benchmark>
+"""
+
+NO_TESTRESULT = """<?xml version="1.0" encoding="UTF-8"?>
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2" id="benchmark_seapath">
+  <Rule id="rule_pass" severity="high"><title>A rule</title></Rule>
+</Benchmark>
+"""
+
+
+@pytest.fixture
+def xccdf_file(tmp_path):
+    def write(content=XCCDF):
+        path = tmp_path / "oscap-result.xml"
+        path.write_text(content)
+        return str(path)
+
+    return write
+
+
+@pytest.fixture
+def run_main(monkeypatch, xccdf_file, tmp_path):
+    """Drive main() the way the CI does, through sys.argv."""
+
+    def run(*extra_args, content=XCCDF):
+        out_dir = tmp_path / "junit"
+        argv = ["oscap2junit", xccdf_file(content), "-o", str(out_dir)]
+        monkeypatch.setattr(oscap2junit.sys, "argv", argv + list(extra_args))
+        oscap2junit.main()
+        return out_dir
+
+    return run
+
+
+def junit_cases(path):
+    """Return the <testcase> elements of a JUnit file, whatever the root is."""
+    root = ET.parse(path).getroot()
+    return root.findall(".//testcase")
+
+
+# --- pure helpers ---------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "severity,minimum,expected",
+    [
+        ("high", None, True),
+        ("low", None, True),
+        ("high", "low", True),
+        ("high", "high", True),
+        ("medium", "high", False),
+        ("low", "medium", False),
+        ("unknown", "low", False),
+        ("bogus", "low", False),
+    ],
+)
+def test_severity_ok(severity, minimum, expected):
+    assert oscap2junit.severity_ok(severity, minimum) is expected
+
+
+def test_get_elem_base_tag_strips_the_namespace():
+    elem = ET.Element("{http://checklists.nist.gov/xccdf/1.2}Rule")
+
+    assert oscap2junit.get_elem_base_tag(elem) == "Rule"
+
+
+def test_get_elem_base_tag_leaves_a_bare_tag_alone():
+    assert oscap2junit.get_elem_base_tag(ET.Element("Rule")) == "Rule"
+
+
+def test_get_elem_text_strips_surrounding_whitespace():
+    elem = ET.Element("title")
+    elem.text = "  a title\n"
+
+    assert oscap2junit.get_elem_text(elem) == "a title"
+
+
+def test_get_elem_text_defaults_when_the_element_is_missing():
+    assert oscap2junit.get_elem_text(None, "fallback") == "fallback"
+    assert oscap2junit.get_elem_text(None) == ""
+
+
+def test_get_elem_text_defaults_when_the_element_is_empty():
+    assert oscap2junit.get_elem_text(ET.Element("title"), "fallback") == "fallback"
+
+
+def test_build_rule_titles_map_walks_nested_groups():
+    root = ET.fromstring(XCCDF)
+
+    titles = oscap2junit.build_rule_titles_map(root)
+
+    assert titles["rule_pass"] == "/tmp is a separate partition"
+    assert titles["rule_fail"] == "nodev is set on /tmp"
+
+
+def test_build_rule_titles_map_falls_back_to_the_rule_id():
+    root = ET.fromstring(XCCDF)
+
+    titles = oscap2junit.build_rule_titles_map(root)
+
+    assert titles["rule_notitle"] == "rule_notitle"
+
+
+def test_escape_xml_escapes_the_five_predefined_entities():
+    assert oscap2junit.escape_xml("""<a href="x">&'</a>""") == (
+        "&lt;a href=&quot;x&quot;&gt;&amp;&apos;&lt;/a&gt;"
+    )
+
+
+# --- argument parsing -----------------------------------------------------
+
+
+def test_parse_args_defaults(monkeypatch):
+    monkeypatch.setattr(oscap2junit.sys, "argv", ["oscap2junit", "result.xml"])
+
+    args = oscap2junit.parse_args()
+
+    assert args.xccdf_result == "result.xml"
+    assert args.output_dir == "oscap-junit"
+    assert args.include_notselected is False
+    assert args.severity is None
+
+
+def test_parse_args_reads_every_option(monkeypatch):
+    monkeypatch.setattr(
+        oscap2junit.sys,
+        "argv",
+        ["oscap2junit", "r.xml", "-o", "out", "--include-notselected",
+         "--severity", "high"],
+    )
+
+    args = oscap2junit.parse_args()
+
+    assert args.output_dir == "out"
+    assert args.include_notselected is True
+    assert args.severity == "high"
+
+
+def test_parse_args_rejects_an_unknown_severity(monkeypatch):
+    monkeypatch.setattr(
+        oscap2junit.sys,
+        "argv",
+        ["oscap2junit", "r.xml", "--severity", "critical"],
+    )
+
+    with pytest.raises(SystemExit):
+        oscap2junit.parse_args()
+
+
+# --- JUnit writing --------------------------------------------------------
+
+
+def test_write_junit_maps_outcomes_onto_junit_results(tmp_path):
+    suites = {
+        "SEAPATH": [
+            {"title": "a passing rule", "idref": "r1", "result": "pass",
+             "result_raw": "pass", "severity": "high"},
+            {"title": "a failing rule", "idref": "r2", "result": "fail",
+             "result_raw": "fail", "severity": "medium"},
+            {"title": "a skipped rule", "idref": "r3", "result": "skipped",
+             "result_raw": "notapplicable", "severity": "low"},
+        ]
+    }
+    output = tmp_path / "out.xml"
+
+    oscap2junit.write_junit(suites, str(output), "hypervisor1")
+
+    cases = {c.get("name"): c for c in junit_cases(output)}
+    assert cases["a passing rule"].find("failure") is None
+    assert cases["a passing rule"].find("skipped") is None
+    failure = cases["a failing rule"].find("failure")
+    assert failure.get("type") == "SecurityPolicyViolation"
+    assert "r2" in failure.get("message")
+    assert "medium" in failure.get("message")
+    assert cases["a skipped rule"].find("skipped").get("message") == "notapplicable"
+
+
+def test_write_junit_attaches_the_rule_metadata_as_properties(tmp_path):
+    suites = {
+        "SEAPATH": [
+            {"title": "a rule", "idref": "r1", "result": "pass",
+             "result_raw": "fixed", "severity": "high"},
+        ]
+    }
+    output = tmp_path / "out.xml"
+
+    oscap2junit.write_junit(suites, str(output), "hypervisor1")
+
+    properties = {
+        p.get("name"): p.get("value")
+        for p in junit_cases(output)[0].findall(".//property")
+    }
+    assert properties == {
+        "rule_id": "r1", "raw_result": "fixed", "severity": "high",
+    }
+
+
+def test_write_junit_stamps_the_target_on_suites_and_cases(tmp_path):
+    suites = {"SEAPATH": [
+        {"title": "a rule", "idref": "r1", "result": "pass",
+         "result_raw": "pass", "severity": "high"},
+    ]}
+    output = tmp_path / "out.xml"
+
+    oscap2junit.write_junit(suites, str(output), "hypervisor1")
+
+    assert junit_cases(output)[0].get("classname") == "hypervisor1"
+    root = ET.parse(output).getroot()
+    suite = root if root.tag == "testsuite" else root.find("testsuite")
+    assert suite.get("hostname") == "hypervisor1"
+
+
+def test_write_junit_sorts_the_suites_by_name(tmp_path):
+    suites = {"zeta": [], "alpha": []}
+    output = tmp_path / "out.xml"
+
+    oscap2junit.write_junit(suites, str(output), "hypervisor1")
+
+    root = ET.parse(output).getroot()
+    names = [s.get("name") for s in root.findall(".//testsuite")]
+    assert names == ["alpha", "zeta"]
+
+
+# --- end to end -----------------------------------------------------------
+
+
+def test_main_writes_a_file_named_after_the_result_id(run_main):
+    out_dir = run_main()
+
+    # "/" and ":" are replaced so the id can be used as a file name.
+    assert (out_dir / "xccdf_result_stig_1_2.xml").is_file()
+
+
+def test_main_excludes_notselected_rules_by_default(run_main):
+    out_dir = run_main()
+
+    names = [c.get("name") for c in junit_cases(out_dir / "xccdf_result_stig_1_2.xml")]
+    assert "rule_notitle" not in names
+
+
+def test_main_can_include_notselected_rules(run_main):
+    out_dir = run_main("--include-notselected")
+
+    names = [c.get("name") for c in junit_cases(out_dir / "xccdf_result_stig_1_2.xml")]
+    assert "rule_notitle" in names
+
+
+def test_main_titles_the_cases_from_the_benchmark(run_main):
+    out_dir = run_main()
+
+    names = [c.get("name") for c in junit_cases(out_dir / "xccdf_result_stig_1_2.xml")]
+    assert "/tmp is a separate partition" in names
+    assert "nodev is set on /tmp" in names
+
+
+def test_main_falls_back_to_the_idref_for_an_unknown_rule(run_main):
+    out_dir = run_main()
+
+    names = [c.get("name") for c in junit_cases(out_dir / "xccdf_result_stig_1_2.xml")]
+    assert "rule_absent_from_benchmark" in names
+
+
+def test_main_maps_error_to_a_failure(run_main):
+    out_dir = run_main()
+
+    cases = {c.get("name"): c
+             for c in junit_cases(out_dir / "xccdf_result_stig_1_2.xml")}
+    assert cases["rule_absent_from_benchmark"].find("failure") is not None
+
+
+def test_main_treats_a_missing_result_element_as_unknown(run_main):
+    out_dir = run_main()
+
+    cases = {c.get("name"): c
+             for c in junit_cases(out_dir / "xccdf_result_stig_1_2.xml")}
+    skipped = cases["rule_no_result"].find("skipped")
+    assert skipped.get("message") == "unknown"
+
+
+def test_main_filters_on_severity(run_main):
+    out_dir = run_main("--severity", "high")
+
+    names = [c.get("name") for c in junit_cases(out_dir / "xccdf_result_stig_1_2.xml")]
+    assert "/tmp is a separate partition" in names
+    # medium and low are below the threshold, and the rule with no severity
+    # attribute at all ranks below everything.
+    assert "nodev is set on /tmp" not in names
+    assert "rule_absent_from_benchmark" not in names
+
+
+def test_main_creates_the_output_directory(run_main, tmp_path):
+    assert not (tmp_path / "junit").exists()
+
+    out_dir = run_main()
+
+    assert out_dir.is_dir()
+
+
+def test_main_reports_what_it_included_and_excluded(run_main, capsys):
+    run_main()
+
+    out = capsys.readouterr().out
+    assert "Included: 5 rules (excluded 1 'notselected')." in out
+    assert "1 passed, 2 failed, 2 skipped" in out
+
+
+def test_main_reports_the_target_and_the_rule_count(run_main, capsys):
+    run_main()
+
+    out = capsys.readouterr().out
+    assert "TestResult target: hypervisor1" in out
+    assert "Found 4 rules in benchmark." in out
+    assert "Found 6 rule-result entries." in out
+
+
+def test_main_exits_on_malformed_xml(run_main, capsys):
+    with pytest.raises(SystemExit) as excinfo:
+        run_main(content="<Benchmark><unclosed></Benchmark>")
+
+    assert excinfo.value.code == 1
+    assert "Failed to parse XML" in capsys.readouterr().err
+
+
+def test_main_exits_when_there_is_no_test_result(run_main, capsys):
+    with pytest.raises(SystemExit) as excinfo:
+        run_main(content=NO_TESTRESULT)
+
+    assert excinfo.value.code == 1
+    assert "No <TestResult> element found" in capsys.readouterr().err

--- a/tests/test_ptp_vsock.py
+++ b/tests/test_ptp_vsock.py
@@ -1,0 +1,243 @@
+# Copyright (C) 2026, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for roles/ptp_status_vsock/files/ptp_vsock.py."""
+
+import pytest
+
+from support import load_script
+
+ptp_vsock = load_script("roles/ptp_status_vsock/files/ptp_vsock.py")
+
+
+class LoopBreak(Exception):
+    """Raised from a stub to escape one of the script's infinite loops."""
+
+
+class FakeConnection:
+    def __init__(self, message):
+        self.message = message
+        self.sent = None
+        self.closed = False
+        self.recv_size = None
+
+    def recv(self, size):
+        self.recv_size = size
+        return self.message.encode("utf-8")
+
+    def sendall(self, payload):
+        self.sent = payload
+
+    def close(self):
+        self.closed = True
+
+
+class FakeSocket:
+    def __init__(self, bind_failures=0):
+        self.bind_failures = bind_failures
+        self.binds = []
+        self.listens = 0
+        self.exited = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        self.exited = True
+
+    def bind(self, address):
+        self.binds.append(address)
+        if len(self.binds) <= self.bind_failures:
+            raise OSError("address already in use")
+
+    def listen(self):
+        self.listens += 1
+
+
+class FakeSocketModule:
+    """Stands in for the socket module: AF_VSOCK is Linux-only."""
+
+    AF_VSOCK = 40
+    SOCK_STREAM = 1
+    VMADDR_CID_HOST = 2
+    error = OSError
+
+    def __init__(self, sock):
+        self._sock = sock
+        self.opened_with = None
+
+    def socket(self, family, kind):
+        self.opened_with = (family, kind)
+        return self._sock
+
+
+@pytest.fixture
+def ptp_files(tmp_path, monkeypatch):
+    """Point the two status file paths at a temporary directory."""
+    status = tmp_path / "ptp_state"
+    details = tmp_path / "ptp_status"
+    monkeypatch.setattr(ptp_vsock, "STATUS_FILE", str(status))
+    monkeypatch.setattr(ptp_vsock, "DETAILS_FILE", str(details))
+    return status, details
+
+
+@pytest.fixture
+def server(monkeypatch):
+    """Install the fake socket module and neutralise the retry sleep."""
+    slept = []
+    monkeypatch.setattr(ptp_vsock, "sleep", slept.append)
+
+    def install(bind_failures=0):
+        sock = FakeSocket(bind_failures)
+        module = FakeSocketModule(sock)
+        monkeypatch.setattr(ptp_vsock, "socket", module)
+        return module, sock, slept
+
+    return install
+
+
+# --- client handler -------------------------------------------------------
+
+
+def test_client_handler_returns_the_sync_state(ptp_files):
+    status, _ = ptp_files
+    status.write_text("1")
+    connection = FakeConnection("STATUS")
+
+    ptp_vsock.client_handler(connection)
+
+    assert connection.sent == b"1"
+
+
+def test_client_handler_returns_the_detailed_status(ptp_files):
+    _, details = ptp_files
+    details.write_text("offset -12 ns\nfreq +3\n")
+    connection = FakeConnection("DETAILS")
+
+    ptp_vsock.client_handler(connection)
+
+    assert connection.sent == b"offset -12 ns\nfreq +3\n"
+
+
+def test_client_handler_defaults_to_unsynchronised(ptp_files, capsys):
+    # The file is missing: the guest must still get an answer.
+    connection = FakeConnection("STATUS")
+
+    ptp_vsock.client_handler(connection)
+
+    assert connection.sent == b"0"
+    assert "PTP STATUS file not found" in capsys.readouterr().out
+
+
+def test_client_handler_answers_an_unknown_request(ptp_files, capsys):
+    connection = FakeConnection("WHATEVER")
+
+    ptp_vsock.client_handler(connection)
+
+    assert connection.sent == b"0"
+    assert "PTP WHATEVER file not found" in capsys.readouterr().out
+
+
+def test_client_handler_always_closes_the_connection(ptp_files):
+    status, _ = ptp_files
+    status.write_text("1")
+    connection = FakeConnection("STATUS")
+
+    ptp_vsock.client_handler(connection)
+
+    assert connection.closed is True
+    assert connection.recv_size == 2048
+
+
+# --- accept loop ----------------------------------------------------------
+
+
+def test_accept_connections_hands_the_client_to_a_thread(monkeypatch, capsys):
+    connection = FakeConnection("STATUS")
+    started = []
+    monkeypatch.setattr(
+        ptp_vsock, "start_new_thread", lambda fn, args: started.append((fn, args))
+    )
+
+    class Listening:
+        def accept(self):
+            return (connection, (3, 1024))
+
+    ptp_vsock.accept_connections(Listening())
+
+    assert started == [(ptp_vsock.client_handler, (connection,))]
+    assert "Connected to: 3:1024" in capsys.readouterr().out
+
+
+# --- server startup -------------------------------------------------------
+
+
+def test_start_server_binds_and_listens(server, monkeypatch):
+    module, sock, _ = server()
+    monkeypatch.setattr(
+        ptp_vsock, "accept_connections", lambda s: (_ for _ in ()).throw(LoopBreak)
+    )
+
+    with pytest.raises(LoopBreak):
+        ptp_vsock.start_server(2, 1234)
+
+    assert module.opened_with == (module.AF_VSOCK, module.SOCK_STREAM)
+    assert sock.binds == [(2, 1234)]
+    assert sock.listens == 1
+
+
+def test_start_server_retries_until_the_port_is_free(server, monkeypatch):
+    _, sock, slept = server(bind_failures=2)
+    monkeypatch.setattr(
+        ptp_vsock, "accept_connections", lambda s: (_ for _ in ()).throw(LoopBreak)
+    )
+
+    with pytest.raises(LoopBreak):
+        ptp_vsock.start_server(2, 1234)
+
+    assert len(sock.binds) == 3
+    assert slept == [5, 5]
+    assert sock.listens == 1
+
+
+def test_start_server_serves_connections_in_a_loop(server, monkeypatch, capsys):
+    _, sock, _ = server()
+    accepted = []
+
+    def accept(s):
+        accepted.append(s)
+        if len(accepted) == 3:
+            raise LoopBreak
+
+    monkeypatch.setattr(ptp_vsock, "accept_connections", accept)
+
+    with pytest.raises(LoopBreak):
+        ptp_vsock.start_server(2, 1234)
+
+    assert accepted == [sock, sock, sock]
+    assert "Server is listing on the port 1234..." in capsys.readouterr().out
+
+
+def test_main_serves_the_port_given_on_the_command_line(server, monkeypatch):
+    module, sock, _ = server()
+    monkeypatch.setattr(
+        ptp_vsock, "accept_connections", lambda s: (_ for _ in ()).throw(LoopBreak)
+    )
+
+    with pytest.raises(LoopBreak):
+        ptp_vsock.main(["1234"])
+
+    assert sock.binds == [(module.VMADDR_CID_HOST, 1234)]
+
+
+def test_main_falls_back_to_sys_argv(server, monkeypatch):
+    module, sock, _ = server()
+    monkeypatch.setattr(ptp_vsock.sys, "argv", ["ptp_vsock.py", "4321"])
+    monkeypatch.setattr(
+        ptp_vsock, "accept_connections", lambda s: (_ for _ in ()).throw(LoopBreak)
+    )
+
+    with pytest.raises(LoopBreak):
+        ptp_vsock.main()
+
+    assert sock.binds == [(module.VMADDR_CID_HOST, 4321)]

--- a/tests/test_remove_disk_xml.py
+++ b/tests/test_remove_disk_xml.py
@@ -1,0 +1,111 @@
+# Copyright (C) 2026, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for roles/backup_restore/files/scripts/remove_disk_xml.py."""
+
+import pytest
+
+from support import load_script
+
+remove_disk_xml = load_script(
+    "roles/backup_restore/files/scripts/remove_disk_xml.py"
+)
+
+DOMAIN_XML = """<domain type='kvm'>
+  <name>guest0</name>
+  <devices>
+    <disk type='network' device='disk'>
+      <source protocol='rbd' name='rbd/system_guest0'/>
+      <target dev='vda' bus='virtio'/>
+    </disk>
+    <disk type='network' device='disk'>
+      <source protocol='rbd' name='rbd/data_guest0_1'/>
+      <target dev='vdb' bus='virtio'/>
+    </disk>
+    <interface type='bridge'>
+      <source bridge='br0'/>
+    </interface>
+  </devices>
+</domain>
+"""
+
+DISKLESS_XML = """<domain type='kvm'>
+  <name>guest0</name>
+  <devices>
+    <interface type='bridge'>
+      <source bridge='br0'/>
+    </interface>
+  </devices>
+</domain>
+"""
+
+
+@pytest.fixture
+def xml_pair(tmp_path):
+    def make(content):
+        src = tmp_path / "domain.xml"
+        src.write_text(content)
+        return str(src), str(tmp_path / "domain-nodisk.xml")
+
+    return make
+
+
+def test_removes_every_disk_element(xml_pair):
+    src, dst = xml_pair(DOMAIN_XML)
+
+    remove_disk_xml.remove_disks(src, dst)
+
+    with open(dst) as f:
+        written = f.read()
+    assert "<disk" not in written
+
+
+def test_keeps_the_other_devices(xml_pair):
+    src, dst = xml_pair(DOMAIN_XML)
+
+    remove_disk_xml.remove_disks(src, dst)
+
+    with open(dst) as f:
+        written = f.read()
+    assert "<interface" in written
+    assert "br0" in written
+    assert "<name>guest0</name>" in written
+
+
+def test_leaves_a_diskless_domain_untouched(xml_pair):
+    src, dst = xml_pair(DISKLESS_XML)
+
+    remove_disk_xml.remove_disks(src, dst)
+
+    with open(dst) as f:
+        written = f.read()
+    assert "<interface" in written
+    assert "<disk" not in written
+
+
+def test_does_not_modify_the_source_file(xml_pair):
+    src, dst = xml_pair(DOMAIN_XML)
+
+    remove_disk_xml.remove_disks(src, dst)
+
+    with open(src) as f:
+        assert f.read() == DOMAIN_XML
+
+
+def test_main_reads_source_and_destination_from_its_argv(xml_pair):
+    src, dst = xml_pair(DOMAIN_XML)
+
+    remove_disk_xml.main([src, dst])
+
+    with open(dst) as f:
+        assert "<disk" not in f.read()
+
+
+def test_main_falls_back_to_sys_argv(xml_pair, monkeypatch):
+    src, dst = xml_pair(DOMAIN_XML)
+    monkeypatch.setattr(remove_disk_xml.sys, "argv", ["remove_disk_xml.py", src, dst])
+
+    remove_disk_xml.main()
+
+    with open(dst) as f:
+        assert "<disk" not in f.read()

--- a/tests/test_run_cyclictest.py
+++ b/tests/test_run_cyclictest.py
@@ -1,0 +1,127 @@
+# Copyright (C) 2026, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for roles/cyclictest/files/run_cyclictest.py."""
+
+import pytest
+
+from support import load_script
+
+run_cyclictest = load_script("roles/cyclictest/files/run_cyclictest.py")
+
+
+class FakeCompletedProcess:
+    def __init__(self, stdout=""):
+        self.stdout = stdout
+
+
+@pytest.fixture
+def fake_run(monkeypatch):
+    def install(stdout=""):
+        recorded = {}
+
+        def _run(argv, **kwargs):
+            recorded["argv"] = argv
+            recorded["kwargs"] = kwargs
+            return FakeCompletedProcess(stdout)
+
+        monkeypatch.setattr(run_cyclictest.subprocess, "run", _run)
+        return recorded
+
+    return install
+
+
+def test_parse_args_defaults():
+    args = run_cyclictest.parse_args(["/tmp/out.txt"])
+
+    assert args.output_file == "/tmp/out.txt"
+    assert args.duration == 20
+    assert args.priority == 90
+    assert args.affinity == "smp"
+
+
+def test_parse_args_reads_every_option():
+    args = run_cyclictest.parse_args(
+        ["/tmp/out.txt", "-d", "60", "-p", "80", "-a", "2-5"]
+    )
+
+    assert args.duration == 60
+    assert args.priority == 80
+    assert args.affinity == "2-5"
+
+
+def test_parse_args_accepts_a_bare_affinity_flag():
+    # -a without a value means "pin the threads, let cyclictest choose".
+    args = run_cyclictest.parse_args(["/tmp/out.txt", "-a"])
+
+    assert args.affinity == ""
+
+
+def test_parse_args_requires_an_output_file():
+    with pytest.raises(SystemExit):
+        run_cyclictest.parse_args([])
+
+
+def test_build_command_defaults_to_the_smp_flag():
+    args = run_cyclictest.parse_args(["/tmp/out.txt"])
+
+    assert run_cyclictest.build_command(args) == (
+        "cyclictest -l100000 -m -S -p90 -i200 -h400 -q"
+    )
+
+
+def test_build_command_pins_the_threads_when_given_an_affinity():
+    args = run_cyclictest.parse_args(["/tmp/out.txt", "-a", "2-5"])
+
+    assert "-a 2-5 -t" in run_cyclictest.build_command(args)
+    assert "-S" not in run_cyclictest.build_command(args)
+
+
+def test_build_command_treats_a_bare_affinity_as_non_smp():
+    args = run_cyclictest.parse_args(["/tmp/out.txt", "-a"])
+
+    assert "-a  -t" in run_cyclictest.build_command(args)
+
+
+def test_build_command_derives_the_cycle_count_from_the_duration():
+    args = run_cyclictest.parse_args(["/tmp/out.txt", "-d", "1"])
+
+    # One second at a 200 us interval is 5000 cycles.
+    assert "-l5000 " in run_cyclictest.build_command(args)
+
+
+def test_build_command_carries_the_priority():
+    args = run_cyclictest.parse_args(["/tmp/out.txt", "-p", "42"])
+
+    assert "-p42" in run_cyclictest.build_command(args)
+
+
+def test_main_writes_the_command_then_its_output(fake_run, tmp_path):
+    fake_run("T: 0 histogram\n")
+    output = tmp_path / "result.txt"
+
+    run_cyclictest.main([str(output)])
+
+    assert output.read_text() == (
+        "cyclictest -l100000 -m -S -p90 -i200 -h400 -qT: 0 histogram\n"
+    )
+
+
+def test_main_runs_cyclictest_with_the_built_argument_list(fake_run, tmp_path):
+    recorded = fake_run()
+
+    run_cyclictest.main([str(tmp_path / "result.txt"), "-a", "2-5"])
+
+    assert recorded["argv"][0] == "cyclictest"
+    assert "-a" in recorded["argv"]
+    assert "2-5" in recorded["argv"]
+    assert recorded["kwargs"]["capture_output"] is True
+    assert recorded["kwargs"]["text"] is True
+
+
+def test_main_announces_the_command(fake_run, tmp_path, capsys):
+    fake_run()
+
+    run_cyclictest.main([str(tmp_path / "result.txt")])
+
+    assert "Will run command: cyclictest" in capsys.readouterr().out

--- a/tests/test_snmp_getdata.py
+++ b/tests/test_snmp_getdata.py
@@ -1,0 +1,544 @@
+# Copyright (C) 2026, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for roles/snmp/files/snmp_getdata.py."""
+
+import io
+import json
+
+import pytest
+
+from support import load_script
+
+snmp = load_script("roles/snmp/files/snmp_getdata.py")
+
+CRM_XML = """<crm_mon>
+  <summary><stack type="corosync"/></summary>
+  <nodes><node name="hyp1" online="true"/></nodes>
+</crm_mon>"""
+
+
+class FakeCommands:
+    """Answer run_command() from substring rules, recording what was asked."""
+
+    def __init__(self, rules=(), default="line one\nline two\n"):
+        self.rules = list(rules)
+        self.default = default
+        self.commands = []
+
+    def __call__(self, command):
+        self.commands.append(command)
+        for needle, response in self.rules:
+            if needle in command:
+                return response
+        return self.default
+
+    def asked(self, needle):
+        return [c for c in self.commands if needle in c]
+
+
+def raid_rules(temperature="41\n", warnings="0\n", total="0\n",
+               devices="Present\n", per_device="0\n"):
+    """
+    Rules for the five arcconf calls collect_raid() makes.
+
+    They are ordered most specific first: all five share the "GETCONFIG 1"
+    prefix and three of them grep for the same S.M.A.R.T. string.
+    """
+    return [
+        ("sum +=", total),
+        ("GETCONFIG 1 PD 0", per_device),
+        ("GETCONFIG 1 AR", devices),
+        ("Current Temperature", temperature),
+        ("GETCONFIG 1  |", warnings),
+    ]
+
+
+def monoline_rules(smart_failures="0\n", lvs_sumup=""):
+    """Rules for the two collect_monolines() calls that steer disk status."""
+    return [
+        ("wc -l", smart_failures),
+        ("select( .lv_health_status", lvs_sumup),
+    ]
+
+
+@pytest.fixture
+def out(monkeypatch):
+    """Capture everything the script writes to its output stream."""
+    sink = io.StringIO()
+    monkeypatch.setattr(snmp, "f", sink)
+    return sink
+
+
+@pytest.fixture
+def commands(monkeypatch):
+    def install(rules=(), default="line one\nline two\n"):
+        fake = FakeCommands(rules, default)
+        monkeypatch.setattr(snmp, "run_command", fake)
+        return fake
+
+    return install
+
+
+@pytest.fixture
+def status():
+    return snmp.DiskStatus()
+
+
+def oids(sink):
+    """Parse the written "oid:value" lines back into a mapping."""
+    parsed = {}
+    for line in sink.getvalue().splitlines():
+        oid, _, value = line.partition(":")
+        parsed[oid] = value
+    return parsed
+
+
+# --- primitives -----------------------------------------------------------
+
+
+def test_run_command_decodes_the_shell_output(monkeypatch):
+    recorded = {}
+
+    def check_output(command, **kwargs):
+        recorded.update(kwargs, command=command)
+        return b"output\n"
+
+    monkeypatch.setattr(snmp.subprocess, "check_output", check_output)
+
+    assert snmp.run_command("echo output") == "output\n"
+    assert recorded["shell"] is True
+    assert recorded["executable"] == "/bin/bash"
+
+
+def test_writeline_joins_the_oid_and_the_value(out):
+    snmp.writeline(".1.2", "a value")
+
+    assert out.getvalue() == ".1.2:a value\n"
+
+
+def test_singlelinetooid_trims_and_suffixes_the_oid(out):
+    snmp.singlelinetooid(".2.1", "a title", "   PASSED  ")
+
+    assert out.getvalue() == ".2.1.0:PASSED\n"
+
+
+def test_multilinetooid_numbers_the_lines_from_one(out):
+    snmp.multilinetooid(".1.1", "a title", "  first\nsecond  \n")
+
+    assert oids(out) == {".1.1.1": "first", ".1.1.2": "second", ".1.1.0": "2"}
+
+
+def test_multilinetooid_records_a_zero_count_for_no_output(out):
+    snmp.multilinetooid(".1.1", "a title", "")
+
+    assert oids(out) == {".1.1.0": "0"}
+
+
+def test_dictarrayoid_writes_the_column_names_then_the_rows(out):
+    rows = [
+        {"lv_name": "root", "lv_health_status": ""},
+        {"lv_name": "data", "lv_health_status": "partial"},
+    ]
+
+    snmp.dictarrayoid(".2.5", "a title", rows)
+
+    assert oids(out) == {
+        # The first row only names the columns.
+        ".2.5.0.0": "lv_name",
+        ".2.5.0.1": "lv_health_status",
+        ".2.5.1.0": "data",
+        ".2.5.1.1": "partial",
+    }
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        ("/dev/null", True),
+        ("/etc/hosts", False),
+        ("/dev/there-is-no-such-device", False),
+    ],
+)
+def test_exist_and_is_character(path, expected):
+    assert snmp.exist_and_is_character(path) is expected
+
+
+def test_disk_status_starts_clean(status):
+    assert status.globalreplacedisk == "OK"
+    assert status.replacedisk == ["OK", "OK", "OK", "OK"]
+
+
+# --- IPMI -----------------------------------------------------------------
+
+
+def test_collect_ipmi_does_nothing_without_a_bmc(out, commands, monkeypatch):
+    fake = commands()
+    monkeypatch.setattr(snmp, "exist_and_is_character", lambda path: False)
+
+    snmp.collect_ipmi()
+
+    assert fake.commands == []
+    assert out.getvalue() == ""
+
+
+@pytest.mark.parametrize(
+    "device", ["/dev/ipmi0", "/dev/ipmi/0", "/dev/ipmidev/0"]
+)
+def test_collect_ipmi_accepts_any_of_the_bmc_device_names(
+    out, commands, monkeypatch, device
+):
+    commands()
+    monkeypatch.setattr(snmp, "exist_and_is_character", lambda path: path == device)
+
+    snmp.collect_ipmi()
+
+    assert oids(out)[".4.1.0"] == "2"
+
+
+def test_collect_ipmi_reads_the_four_sensor_views(out, commands, monkeypatch):
+    fake = commands()
+    monkeypatch.setattr(snmp, "exist_and_is_character", lambda path: True)
+
+    snmp.collect_ipmi()
+
+    assert len(fake.asked("ipmitool")) == 4
+    assert fake.asked("sensor | ")
+    assert fake.asked("sensor -v")
+    assert fake.asked("sdr list | ")
+    assert fake.asked("sdr list -v")
+    assert set(oids(out)) >= {".4.1.0", ".4.2.0", ".4.3.0", ".4.4.0"}
+
+
+# --- RAID -----------------------------------------------------------------
+
+
+@pytest.fixture
+def with_arcconf(monkeypatch):
+    def install(present=True):
+        monkeypatch.setattr(snmp.os.path, "isfile", lambda path: present)
+
+    return install
+
+
+def test_collect_raid_does_nothing_without_a_controller(
+    out, commands, with_arcconf, status
+):
+    fake = commands()
+    with_arcconf(False)
+
+    snmp.collect_raid(status)
+
+    assert fake.commands == []
+    assert out.getvalue() == ""
+
+
+def test_collect_raid_records_the_disk_temperatures(
+    out, commands, with_arcconf, status
+):
+    commands(rules=raid_rules(temperature="41\n 42 \n"))
+    with_arcconf()
+
+    snmp.collect_raid(status)
+
+    written = oids(out)
+    assert written[".3.1.1.0"] == "41"
+    assert written[".3.1.2.0"] == "42"
+
+
+def test_collect_raid_leaves_healthy_disks_alone(
+    out, commands, with_arcconf, status
+):
+    commands(rules=raid_rules(warnings="0\n0\n", devices="Present\nPresent\n"))
+    with_arcconf()
+
+    snmp.collect_raid(status)
+
+    assert status.replacedisk == ["OK", "OK", "OK", "OK"]
+    assert status.globalreplacedisk == "OK"
+
+
+def test_collect_raid_flags_the_disk_that_raised_smart_warnings(
+    out, commands, with_arcconf, status
+):
+    commands(rules=raid_rules(warnings="0\n3\n", devices="Present\nPresent\n"))
+    with_arcconf()
+
+    snmp.collect_raid(status)
+
+    assert status.replacedisk[1] == "RAID SMART Warnings on disk2"
+    assert status.globalreplacedisk == "RAID SMART Warnings on one disk"
+
+
+@pytest.mark.parametrize(
+    "total,expected",
+    [
+        ("0\n", "OK"),
+        ("\n", "OK"),
+        ("5\n", "RAID SMART Warnings on one disk"),
+    ],
+)
+def test_collect_raid_reads_the_total_smart_warning_count(
+    out, commands, with_arcconf, status, total, expected
+):
+    commands(rules=raid_rules(total=total))
+    with_arcconf()
+
+    snmp.collect_raid(status)
+
+    assert status.globalreplacedisk == expected
+
+
+def test_collect_raid_flags_a_missing_array_device(
+    out, commands, with_arcconf, status
+):
+    commands(rules=raid_rules(devices="Present\nMissing\n"))
+    with_arcconf()
+
+    snmp.collect_raid(status)
+
+    assert status.replacedisk[1] == 1
+
+
+@pytest.mark.parametrize("warnings,flagged", [("0\n", False), ("2\n", True),
+                                              ("\n", False)])
+def test_collect_raid_checks_each_physical_device(
+    out, commands, with_arcconf, status, warnings, flagged
+):
+    commands(rules=raid_rules(per_device=warnings))
+    with_arcconf()
+
+    snmp.collect_raid(status)
+
+    assert (status.replacedisk == [1, 1, 1, 1]) is flagged
+    assert oids(out)[".3.5.1.1.0"] == warnings.strip()
+
+
+# --- SMART health ---------------------------------------------------------
+
+
+def test_collect_smart_health_probes_the_four_sata_disks(out, commands, status):
+    fake = commands(default="PASSED\n")
+
+    snmp.collect_smart_health(status)
+
+    assert len(fake.asked("smartctl -H /dev/sd")) == 4
+    assert set(oids(out)) == {".2.1.0", ".2.2.0", ".2.3.0", ".2.4.0"}
+    assert status.replacedisk == ["OK", "OK", "OK", "OK"]
+
+
+def test_collect_smart_health_flags_a_disk_that_did_not_pass(
+    out, commands, status
+):
+    commands(rules=[("/dev/sdb", "FAILED!\n")], default="PASSED\n")
+
+    snmp.collect_smart_health(status)
+
+    assert status.replacedisk == ["OK", 1, "OK", "OK"]
+
+
+def test_collect_smart_health_ignores_a_disk_that_is_not_there(
+    out, commands, status
+):
+    # An absent disk produces no output at all, which is not a failure.
+    commands(default="\n")
+
+    snmp.collect_smart_health(status)
+
+    assert status.replacedisk == ["OK", "OK", "OK", "OK"]
+    assert oids(out)[".2.1.0"] == ""
+
+
+# --- LVM ------------------------------------------------------------------
+
+
+def test_collect_lvs_writes_the_logical_volume_table(out, commands):
+    commands(default=json.dumps([
+        {"lv_name": "root", "lv_health_status": ""},
+        {"lv_name": "data", "lv_health_status": "partial"},
+    ]))
+
+    snmp.collect_lvs()
+
+    written = oids(out)
+    assert written[".2.5.0.0"] == "lv_name"
+    assert written[".2.5.1.1"] == "partial"
+
+
+# --- monoline values ------------------------------------------------------
+
+
+def test_collect_monolines_writes_one_value_per_oid(out, commands, status):
+    commands(rules=monoline_rules(), default="value\n")
+
+    snmp.collect_monolines(status)
+
+    assert set(oids(out)) == {".2.6.0", ".2.7.0", ".2.8.0", ".2.9.0", ".2.10.0"}
+
+
+def test_collect_monolines_reports_healthy_smart_disks(out, commands, status):
+    commands(rules=monoline_rules(), default="value\n")
+
+    snmp.collect_monolines(status)
+
+    assert oids(out)[".2.6.0"] == "SMARTOK"
+    assert status.globalreplacedisk == "OK"
+
+
+def test_collect_monolines_reports_failing_smart_disks(out, commands, status):
+    commands(rules=monoline_rules(smart_failures="2\n"), default="value\n")
+
+    snmp.collect_monolines(status)
+
+    assert oids(out)[".2.6.0"] == "SMARTPROBLEM"
+    assert status.globalreplacedisk == "SMART tests not passed"
+
+
+def test_collect_monolines_reports_a_clean_lvm(out, commands, status):
+    commands(rules=monoline_rules(), default="value\n")
+
+    snmp.collect_monolines(status)
+
+    assert oids(out)[".2.9.0"] == "NO LVS PROBLEM"
+    assert status.globalreplacedisk == "OK"
+
+
+def test_collect_monolines_reports_an_unhealthy_lvm(out, commands, status):
+    commands(rules=monoline_rules(lvs_sumup='{"lv_name":"data"}'),
+             default="value\n")
+
+    snmp.collect_monolines(status)
+
+    assert oids(out)[".2.9.0"] == 'LVS PROBLEM: {"lv_name":"data"}'
+    assert status.globalreplacedisk == "LVS health not OK"
+
+
+def test_collect_monolines_reads_the_ceph_health(out, commands, status):
+    fake = commands(rules=monoline_rules() + [("health.status", "HEALTH_OK\n")],
+                    default="value\n")
+
+    snmp.collect_monolines(status)
+
+    assert fake.asked("ceph status --format json-pretty")
+    assert oids(out)[".2.10.0"] == "HEALTH_OK"
+
+
+# --- multiline values -----------------------------------------------------
+
+
+def test_collect_multilines_writes_every_section(out, commands):
+    commands(rules=[("crm status --as-xml", CRM_XML)])
+
+    snmp.collect_multilines()
+
+    written = oids(out)
+    # .1.1 to .1.10 are plain multiline dumps; .1.11 is replaced by the two
+    # parsed crm sub-trees.
+    for i in range(1, 11):
+        assert ".1.{}.0".format(i) in written
+    assert ".1.11.0" not in written
+
+
+def test_collect_multilines_runs_the_expected_tools(out, commands):
+    fake = commands(rules=[("crm status --as-xml", CRM_XML)])
+
+    snmp.collect_multilines()
+
+    assert fake.asked("crm status")
+    assert fake.asked("virsh --connect qemu:///system domstats")
+    assert fake.asked("dommemstat")
+    assert fake.asked("ceph status")
+    assert fake.asked("virt-df.sh")
+    assert fake.asked("virsh -c qemu:///system list --all")
+    assert fake.asked("Temperature_Celsius")
+    assert fake.asked("udevadm")
+    assert fake.asked("lvs -a -o +devices,lv_health_status")
+
+
+def test_collect_multilines_splits_the_crm_status_into_summary_and_nodes(
+    out, commands
+):
+    commands(rules=[("crm status --as-xml", CRM_XML)])
+
+    snmp.collect_multilines()
+
+    written = oids(out)
+    assert json.loads(written[".1.11.0.1.1"]) == {"stack": {"type": "corosync"}}
+    assert json.loads(written[".1.11.0.2.1"]) == {
+        "node": {"name": "hyp1", "online": "true"}
+    }
+
+
+def test_collect_multilines_survives_an_unparsable_crm_status(out, commands):
+    commands(rules=[("crm status --as-xml", "<crm_mon><unclosed>"),
+                    ("lvs -a -o +devices,lv_health_status", "lvs output\n")])
+
+    snmp.collect_multilines()
+
+    written = oids(out)
+    assert ".1.11.0.1.1" not in written
+    # Known defect: on a parse error the loop falls through to the generic
+    # write with `data` still holding the previous iteration's output, so
+    # .1.11 repeats the lvs status instead of reporting the crm one.
+    assert written[".1.11.1"] == "lvs output"
+
+
+# --- disk replacement summary ---------------------------------------------
+
+
+def test_write_disk_replacement_status_reports_healthy_disks(out, status):
+    snmp.write_disk_replacement_status(status)
+
+    written = oids(out)
+    assert [written[".5.{}.0".format(i)] for i in range(1, 5)] == ["OK"] * 4
+    assert written[".5.5.0"] == "OK"
+
+
+def test_write_disk_replacement_status_keeps_the_raid_message(out, status):
+    status.replacedisk[0] = "RAID SMART Warnings on disk1"
+    status.globalreplacedisk = "RAID SMART Warnings on one disk"
+
+    snmp.write_disk_replacement_status(status)
+
+    written = oids(out)
+    assert written[".5.1.0"] == "RAID SMART Warnings on disk1"
+    assert written[".5.5.0"] == "RAID SMART Warnings on one disk"
+
+
+def test_write_disk_replacement_status_breaks_on_a_flagged_disk(out, status):
+    # Known defect: the SMART and array-device checks flag a disk with the
+    # integer 1, and singlelinetooid() calls lstrip() on the value. The whole
+    # collection therefore dies exactly when a disk starts failing, and
+    # /tmp/snmpdata.txt is left holding the last healthy snapshot.
+    status.replacedisk[2] = 1
+
+    with pytest.raises(AttributeError):
+        snmp.write_disk_replacement_status(status)
+
+    assert status.globalreplacedisk == "Problem on one disk"
+
+
+# --- entry point ----------------------------------------------------------
+
+
+def test_main_publishes_the_data_file_atomically(
+    monkeypatch, commands, with_arcconf, tmp_path
+):
+    commands(rules=[("crm status --as-xml", CRM_XML),
+                    ("jq -c .report[].lv", json.dumps([{"lv_name": "root"}]))]
+                   + monoline_rules(),
+             default="PASSED\n")
+    with_arcconf(False)
+    monkeypatch.setattr(snmp, "exist_and_is_character", lambda path: False)
+    tmp_file = tmp_path / "snmpdata_tmp.txt"
+    final = tmp_path / "snmpdata.txt"
+    monkeypatch.setattr(snmp, "snmpdata_tmp", str(tmp_file))
+    monkeypatch.setattr(snmp, "snmpdata", str(final))
+
+    snmp.main()
+
+    # The collector writes to a temporary file and renames it into place, so
+    # snmpd never reads a half-written table.
+    assert not tmp_file.exists()
+    assert final.read_text().startswith(".2.1.0:PASSED")
+    assert ".5.5.0:OK" in final.read_text()

--- a/tests/test_snmp_getdata.py
+++ b/tests/test_snmp_getdata.py
@@ -505,17 +505,31 @@ def test_write_disk_replacement_status_keeps_the_raid_message(out, status):
     assert written[".5.5.0"] == "RAID SMART Warnings on one disk"
 
 
-def test_write_disk_replacement_status_breaks_on_a_flagged_disk(out, status):
-    # Known defect: the SMART and array-device checks flag a disk with the
-    # integer 1, and singlelinetooid() calls lstrip() on the value. The whole
-    # collection therefore dies exactly when a disk starts failing, and
-    # /tmp/snmpdata.txt is left holding the last healthy snapshot.
+def test_write_disk_replacement_status_reports_a_flagged_disk(out, status):
+    # The SMART and array-device checks flag a disk with the integer 1, where
+    # the RAID check stores a message; both have to reach the OID tree.
     status.replacedisk[2] = 1
 
-    with pytest.raises(AttributeError):
-        snmp.write_disk_replacement_status(status)
+    snmp.write_disk_replacement_status(status)
 
-    assert status.globalreplacedisk == "Problem on one disk"
+    written = oids(out)
+    assert written[".5.3.0"] == "1"
+    assert written[".5.1.0"] == "OK"
+    assert written[".5.5.0"] == "Problem on one disk"
+
+
+def test_a_failing_disk_still_gets_published(out, commands, status):
+    # The whole point of the collector: a disk going bad must be reported,
+    # not crash the run and leave snmpd on the last healthy snapshot.
+    commands(rules=[("/dev/sdc", "FAILED!\n")], default="PASSED\n")
+
+    snmp.collect_smart_health(status)
+    snmp.write_disk_replacement_status(status)
+
+    written = oids(out)
+    assert written[".2.3.0"] == "FAILED!"
+    assert written[".5.3.0"] == "1"
+    assert written[".5.5.0"] == "Problem on one disk"
 
 
 # --- entry point ----------------------------------------------------------

--- a/tests/test_snmp_getdata.py
+++ b/tests/test_snmp_getdata.py
@@ -477,10 +477,10 @@ def test_collect_multilines_survives_an_unparsable_crm_status(out, commands):
 
     written = oids(out)
     assert ".1.11.0.1.1" not in written
-    # Known defect: on a parse error the loop falls through to the generic
-    # write with `data` still holding the previous iteration's output, so
-    # .1.11 repeats the lvs status instead of reporting the crm one.
-    assert written[".1.11.1"] == "lvs output"
+    # The raw crm output is reported instead of the parsed sub-trees, and in
+    # particular instead of the lvs status the previous iteration produced.
+    assert written[".1.11.1"] == "<crm_mon><unclosed>"
+    assert written[".1.10.1"] == "lvs output"
 
 
 # --- disk replacement summary ---------------------------------------------

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,23 @@
 [tox]
 env_list =
+    unit
     molecule-roles
     molecule-playbooks
 
 labels =
     molecule = molecule-roles, molecule-playbooks
+
+[testenv:unit]
+description = Run the Python unit tests with statement and branch coverage
+deps =
+    -r unit_requirements.txt
+commands =
+    pytest tests/ {posargs} \
+        --cov \
+        --cov-report=term-missing \
+        --cov-report=xml:{toxinidir}/coverage.xml \
+        --cov-report=html:{toxinidir}/htmlcov \
+        --cov-fail-under={env:COV_FAIL_UNDER:30}
 
 [testenv:molecule-roles]
 description = Run Molecule tests for all roles that have molecule/<scenario>/

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands =
         --cov-report=term-missing \
         --cov-report=xml:{toxinidir}/coverage.xml \
         --cov-report=html:{toxinidir}/htmlcov \
-        --cov-fail-under={env:COV_FAIL_UNDER:65}
+        --cov-fail-under={env:COV_FAIL_UNDER:99}
 
 [testenv:molecule-roles]
 description = Run Molecule tests for all roles that have molecule/<scenario>/

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,11 @@ labels =
 
 [testenv:unit]
 description = Run the Python unit tests with statement and branch coverage
+# The suite imports the scripts from where they live, which would otherwise
+# leave a __pycache__ inside the role files/ directories they are deployed
+# from.
+setenv =
+    PYTHONDONTWRITEBYTECODE = 1
 deps =
     -r unit_requirements.txt
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands =
         --cov-report=term-missing \
         --cov-report=xml:{toxinidir}/coverage.xml \
         --cov-report=html:{toxinidir}/htmlcov \
-        --cov-fail-under={env:COV_FAIL_UNDER:41}
+        --cov-fail-under={env:COV_FAIL_UNDER:65}
 
 [testenv:molecule-roles]
 description = Run Molecule tests for all roles that have molecule/<scenario>/

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands =
         --cov-report=term-missing \
         --cov-report=xml:{toxinidir}/coverage.xml \
         --cov-report=html:{toxinidir}/htmlcov \
-        --cov-fail-under={env:COV_FAIL_UNDER:30}
+        --cov-fail-under={env:COV_FAIL_UNDER:41}
 
 [testenv:molecule-roles]
 description = Run Molecule tests for all roles that have molecule/<scenario>/

--- a/unit_requirements.txt
+++ b/unit_requirements.txt
@@ -1,0 +1,14 @@
+# Copyright (C) 2026, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+#
+# Dependencies for the Python unit test suite (tox -e unit).
+# Third-party imports of the scripts under test are listed here so the tests
+# exercise the real library rather than a stub. The ones that cannot be
+# installed from PyPI (rados, rbd, vm_manager, ansible) are stubbed in
+# tests/support.py instead.
+
+pytest
+pytest-cov
+junitparser
+lxml
+xmltodict


### PR DESCRIPTION
The repository shipped 680 statements of Python (the `cluster_vm` module, the role `files/` payloads, the OpenSCAP report converter) with no test of any kind, and no way to notice: `tox.ini` declared molecule environments only.

Coverage of that Python goes from **0% to 100% of statements and 98.7% of branches**, over 209 tests. The three remaining partial branches are the unreachable fall-through of the last `elif` in the three index-driven dispatch loops of `snmp_getdata.py`.

## What lands

- `.coveragerc` scopes the measurement and reports every file it finds, so a new untested script shows up at 0% instead of not showing up at all. Omitted: the git submodules, the ctypes probes under `cukinia-tests`, the three-line `vmmgrapi` WSGI entrypoint.
- A `tox -e unit` environment and a `ci-unit.yml` workflow calling it, wired between qa and molecule. The job publishes the per-file table to the step summary and keeps `coverage.xml` and `htmlcov/` as artefacts. `--cov-fail-under` is a ratchet: raise it, never lower it.
- Tests for all nine files, `tests/README.md` for the conventions.

Five scripts did their work at import time and could not be exercised at all. They now expose a `main()` behind the usual `__main__` guard, with the same command line: the cron entry, the systemd unit and the calling shell scripts are unaffected.

`snmp_getdata.py` was the big one, 219 statements entirely at module level. Its collection is split along the boundaries the OID tree already had. The restructuring was checked by running the old and new versions side by side over nine hardware scenarios and diffing everything written: identical byte for byte.

## Two production bugs, fixed in their own commits

Both were found by that differential harness, not by reading the code.

- `snmp_getdata` flagged a suspect disk with the integer `1`, then called `lstrip()` on it. The collection died **exactly when a disk started failing**, and since it runs from cron every five minutes, snmpd kept serving the last snapshot taken while every disk was healthy. The monitoring went blind at the worst moment, silently.
- On an unparsable `crm status --as-xml`, OID `.1.11` repeated the lvs status of `.1.10` instead of reporting the crm failure.

## Scope

Not addressed here: **the Ansible roles and playbooks**, which are most of what this repository ships. They stay covered by molecule (3 roles out of 56 have a scenario) and by the integration jobs. There is no established free tool reporting statement coverage over Ansible tasks, which is the argument to make in the badge justification rather than something to fix in code.
