### PR TITLE
timemaster: let chrony step the clock without a step limit

### DIFF
--- a/roles/timemaster/templates/timemaster.conf.j2
+++ b/roles/timemaster/templates/timemaster.conf.j2
@@ -28,6 +28,14 @@ include {{ timemaster_path_chrony_conf }}
 {% else %}server {{ line }} iburst maxsamples 10 minsamples 10 maxpoll 6 minpoll 6
 {% endif %}{% endfor %}
 {% endif %}
+# Step the clock whenever the offset exceeds 1 second, with no limit on the
+# number of steps. A grand master clock with no GPS fix yet announces 1970 over
+# PTP at boot, and chrony steps to it. The distribution default (makestep 1 3)
+# would then let the limit be reached before the grand master converges, and
+# chrony would only slew back, taking hours to recover. The same applies after
+# a grand master crash. This directive comes after the include above so that it
+# overrides the value shipped in {{ timemaster_path_chrony_conf }}.
+makestep 1 -1
 
 [ntp.conf]
 includefile /etc/ntp.conf


### PR DESCRIPTION
A grand master clock with no GPS fix yet can announce 1970 over PTP. At boot chrony believes it and steps the clock back to 1970. When the GMC converges a few minutes later, chrony has already used up its step budget: the distribution `chrony.conf` ships `makestep 1 3`. The remaining offset is only slewed, and a 56 year gap never closes. Same story after a GMC crash and restart.

This sets `makestep 1 -1` in the `[chrony.conf]` section of `timemaster.conf.j2`. Steps stay gated on an offset above one second, but their number per run is no longer capped.

The directive is placed after the `include` of the distribution `chrony.conf` so it overrides the value from there (chrony keeps the last occurrence it parses), and outside the `ntp_servers` conditional so PTP-only nodes get it too.

Tradeoff worth stating: an unlimited step count means a misbehaving source could step the clock repeatedly, which breaks monotonic assumptions in anything running on the node. PTP converges in seconds and stays stable, so in practice these steps happen at boot and after a GMC failure, which are exactly the moments where stepping is the right answer.

PR #1000 ! Wow—Just 24 to go until a big round-number milestone! (ht xkcd)