### PR TITLE
inventories/examples: add SSH private key option for ansible connection

### DIFF
--- a/inventories/examples/seapath-cluster.yaml
+++ b/inventories/examples/seapath-cluster.yaml
@@ -47,6 +47,8 @@ all:
     ansible_python_interpreter: /usr/bin/python3
     ansible_remote_tmp: /tmp/.ansible/tmp
     ansible_user: ansible
+    # Uncomnent this line if you use a no standard ssh private key
+    # ansible_ssh_private_key_file: "~/.ssh/seapath-v2.0.0-artifacts-key"
     ip_addr: "{{ ansible_host }}"
     hostname: "{{ inventory_hostname }}"
     apply_network_config: true

--- a/inventories/examples/seapath-standalone.yaml
+++ b/inventories/examples/seapath-standalone.yaml
@@ -31,6 +31,8 @@ all:
       ansible_python_interpreter: /usr/bin/python3
       ansible_remote_tmp: /tmp/.ansible/tmp
       ansible_user: ansible
+      # Uncomnent this line if you use a no standard ssh private key
+      # ansible_ssh_private_key_file: "~/.ssh/seapath-v2.0.0-artifacts-key"
 
       # Hardening Debian specific
       # On Debian you can defined the Grub (Bootloader) protected password here

--- a/inventories/examples/seapath-vm-deployement.yaml
+++ b/inventories/examples/seapath-vm-deployement.yaml
@@ -50,3 +50,5 @@ VMs:
 
   vars:
     ansible_user: ansible # Only for connection test
+    # Uncomnent this line if you use a no standard ssh private key
+    # ansible_ssh_private_key_file: "~/.ssh/seapath-v2.0.0-artifacts-key"


### PR DESCRIPTION
Add a commented line in the example inventories to allow users to specify a custom SSH private key for Ansible connections. This is useful for users who do not use the default SSH key and need to provide a specific key for connecting to their hosts.