### PR TITLE
galaxy: ship the vendored submodules in the collection

### DIFF
--- a/.github/workflows/galaxy-publish.yml
+++ b/.github/workflows/galaxy-publish.yml
@@ -29,6 +29,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # The roles ship the submodule sources they install on the hosts, so
+          # the build needs them checked out. Recursive because cukinia has a
+          # submodule of its own.
+          submodules: recursive
+
+      - name: Check the submodules are populated
+        run: |
+          status=0
+          while read -r path; do
+            if [ -z "$(ls -A "${path}" 2>/dev/null)" ]; then
+              echo "::error::Submodule ${path} is empty, the collection would ship a broken role."
+              status=1
+            fi
+          done < <(git config --file .gitmodules --get-regexp '\.path$' | cut -d ' ' -f 2)
+          exit "${status}"
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -27,6 +27,9 @@ dependencies:
 build_ignore:
   - .github
   - .gitignore
+  # Gitlink files of the vendored submodules: ansible-galaxy only drops .git
+  # when it is a directory at the collection root.
+  - "**/.git"
   - .pre-commit-config.yaml
   - .ansible-lint.yml
   - .yamllint


### PR DESCRIPTION
`deploy_vm_manager`, `deploy_cukinia` and `deploy_python3_setup_ovs` synchronize their sources from the role's `files/` directory and install them on the hosts. Those sources are git submodules, and the publish workflow checked the repository out without them. The collections uploaded to Galaxy as v2.0.0 and v2.0.1 therefore carry three empty directories, and each of those roles fails at its `pip install` step for anyone installing from Galaxy rather than from a git clone.

fix:

`ansible-galaxy collection build` walks the working tree rather than the git index, so simply checking the submodules out is enough for their content to land in the tarball. No packaging change is needed beyond that.

- `submodules: recursive` on the checkout step. Recursive because cukinia has a submodule of its own (`bats/bats-mock`).
- A guard step that reads the submodule paths from `.gitmodules` and fails the workflow if any of them is empty, so a future regression stops the build instead of publishing a broken collection.
- `"**/.git"` added to `build_ignore`. `ansible-galaxy` only drops `.git` when it is a directory at the collection root, so the submodules' `gitdir:` stub files were shipped as well.