### PR TITLE
ci-yocto: disable SV latency tests on PR runs

### DIFF
--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -71,6 +71,20 @@ on:
         description: |
           Don't expect the test playbooks to run Cyclictests. Can be overriden
           per host with the 'skip_cyclictest' Ansible variable.
+      do_latency_tests:
+        type: boolean
+        default: true
+        description: |
+          Whether to run the SV (Sampled Values) latency tests on the VMs.
+          Those tests depend on an accurate SV publisher, which is not
+          currently the case, so they can be flaky. Disable them for CI
+          runs on PRs.
+      pcap_loop:
+        type: number
+        default: 10
+        description: |
+          Number of times the SV pcap is played during the latency tests.
+          A higher value gives more meaningful results but takes more time.
 
 env:
   # TODO make this better
@@ -79,7 +93,7 @@ env:
   CYCLICTEST_INTERVAL: 200 # hardcoded in the cyclictest role for now
   LATENCY_MAXIMAL_HYP: 100
   LATENCY_MAXIMAL_VM: 100
-  PCAP_LOOP: 10
+  PCAP_LOOP: ${{ inputs.pcap_loop }}
   PCAP: "/seapath-ci/pcaps/8_streams_4000_SV.pcap"
 
 jobs:
@@ -260,7 +274,14 @@ jobs:
           echo "Deployed VMs $vms_pretty_list"
           echo "INVENTORY_VMS=$vms" >> "$GITHUB_ENV"
 
-          echo "DO_LATENCY_TESTS=$(echo "$vms" | jq 'any(.[]; .sv_subscriber == true and .rt == true)')" >> "$GITHUB_ENV"
+          DO_LATENCY_TESTS=$(echo "$vms" | jq 'any(.[]; .sv_subscriber == true and .rt == true)')
+          # SV latency tests depend on an accurate SV publisher and can be
+          # flaky, so callers can disable them, e.g. for CI runs on PRs.
+          if [[ "$DO_LATENCY_TESTS" == "true" && "${{ inputs.do_latency_tests }}" != "true" ]]; then
+            echo "::notice title=${{ inputs.seapath-flavor }} VMs::SV latency tests are disabled"
+            DO_LATENCY_TESTS=false
+          fi
+          echo "DO_LATENCY_TESTS=$DO_LATENCY_TESTS" >> "$GITHUB_ENV"
 
       # TODO weekly benchmark
 

--- a/.github/workflows/ci-yocto.yml
+++ b/.github/workflows/ci-yocto.yml
@@ -51,3 +51,7 @@ jobs:
         playbooks/ci_vms_standalone_ptp.yaml
       vms-test-playbooks: >-
         playbooks/ci_all_machines_tests.yaml
+      # SV latency tests only run in the weekly CI: the SV publisher is not
+      # accurate (it does bursts), so the tests are too flaky for CI on PRs.
+      do_latency_tests: ${{ inputs.weekly }}
+      pcap_loop: ${{ inputs.pcap_loop }}


### PR DESCRIPTION
## Description

Remove the SV (Sampled Values) latency tests from the ci-yocto CI runs triggered on Pull Requests.

These tests are flaky because our SV publisher is not accurate (it does bursts), so they were too often failing the PR CI for reasons unrelated to the changes under review.

The SV latency tests now only run in the weekly Yocto CI.

## Changes

- `.github/workflows/_tests.yml`:
  - add a `do_latency_tests` input (default `true`, so the Debian/SLES/OracleLinux CI behavior is unchanged) to disable the SV latency tests when requested
  - add a `pcap_loop` input to replace the hardcoded `PCAP_LOOP` (the `pcap_loop` input was declared by `ci-yocto.yml` but never forwarded since the CI rework, so the weekly 15-minute latency test was silently running with `PCAP_LOOP: 10`)
- `.github/workflows/ci-yocto.yml`: forward `weekly` and `pcap_loop` to the reusable `_tests.yml` workflow, so the latency tests only run in the weekly CI

## Testing

- YAML validated with `yamllint` and `actionlint`
- Shell logic verified: on PR, `weekly` is `false` so `DO_LATENCY_TESTS` is forced to `false` and the latency steps are skipped; on the weekly schedule, `weekly` is `true` and `pcap_loop: 900` restores the intended 15-minute latency test.