### PR TITLE
configure_hypervisor: skip irqbalance when it is not installed

### DIFF
--- a/roles/configure_hypervisor/tasks/irqbalance.yml
+++ b/roles/configure_hypervisor/tasks/irqbalance.yml
@@ -2,9 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-- name: Stop and mask irqbalance.service
+- name: Populate service facts
+  ansible.builtin.service_facts:
+- name: Stop and mask irqbalance.service if it is installed
   ansible.builtin.systemd:
     name: irqbalance.service
     state: stopped
     enabled: false
     masked: true
+  when:
+    - "'irqbalance.service' in services"
+    - "services['irqbalance.service'].status != 'not-found'"

--- a/roles/configure_hypervisor/templates/tuned.conf.j2
+++ b/roles/configure_hypervisor/templates/tuned.conf.j2
@@ -32,8 +32,8 @@ enabled=0
 # Prevent tuned from stopping and restarting irqbalance when applying this
 # profile. The realtime base profile's [irqbalance] plugin causes a ~1s IRQ
 # redistribution that breaks Corosync heartbeats and triggers quorum loss.
-# irqbalance is masked system-wide; NIC IRQs are managed by nic-irq-monitor
-# and isolated CPUs are covered by isolcpus=managed_irq.
+# irqbalance is masked wherever the package is installed; NIC IRQs are managed
+# by nic-irq-monitor and isolated CPUs are covered by isolcpus=managed_irq.
 enabled=0
 
 [script]


### PR DESCRIPTION
The stop and mask task failed outright on machines where the irqbalance package is absent. It is now guarded by service facts, the way the timemaster role already does for chronyd and systemd-timesyncd.

The tuned.conf comment is adjusted accordingly: irqbalance is masked where it is installed, not system-wide.