### PR TITLE
roles: let synchronize use the ssh connection args

### DIFF
--- a/roles/backup_restore/tasks/main.yml
+++ b/roles/backup_restore/tasks/main.yml
@@ -4,6 +4,7 @@
 ---
 - name: Synchronization of backup-restore folder on the control machine to dest on the remote hosts
   ansible.posix.synchronize:
+    use_ssh_args: true
     src: scripts/
     dest: /usr/local/bin/
     rsync_opts:

--- a/roles/configure_physical_machine/tasks/centos/ressource-agents.yml
+++ b/roles/configure_physical_machine/tasks/centos/ressource-agents.yml
@@ -12,6 +12,7 @@
 
 - name: Copy Pacemaker Seapath Resource-Agent files
   ansible.posix.synchronize:
+    use_ssh_args: true
     src: centos/pacemaker_ra/
     dest: /usr/lib/ocf/resource.d/seapath/
     rsync_opts:

--- a/roles/configure_physical_machine/tasks/debian/ressource-agents.yml
+++ b/roles/configure_physical_machine/tasks/debian/ressource-agents.yml
@@ -11,6 +11,7 @@
 
 - name: Copy Pacemaker Seapath Resource-Agent files
   ansible.posix.synchronize:
+    use_ssh_args: true
     src: debian/pacemaker_ra/
     dest: /usr/lib/ocf/resource.d/seapath/
     rsync_opts:

--- a/roles/configure_physical_machine/tasks/oraclelinux/ressource-agents.yml
+++ b/roles/configure_physical_machine/tasks/oraclelinux/ressource-agents.yml
@@ -11,6 +11,7 @@
 
 - name: Copy Pacemaker Seapath Resource-Agent files
   ansible.posix.synchronize:
+    use_ssh_args: true
     src: pacemaker_ra/
     dest: /usr/lib/ocf/resource.d/seapath/
     rsync_opts:

--- a/roles/configure_physical_machine/tasks/sles/ressource-agents.yml
+++ b/roles/configure_physical_machine/tasks/sles/ressource-agents.yml
@@ -10,6 +10,7 @@
 
 - name: Copy Pacemaker Seapath Resource-Agent files
   ansible.posix.synchronize:
+    use_ssh_args: true
     src: pacemaker_ra/
     dest: /usr/lib/ocf/resource.d/seapath/
     rsync_opts:

--- a/roles/deploy_cephfs/tasks/main.yml
+++ b/roles/deploy_cephfs/tasks/main.yml
@@ -150,6 +150,7 @@
 
 - name: Synchronize local cephfs_upload content to remote deploy_cephfs_remotedir
   ansible.posix.synchronize:
+    use_ssh_args: true
     src: "{{ deploy_cephfs_localdirtoupload }}"
     dest: "{{ deploy_cephfs_remotedir }}"
     archive: true

--- a/roles/deploy_cukinia_tests/tasks/main.yml
+++ b/roles/deploy_cukinia_tests/tasks/main.yml
@@ -5,6 +5,7 @@
 ---
 - name: Copy Cukinia's tests
   ansible.posix.synchronize:
+    use_ssh_args: true
     src: cukinia-tests/cukinia
     dest: /etc/
     delete: true

--- a/roles/deploy_python3_setup_ovs/tasks/main.yml
+++ b/roles/deploy_python3_setup_ovs/tasks/main.yml
@@ -13,6 +13,7 @@
 
 - name: Synchronization of src python3-setup-ovs on the control machine to dest on the remote hosts
   ansible.posix.synchronize:
+    use_ssh_args: true
     src: python3-setup-ovs
     dest: /tmp/src
     rsync_opts:

--- a/roles/deploy_vm_manager/tasks/main.yml
+++ b/roles/deploy_vm_manager/tasks/main.yml
@@ -13,6 +13,7 @@
 
 - name: Synchronization of src vm_manager on the control machine to dest on the remote hosts
   ansible.posix.synchronize:
+    use_ssh_args: true
     src: vm_manager
     dest: /tmp/src
     rsync_opts:

--- a/roles/snmp/tasks/main.yml
+++ b/roles/snmp/tasks/main.yml
@@ -48,6 +48,7 @@
 
     - name: Synchronization of snmp_ scripts
       ansible.posix.synchronize:
+        use_ssh_args: true
         src: scripts/
         dest: /usr/local/bin/
         rsync_opts:


### PR DESCRIPTION
synchronize builds its own `--rsh` and ignores `ansible_ssh_common_args`, so rsync connects straight to the target. Every synchronize task fails when the machines are only reachable through a jump host, which is the case when deploying from AWX.

`use_ssh_args: true` makes the action plugin append `ssh_args`, `ssh_common_args` and `ssh_extra_args` to that `--rsh`. Needs `ansible.posix` on ansible-core >= 2.11 to pick up the inventory vars and not just `ansible.cfg`.

No effect without a jump host: `ssh_connection_multiplexing` defaults to false, so the `-S none` the module already puts first neutralises the inherited `ControlMaster`.