### PR TITLE
network_buildhosts: fail when hosts_path does not exist

### DIFF
--- a/roles/network_buildhosts/tasks/main.yml
+++ b/roles/network_buildhosts/tasks/main.yml
@@ -45,17 +45,20 @@
         path: "{{ hosts_path }}"
       register: network_buildhosts_hosts_file_exists
       become: false
-    - name: Apply custom hosts file content to /etc/hosts
-      when: network_buildhosts_hosts_file_exists.stat.exists
-      block:
-        - name: Read the hosts file content if it exists
-          delegate_to: localhost
-          ansible.builtin.slurp:
-            src: "{{ hosts_path }}"
-          register: network_buildhosts_hosts_content
-          become: false
-        - name: Ensure /etc/hosts contains the updated user hosts content
-          ansible.builtin.blockinfile:
-            path: /etc/hosts
-            block: "{{ network_buildhosts_hosts_content.content | b64decode }}"
-            marker: "# {mark} user hosts file"
+    - name: Fail if the custom hosts file is missing
+      ansible.builtin.assert:
+        that: network_buildhosts_hosts_file_exists.stat.exists
+        fail_msg: >-
+          hosts_path points to {{ hosts_path }}, which does not exist on the
+          Ansible controller
+    - name: Read the hosts file content
+      delegate_to: localhost
+      ansible.builtin.slurp:
+        src: "{{ hosts_path }}"
+      register: network_buildhosts_hosts_content
+      become: false
+    - name: Ensure /etc/hosts contains the updated user hosts content
+      ansible.builtin.blockinfile:
+        path: /etc/hosts
+        block: "{{ network_buildhosts_hosts_content.content | b64decode }}"
+        marker: "# {mark} user hosts file"


### PR DESCRIPTION
A `hosts_path` pointing to a missing file was silently skipped: the stat task returned `exists=false` and the guarded block was skipped without a warning, so a typo in the path looked exactly like a nominal run without a custom hosts file.

The `when: hosts_path is defined` guard already covers the "no custom file wanted" case, so a missing path can only be a mistake. Assert on it, and drop the now useless `stat.exists` guard below.