### PR TITLE
meta/runtime.yml: fix ansible requirement in the collection

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,4 +1,4 @@
 # Copyright (C) 2026 RTE
 # SPDX-License-Identifier: Apache-2.0
 ---
-requires_ansible: ">=2.16.0"
+requires_ansible: ">=2.16.19,<2.17.0"


### PR DESCRIPTION
We want to impose 2.16 but with a recent enough bugfix version so that we do not encounter bugs like https://github.com/ansible/ansible/issues/84484