### PR TITLE
prepare: check jmespath dependency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
   cqfd init           # build the dev container
   cqfd -b prepare     # install galaxy deps, submodules, patches, plugins
   ```
-- **Without cqfd**: install `ansible-core~=2.16.0`, `netaddr`, `six`, `rsync`, then run `./prepare.sh`.
+- **Without cqfd**: install `ansible-core~=2.16.0`, `netaddr`, `six`, `jmespath`, `rsync`, then run `./prepare.sh`.
 
 ## Lint / Format
 

--- a/README.adoc
+++ b/README.adoc
@@ -122,7 +122,7 @@ https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.ht
 *Warning:* Currently only the Ansible version 2.16 is supported. Other versions
 will not work.
 
-Also you must also install the `netaddr`, `six` and `jmespath` python3 modules as well as the `rsync` package.
+You must also install the `netaddr`, `six` and `jmespath` python3 modules as well as the `rsync` package.
 
 === Additional components
 

--- a/README.adoc
+++ b/README.adoc
@@ -122,7 +122,7 @@ https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.ht
 *Warning:* Currently only the Ansible version 2.16 is supported. Other versions
 will not work.
 
-Also you must also install the `netaddr` and `six` python3 module as well as the `rsync` package.
+Also you must also install the `netaddr`, `six` and `jmespath` python3 modules as well as the `rsync` package.
 
 === Additional components
 

--- a/prepare.sh
+++ b/prepare.sh
@@ -45,6 +45,16 @@ then
     exit 1
 fi
 
+echo "Test python3 jmespath module is installed"
+if ! cat << EOF | python3 &>/dev/null
+import jmespath
+EOF
+then
+    echo "Error: python3 jmespath module must be installed" 1>&2
+    echo "See README.adoc for instructions" 1>&2
+    exit 1
+fi
+
 echo "Install roles in requirements.yaml"
 ansible-galaxy install --force --roles-path="$(pwd)/roles" -r ansible-requirements.yaml
 


### PR DESCRIPTION
The documented non-cqfd setup lists `netaddr` and `six`, but several roles use `community.general.json_query`, which requires the `jmespath` Python module in the controller's environment.

With the ansible repository at v2.0.1, ansible-core 2.16, and a clean Python environment containing the documented dependencies but not jmespath, `seapath_setup_main.yaml` failed at `roles/cephadm/tasks/main.yml` after Ceph bootstrap:

```
You need to install "jmespath" prior to running json_query filter
```

The cqfd image already installs jmespath (`.cqfd/docker/Dockerfile`), and the virtual-cluster CI workflow pip-installs it before running `prepare.sh` — only the native (non-cqfd) path is missing it.

This PR:
- adds a jmespath check to `prepare.sh`, following the existing netaddr check style, so the failure happens early with an actionable message;
- mentions the prerequisite in `README.adoc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
