### PR TITLE
cluster_remove_machine: refuse to drop a machine the cluster has not lost

### DIFF
--- a/README-ansible-galaxy.md
+++ b/README-ansible-galaxy.md
@@ -165,7 +165,7 @@ The other playbooks can be called alone to re-configure a specific part, when yo
 - `cluster_setup_ha.yaml`: Configure Corosync and Pacemaker et Corosync
 - `cluster_setup_libvirt.yaml`: Create a Ceph RBD pool for libvirt
 - `cluster_setup_users.yaml`: Setup libvirtadmin user over the cluster
-- `cluster_remove_machine.yaml`: Remove a machine from the cluster (pacemaker and Ceph), e.g. before replacing it.
+- `cluster_remove_machine.yaml`: Remove a machine the cluster has lost from pacemaker and Ceph, e.g. before replacing it. It refuses to run while the machine still has OSDs up, as it drops the Ceph host by force without draining it.
 
 ## VM deployement
 

--- a/playbooks/cluster_remove_machine.yaml
+++ b/playbooks/cluster_remove_machine.yaml
@@ -61,6 +61,30 @@
           playbook again.
       run_once: true
 
+    # crm_node -R returns a success against a machine that is still an active
+    # Corosync member and the removal is then silently lost: the node stays in
+    # the member list and its ceph-mgr keeps running on a cluster it no longer
+    # belongs to. Ask Pacemaker the same way we ask Ceph.
+    - name: Get the Pacemaker node list # noqa: run-once[task]
+      ansible.builtin.command: crm_node -l
+      register: pacemaker_node_list
+      changed_when: false
+      delegate_to: "{{ first_node }}"
+      run_once: true
+
+    - name: Refuse to remove a machine still active in the Corosync ring # noqa: run-once[task]
+      ansible.builtin.assert:
+        that: >-
+          pacemaker_node_list.stdout_lines
+          | select('search', '\s' ~ machine_to_remove ~ '\s+member$')
+          | list | length == 0
+        fail_msg: >-
+          {{ machine_to_remove }} is still an active Corosync member. Removing
+          it now would be reported as a success and silently lost, and its
+          ceph-mgr would keep running on a cluster it no longer belongs to.
+          Power {{ machine_to_remove }} off, then run this playbook again.
+      run_once: true
+
     - name: Remove machine from pacemaker-corosync cluster # noqa: run-once[task]
       ansible.builtin.command: "crm_node -R {{ machine_to_remove }} --force"
       delegate_to: "{{ first_node }}"
@@ -72,3 +96,22 @@
       delegate_to: "{{ first_node }}"
       run_once: true
       changed_when: true
+
+    - name: Get the Pacemaker node list again # noqa: run-once[task]
+      ansible.builtin.command: crm_node -l
+      register: pacemaker_node_list_after
+      changed_when: false
+      delegate_to: "{{ first_node }}"
+      run_once: true
+
+    - name: Fail if Pacemaker still knows machine_to_remove # noqa: run-once[task]
+      ansible.builtin.assert:
+        that: >-
+          pacemaker_node_list_after.stdout_lines
+          | select('search', '\s' ~ machine_to_remove ~ '\s')
+          | list | length == 0
+        fail_msg: >-
+          crm_node -R reported a success but {{ machine_to_remove }} is still
+          in the Pacemaker node list. Check what happened before reusing the
+          machine.
+      run_once: true

--- a/playbooks/cluster_remove_machine.yaml
+++ b/playbooks/cluster_remove_machine.yaml
@@ -9,6 +9,11 @@
         msg: "machine_to_remove must be declared"
       when: machine_to_remove is undefined
 
+    - name: Exit playbook, if the machine is not part of the cluster
+      ansible.builtin.fail:
+        msg: "{{ machine_to_remove }} is not part of the cluster_machines group"
+      when: machine_to_remove not in (groups['cluster_machines'] | default([]))
+
 - name: Remove node from pacemaker and ceph
   hosts: cluster_machines
   become: true
@@ -19,6 +24,42 @@
     - name: Define first_node excluding machine_to_remove
       ansible.builtin.set_fact:
         first_node: "{{ (groups['cluster_machines'] | difference([machine_to_remove]))[0] }}"
+
+    # This playbook removes a machine the cluster has already lost: the host
+    # is dropped by force and offline, which abandons its OSDs instead of
+    # draining them. Doing that to a machine whose OSDs are still serving
+    # leaves the cluster degraded with no warning, so ask Ceph first.
+    - name: Get the OSD tree of the cluster # noqa: run-once[task]
+      ansible.builtin.command: ceph osd tree --format json
+      register: cluster_osd_tree
+      changed_when: false
+      delegate_to: "{{ first_node }}"
+      run_once: true
+
+    - name: List the OSDs of machine_to_remove that are still up # noqa: run-once[task]
+      ansible.builtin.set_fact:
+        machine_to_remove_up_osds: >-
+          {{ (cluster_osd_tree.stdout | from_json).nodes
+             | selectattr('type', 'equalto', 'osd')
+             | selectattr('status', 'equalto', 'up')
+             | selectattr('id', 'in', (cluster_osd_tree.stdout | from_json).nodes
+                 | selectattr('type', 'equalto', 'host')
+                 | selectattr('name', 'equalto', machine_to_remove_hostname)
+                 | map(attribute='children') | flatten)
+             | map(attribute='name') | list }}
+      run_once: true
+
+    - name: Refuse to remove a machine whose OSDs are still up # noqa: run-once[task]
+      ansible.builtin.assert:
+        that: machine_to_remove_up_osds | length == 0
+        fail_msg: >-
+          {{ machine_to_remove }} still has OSDs up in the cluster
+          ({{ machine_to_remove_up_osds | join(', ') }}). Removing it now would
+          abandon them and leave the cluster degraded. Drain the machine first
+          with "ceph orch host drain {{ machine_to_remove_hostname }}", wait for
+          "ceph orch osd rm status" to report no remaining OSD, then run this
+          playbook again.
+      run_once: true
 
     - name: Remove machine from pacemaker-corosync cluster # noqa: run-once[task]
       ansible.builtin.command: "crm_node -R {{ machine_to_remove }} --force"


### PR DESCRIPTION
`cluster_remove_machine.yaml` removes the Ceph host with `--force --offline`, so the host is dropped without being drained and its OSDs are abandoned. That is the right move for a machine the cluster has already lost, which is what this playbook is for, and nothing checks that this is the situation. Aimed at a healthy machine, or at the wrong one after a typo in `machine_to_remove`, it leaves the cluster degraded without a word.

The playbook now reads `ceph osd tree` first and stops if the machine still has OSDs in the `up` state, pointing at `ceph orch host drain` as the way to retire a machine that is alive. A machine whose OSDs are all down, or that carries no OSD, is removed as before.

Asking Ceph rather than probing the machine over SSH keeps the answer meaningful when the control node reaches the cluster through a bastion, and it asks the question that matters: would this removal abandon data that is still being served.

It also refuses a `machine_to_remove` absent from `cluster_machines`, which used to fail later on an undefined hostvars lookup.

Picks up one of the valid points of #867, which will be closed with a reference to this PR.

---

A second commit applies the same reasoning to Pacemaker, which the playbook removes the machine from without ever asking it anything.

`crm_node -R` returns a success against a machine that is still an active Corosync member, and the removal is then silently lost. Measured on a three node bench, removing a live node: the command reported `changed`, the node stayed `member` in `crm_node -l`, Corosync and Pacemaker were still running on it, and its `ceph-mgr` was still the active manager of the cluster it had just been removed from.

The playbook now reads `crm_node -l` before acting and stops if the machine is still an active member, symmetrically to the OSD guard. A machine that is powered off shows up as `lost` and is removed as before. It reads the node list again at the end and fails if the machine is still listed, since this is the command that lies.

The two guard blocks were exercised on a three node bench: refusal against a live member, and a clean run against a powered off one.
