### PR TITLE
cyclictest: add a standalone playbook and check for the binary

### DIFF
--- a/playbooks/test_run_cyclictest.yaml
+++ b/playbooks/test_run_cyclictest.yaml
@@ -1,0 +1,24 @@
+# Copyright (C) 2026, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+# Ansible playbook that measures the latency of the hypervisors with
+# cyclictest and fetches the histogram to the control machine.
+#
+# The `cyclictest` role has only ever been reachable through
+# `ci_all_machines_tests.yaml`, which runs it after the Yocto functional tests
+# and therefore cannot be used on a Debian machine or on a running deployment.
+# This playbook is that role on its own, so a latency measurement is something
+# an operator can ask for on any SEAPATH machine.
+#
+# Nothing on the machines is changed: the role copies a script to a temporary
+# directory, runs cyclictest, fetches the result and leaves.
+
+---
+- name: Measure the latency with cyclictest
+  hosts:
+    - cluster_machines
+    - standalone_machine
+  become: true
+  gather_facts: false
+  roles:
+    - cyclictest

--- a/roles/cyclictest/README.md
+++ b/roles/cyclictest/README.md
@@ -4,7 +4,11 @@ This role runs cyclictest and fetch the resulting histogram.
 
 ## Requirements
 
-no requirement.
+`cyclictest`, from the `rt-tests` package. Nothing in this collection installs
+it, and this role does not either: a latency measurement must change nothing on
+the machines it measures. The role checks for the binary first and fails
+naming the package, because without that check the failure is a Python
+traceback from the script, ending in `FileNotFoundError`.
 
 ## Role Variables
 

--- a/roles/cyclictest/tasks/main.yml
+++ b/roles/cyclictest/tasks/main.yml
@@ -7,6 +7,27 @@
     state: directory
   register: cyclictest_tmp_test_dir
 
+# cyclictest comes from the `rt-tests` package, which nothing in this
+# collection installs. Without this check the run reaches the script, which
+# does not catch the missing binary, and the operator gets a Python traceback
+# ending in FileNotFoundError instead of the name of the package to install.
+#
+# `shell` rather than `command`, because `command -v` is a shell builtin. `which`
+# is a real binary but is absent from the minimal images this has to work on.
+- name: Look for cyclictest # noqa: command-instead-of-shell
+  ansible.builtin.shell: command -v cyclictest
+  register: cyclictest_binary
+  changed_when: false
+  failed_when: false
+
+- name: Fail with the name of the package rather than with a traceback
+  ansible.builtin.fail:
+    msg: >-
+      cyclictest is not installed on {{ inventory_hostname }}. The rt-tests
+      package provides it. Nothing here installs it, because a latency
+      measurement must change nothing on the machines it measures.
+  when: cyclictest_binary.rc != 0
+
 - name: Copy cyclictest script
   ansible.builtin.copy:
     src: run_cyclictest.py


### PR DESCRIPTION
The `cyclictest` role is only reachable through `ci_all_machines_tests.yaml`, which runs it after the Yocto functional tests. Measuring latency on a Debian machine, or on a deployment that is already running, means editing that playbook or calling the role by hand.

The first commit adds `playbooks/test_run_cyclictest.yaml`: the role on its own, against `cluster_machines` and `standalone_machine`, the groups the other `seapath_setup` playbooks play. Nothing on the targets changes. The role copies a script to a temporary directory, runs cyclictest, fetches the histogram to the control machine and leaves.

The second commit makes a missing binary readable. cyclictest comes from the `rt-tests` package and nothing in this collection installs it, so on a machine without it the role reached the script, which does not catch the missing binary, and the operator got a Python traceback ending in `FileNotFoundError`. The role now looks for the binary first and fails naming the package. It still installs nothing: a latency measurement must change nothing on the machines it measures. The README claimed "no requirement", which was wrong.