### PR TITLE
feat: add a hwlatdetect role and its playbook

### DIFF
--- a/playbooks/test_run_hwlatdetect.yaml
+++ b/playbooks/test_run_hwlatdetect.yaml
@@ -1,0 +1,29 @@
+# Copyright (C) 2026, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+# Ansible playbook that measures the interruptions the kernel cannot see, with
+# hwlatdetect, and fetches the result to the control machine.
+#
+# This is the measurement no other check on a SEAPATH machine can make. A
+# System Management Interrupt takes the CPU into firmware without telling the
+# operating system, so the time is missing from the kernel's accounting and
+# from cyclictest's view of it. A correctly isolated machine that still misses
+# its deadline is either a firmware problem or a configuration one, and this is
+# what tells the two apart.
+#
+# Nothing on the machines is changed. Run it where no live traffic is carried,
+# on a bench, on a machine not yet in service, or on one taken out of the
+# cluster: the tracer rotates over every CPU, isolated cores included, and
+# blocks the one it lands on with interrupts disabled for the sampling width of
+# every window, 0.5s at the default settings, which no guest processing Sampled
+# Values survives.
+
+---
+- name: Measure the hardware latency with hwlatdetect
+  hosts:
+    - cluster_machines
+    - standalone_machine
+  become: true
+  gather_facts: false
+  roles:
+    - hwlatdetect

--- a/roles/hwlatdetect/README.md
+++ b/roles/hwlatdetect/README.md
@@ -28,6 +28,23 @@ build that no package fixes, so a machine that will never answer is an expected
 state: a measurement plays every machine of the inventory, and one kernel that
 cannot answer must not take down a run that has already loaded the others.
 
+## A patched copy is what runs
+
+`rt-tests` 2.6 counts the SMIs before it starts the tracer, by parsing
+`rdmsr -a -d 0x34` and converting each line to an integer. The `msr-tools`
+snapshot Debian ships since `1.3+git20220805` prefixes every line with
+`CPU n: `, so the conversion raises and `hwlatdetect` dies before it measures
+anything. It only happens where the `msr` module is loaded, which is why one
+machine of a cluster measures and its neighbour brings back a traceback, from
+the same run and the same package version.
+
+So the role copies `hwlatdetect` into its temporary directory, fixes that one
+line on the copy, and runs the copy. `/usr/sbin/hwlatdetect` is left alone, for
+the same reason the role does not install `rt-tests`: a measurement changes
+nothing on the machines it measures. The copy goes away with the directory, and
+the substitution is a no-op on a machine whose `rdmsr` prints the old format.
+Remove it when the fix is released upstream.
+
 ## Role Variables
 
 | Variable                   | Required | Type   | Default | Comments                                                        |

--- a/roles/hwlatdetect/README.md
+++ b/roles/hwlatdetect/README.md
@@ -1,0 +1,75 @@
+# hwlatdetect Role
+
+This role runs `hwlatdetect` and fetches the result.
+
+It measures what every other real time check on a SEAPATH machine is blind to:
+interruptions the kernel never sees. A System Management Interrupt takes the
+CPU into firmware, and the operating system is not told it happened, so the
+time is missing from the kernel's own accounting and from `cyclictest`'s view
+of it. `hwlatdetect` finds them by polling the TSC in a tight loop with
+interrupts disabled and reporting the gaps.
+
+That makes it the answer to a question the rest of the tuning cannot settle: a
+machine that is correctly isolated and still misses its deadline is either a
+firmware problem or a configuration one, and this is what tells the two apart.
+
+## Requirements
+
+- `hwlatdetect`, from the `rt-tests` package. The role checks for it and fails
+  naming the package. Nothing here installs it: a measurement must change
+  nothing on the machines it measures.
+- A kernel built with `CONFIG_HWLAT_TRACER`. The role checks for the tracer and
+  records its absence in the result rather than failing.
+
+The two checks are deliberately different. A missing package is a machine that
+was not prepared, and the same machine answers as soon as it is, so the run
+stops and says which package. A missing tracer is a property of the kernel
+build that no package fixes, so a machine that will never answer is an expected
+state: a measurement plays every machine of the inventory, and one kernel that
+cannot answer must not take down a run that has already loaded the others.
+
+## Role Variables
+
+| Variable                   | Required | Type   | Default | Comments                                                        |
+|----------------------------|----------|--------|---------|-----------------------------------------------------------------|
+| hwlatdetect_result_folder  | No       | String | ..      | Path where the result is stored                                 |
+| hwlatdetect_duration       | No       | Int    | 120     | Duration of the test in seconds                                 |
+| hwlatdetect_window         | No       | Int    | 1000000 | Microseconds between the start of one sampling period and the next |
+| hwlatdetect_width          | No       | Int    | 500000  | Microseconds spent sampling within each window                  |
+| hwlatdetect_threshold      | No       | Int    | 10      | Microseconds below which a gap is not reported                  |
+
+`width` out of every `window` is the fraction of wall clock time the hardware
+is actually watched: at the defaults the detector is looking half the time, so
+a 120 second run observes 60 seconds of the machine. Raising the fraction finds
+rarer events and blocks the CPU it is watching for longer.
+
+## Not for a machine in production
+
+The hwlat thread moves to another CPU at the start of every window, round-robin
+over `tracing_cpumask`, which is every CPU by default. The isolated cores
+carrying the real time guests are sampled like the rest, and that is the point:
+the SMI worth finding is the one that hits an isolated core.
+
+It is also the cost. On the window where the thread lands on a core, that core
+runs `width` microseconds with interrupts disabled, 0.5s at the defaults. The
+rotation spreads it: on a 24 core machine, a 120s run blocks each core about
+2.5s in total, in 0.5s slices.
+
+A 0.5s slice is far beyond what a guest processing Sampled Values tolerates.
+Run this on a machine that carries no live traffic: a bench, a new machine
+before it is put in service, or one taken out of the cluster. That is also why
+this role is not part of `seapath_setup_main.yaml`.
+
+## Example Playbook
+
+```yaml
+- hosts: cluster_machines
+  roles:
+    - { role: seapath_ansible.hwlatdetect }
+```
+
+Or through the playbook that wraps it:
+
+```
+ansible-playbook seapath.ansible.test_run_hwlatdetect
+```

--- a/roles/hwlatdetect/defaults/main.yml
+++ b/roles/hwlatdetect/defaults/main.yml
@@ -1,0 +1,20 @@
+# Copyright (C) 2026, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+---
+hwlatdetect_result_folder: ".."
+# How long the detector runs, in seconds. It measures for `width` out of every
+# `window`, so the sampled fraction is width/window: at the defaults below the
+# hardware is watched half the time, and a 120s run observes 60s of it.
+#
+# These defaults are for a machine carrying no live traffic. The tracer rotates
+# over every CPU, isolated cores included, and blocks the one it lands on for
+# `width` with interrupts disabled: 0.5s here, which no guest processing
+# Sampled Values survives. See the README.
+hwlatdetect_duration: 120
+hwlatdetect_window: 1000000
+hwlatdetect_width: 500000
+# Microseconds. A sample below this is not reported, so the value decides what
+# counts as an interruption worth knowing about rather than measurement noise.
+# 10us is the rt-tests default.
+hwlatdetect_threshold: 10

--- a/roles/hwlatdetect/meta/main.yml
+++ b/roles/hwlatdetect/meta/main.yml
@@ -1,0 +1,16 @@
+# Copyright (C) 2026, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+---
+galaxy_info:
+  author: "Seapath"
+  description: >-
+    Run hwlatdetect and fetch the result, measuring the interruptions the
+    kernel cannot see.
+  min_ansible_version: 2.9.10
+  license: Apache-2.0
+  platforms:
+    - name: Debian
+      versions:
+        - all
+dependencies: []

--- a/roles/hwlatdetect/tasks/main.yml
+++ b/roles/hwlatdetect/tasks/main.yml
@@ -56,6 +56,41 @@
          | map('intersect', ['hwlat'])
          | select() | list | length > 0 }}
 
+# Debian's rt-tests 2.6 reads the SMI counters before it starts the tracer, by
+# parsing `rdmsr -a -d 0x34` and converting each line to an integer. The
+# msr-tools snapshot Debian ships since 1.3+git20220805 prefixes every line
+# with `CPU n: `, so the conversion raises and the tool dies before it measures
+# anything, on every machine where the `msr` module happens to be loaded. On a
+# four machine cluster that is two machines measured and two tracebacks, from
+# the same run and the same package version.
+#
+# Patched on a copy in the temporary directory rather than in /usr/sbin, for
+# the same reason this role refuses to install rt-tests: a measurement changes
+# nothing on the machines it measures. The copy goes away with the directory.
+# Drop this when the fix is released upstream.
+- name: Take the copy of hwlatdetect this run executes
+  ansible.builtin.copy:
+    src: "{{ hwlatdetect_binary.stdout }}"
+    dest: "{{ hwlatdetect_tmp_test_dir.path }}/hwlatdetect"
+    remote_src: true
+    mode: "0755"
+  when: hwlatdetect_supported | bool
+
+# The last field of the line, which is the count in both formats rdmsr has
+# printed: `6686` and `CPU 0: 6686`. A machine whose rdmsr already prints the
+# old format is left as it was, because the line the regexp names is not there
+# to replace.
+- name: Read the SMI counters in both formats rdmsr prints
+  ansible.builtin.replace:
+    path: "{{ hwlatdetect_tmp_test_dir.path }}/hwlatdetect"
+    regexp: >-
+      ^(\s*)counts = \[int\(x\.strip\(\)\) for x in
+      p\.stdout\.readlines\(\)\]$
+    replace: >-
+      \1counts = [int(line.split()[-1]) for line in p.stdout.readlines()
+      if line.strip()]
+  when: hwlatdetect_supported | bool
+
 - name: Execute hwlatdetect
   # Never fails the play. A measurement plays every machine the inventory
   # declares and the collection sets any_errors_fatal, so one machine whose
@@ -65,9 +100,14 @@
   #
   # Bare integers: window, width and threshold are microseconds and duration is
   # seconds, which is what the rt-tests script documents as its defaults.
+  #
+  # Run through the interpreter rather than through the shebang, because the
+  # temporary directory can sit on a filesystem mounted `noexec`.
   ansible.builtin.command:
     argv:
-      - hwlatdetect
+      - /usr/bin/env
+      - python3
+      - "{{ hwlatdetect_tmp_test_dir.path }}/hwlatdetect"
       - "--duration={{ hwlatdetect_duration }}"
       - "--window={{ hwlatdetect_window }}"
       - "--width={{ hwlatdetect_width }}"

--- a/roles/hwlatdetect/tasks/main.yml
+++ b/roles/hwlatdetect/tasks/main.yml
@@ -1,0 +1,107 @@
+# Copyright (C) 2026, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Create temporary test directory
+  ansible.builtin.tempfile:
+    state: directory
+  register: hwlatdetect_tmp_test_dir
+
+# hwlatdetect comes from the same `rt-tests` package as cyclictest, and
+# nothing in this collection installs it. Checked separately from the tracer
+# below, because the two failures call for different answers: install a package
+# here, boot a different kernel there. Without this check the command module
+# reports a missing executable and `failed_when: false` swallows it, leaving
+# the task below to render an undefined stdout.
+- name: Look for hwlatdetect # noqa: command-instead-of-shell
+  ansible.builtin.shell: command -v hwlatdetect
+  register: hwlatdetect_binary
+  changed_when: false
+  failed_when: false
+
+- name: Fail with the name of the package rather than with a missing executable
+  ansible.builtin.fail:
+    msg: >-
+      hwlatdetect is not installed on {{ inventory_hostname }}. The rt-tests
+      package provides it. Nothing here installs it, because a measurement must
+      change nothing on the machines it measures.
+  when: hwlatdetect_binary.rc != 0
+
+# hwlatdetect drives the kernel's hwlat tracer, so a kernel built without
+# CONFIG_HWLAT_TRACER has nothing to drive. Looked for in both places tracefs
+# is mounted: modern kernels put it at /sys/kernel/tracing, older ones only
+# under debugfs. Checked before the run rather than after, because the failure
+# is otherwise a message about a missing file that reads as a broken playbook
+# rather than as a kernel that cannot answer the question.
+- name: Look for the hwlat tracer
+  ansible.builtin.slurp:
+    src: "{{ item }}/available_tracers"
+  register: hwlatdetect_tracers
+  failed_when: false
+  loop:
+    - /sys/kernel/tracing
+    - /sys/kernel/debug/tracing
+
+# available_tracers is a space separated list, so the question is word
+# membership. Asked with `split` rather than a regex: a `\b` written here
+# reaches Jinja before it reaches the regex engine, and Jinja reads it as a
+# backspace, which matches nothing and reports every kernel as unsupported.
+- name: Note whether this kernel offers the tracer
+  ansible.builtin.set_fact:
+    hwlatdetect_supported: >-
+      {{ hwlatdetect_tracers.results
+         | map(attribute='content', default='')
+         | map('b64decode')
+         | map('split')
+         | map('intersect', ['hwlat'])
+         | select() | list | length > 0 }}
+
+- name: Execute hwlatdetect
+  # Never fails the play. A measurement plays every machine the inventory
+  # declares and the collection sets any_errors_fatal, so one machine whose
+  # kernel refuses would take down a run that has already loaded the others.
+  # The reason is written into the fetched file instead, where whoever asked
+  # for the measurement reads it.
+  #
+  # Bare integers: window, width and threshold are microseconds and duration is
+  # seconds, which is what the rt-tests script documents as its defaults.
+  ansible.builtin.command:
+    argv:
+      - hwlatdetect
+      - "--duration={{ hwlatdetect_duration }}"
+      - "--window={{ hwlatdetect_window }}"
+      - "--width={{ hwlatdetect_width }}"
+      - "--threshold={{ hwlatdetect_threshold }}"
+  register: hwlatdetect_run
+  changed_when: true
+  failed_when: false
+  when: hwlatdetect_supported | bool
+
+- name: Save the result
+  # The command line first, so the artefact says what produced it, then stdout
+  # and stderr. Both, because hwlatdetect reports a refusal on stderr and a
+  # file holding an empty stdout says nothing about why it is empty.
+  ansible.builtin.copy:
+    content: |
+      hwlatdetect --duration={{ hwlatdetect_duration }} --window={{ hwlatdetect_window }} --width={{ hwlatdetect_width }} --threshold={{ hwlatdetect_threshold }}
+      {% if hwlatdetect_supported | bool %}
+      {{ hwlatdetect_run.stdout | default('') }}
+      {{ hwlatdetect_run.stderr | default('') }}
+      {% else %}
+      hwlatdetect did not run on {{ inventory_hostname }}: this kernel offers no
+      hwlat tracer, which is what CONFIG_HWLAT_TRACER provides. Nothing was
+      measured here.
+      {% endif %}
+    dest: "{{ hwlatdetect_tmp_test_dir.path }}/hwlatdetect.txt"
+    mode: "0644"
+
+- name: Fetch results
+  ansible.builtin.fetch:
+    src: "{{ hwlatdetect_tmp_test_dir.path }}/hwlatdetect.txt"
+    dest: "{{ hwlatdetect_result_folder }}/hwlatdetect_{{ inventory_hostname }}.txt"
+    flat: true
+
+- name: Remove the temporary test directory
+  ansible.builtin.file:
+    path: "{{ hwlatdetect_tmp_test_dir.path }}"
+    state: absent


### PR DESCRIPTION
`hwlatdetect` reports the interruptions the kernel never sees. An SMI takes the CPU into firmware without telling the operating system, so the time is missing from the kernel's own accounting and from cyclictest's view of it. A machine that is correctly isolated and still misses its deadline is either a firmware problem or a configuration one, and this is the measurement that tells the two apart.

The role runs the detector and fetches the result, plus `playbooks/test_run_hwlatdetect.yaml` to play it against `cluster_machines` and `standalone_machine`. Nothing here installs `rt-tests`, and nothing on the targets changes.

Both missing prerequisites fail the play before any machine starts measuring: a missing `hwlatdetect` binary names the `rt-tests` package, a kernel without the hwlat tracer names `CONFIG_HWLAT_TRACER`. A run that does not complete fails the play too, but only after the results are fetched, since the machines measure in parallel and `any_errors_fatal` would otherwise drop the results of the machines that did measure. The exit status alone cannot tell a failure: hwlatdetect exits 1 when the worst gap exceeds the threshold, which is a finding, and a crash exits 1 as well. The role fails when the exit status is above 1 or when the report line is missing from stdout. The fetched file holds the exit status, stdout and stderr.

Run it on a machine carrying no live traffic. The hwlat thread moves to another CPU at the start of every window, round robin over `tracing_cpumask`, so the isolated cores are sampled like the rest. That is the point, the SMI worth finding is the one that hits an isolated core, and it is what the measurement costs: the core the thread lands on runs `width` microseconds with interrupts disabled, 0.5s at the defaults. No guest processing Sampled Values survives that, which is why the defaults are documented as a bench setting and why the role stays out of `seapath_setup_main.yaml`.

