### PR TITLE
galaxy: ship the vendored submodules in the collection

### DIFF
--- a/.github/workflows/galaxy-publish.yml
+++ b/.github/workflows/galaxy-publish.yml
@@ -29,6 +29,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # The roles ship the submodule sources they install on the hosts, so
+          # the build needs them checked out. Recursive because cukinia has a
+          # submodule of its own.
+          submodules: recursive
+
+      - name: Check the submodules are populated
+        run: |
+          status=0
+          while read -r path; do
+            if [ -z "$(ls -A "${path}" 2>/dev/null)" ]; then
+              echo "::error::Submodule ${path} is empty, the collection would ship a broken role."
+              status=1
+            fi
+          done < <(git config --file .gitmodules --get-regexp '\.path$' | cut -d ' ' -f 2)
+          exit "${status}"
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -27,6 +27,9 @@ dependencies:
 build_ignore:
   - .github
   - .gitignore
+  # Gitlink files of the vendored submodules: ansible-galaxy only drops .git
+  # when it is a directory at the collection root.
+  - "**/.git"
   - .pre-commit-config.yaml
   - .ansible-lint.yml
   - .yamllint


### PR DESCRIPTION
Backport of #1002 to `dev2.0`, for the v2.0.2 release.

Straight cherry-pick of 0dae6bc, the diff is identical to the one merged on `main`.

Without it the collection published on Ansible Galaxy from a `v2.0.x` tag carries three empty submodule directories, and `deploy_vm_manager`, `deploy_cukinia` and `deploy_python3_setup_ovs` all fail at their pip install step.