### PR TITLE
deploy_vms: let an inventory say which deployment a guest belongs to

### DIFF
--- a/inventories/examples/seapath-vm-deployement.yaml
+++ b/inventories/examples/seapath-vm-deployement.yaml
@@ -11,6 +11,25 @@
 # - General inventory : https://lf-energy.atlassian.net/wiki/x/lIblAQ
 # - guest.xml.j2 templated xml file : https://lf-energy.atlassian.net/wiki/x/ao3lAQ
 
+# A flat `VMs` group, as below, is deployed by whichever of
+# `deploy_vms_cluster.yaml` / `deploy_vms_standalone.yaml` is run. When one
+# inventory holds both a cluster and a standalone machine, declare `cluster_VMs`
+# and `standalone_VMs` as children of `VMs` and put each guest under the one
+# that deploys it:
+#
+#   VMs:
+#     children:
+#       cluster_VMs:
+#         hosts:
+#           rtvm:
+#             [...]
+#       standalone_VMs:
+#         hosts:
+#           vm:
+#             [...]
+#
+# `groups['VMs']` stays the union of both, so the plays that configure the
+# guests themselves are unchanged.
 ---
 VMs:
   hosts:

--- a/playbooks/deploy_vms_cluster.yaml
+++ b/playbooks/deploy_vms_cluster.yaml
@@ -1,15 +1,22 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
 # Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
-# Deploy all VMs define in the VMs group
+# Deploy the VMs of the cluster: the members of `cluster_VMs` when the
+# inventory declares that group, and every member of `VMs` otherwise.
 
 ---
 - name: Deploy VMs on cluster
   hosts: "{{ groups['cluster_machines'][0] }}"
   gather_facts: false
   become: true
+  vars:
+    # `cluster_VMs`, a child group of `VMs`, tells an inventory holding both a
+    # cluster and a standalone machine which guests belong here. A flat `VMs`
+    # group behaves as before.
+    deploy_vms_cluster_guests: >-
+      {{ groups['cluster_VMs'] if 'cluster_VMs' in groups else groups['VMs'] }}
   tasks:
     - name: Deploy VMs on Cluster Role
-      with_items: "{{ groups['VMs'] }}"
+      with_items: "{{ deploy_vms_cluster_guests }}"
       ansible.builtin.include_role:
         name: deploy_vms_cluster

--- a/roles/deploy_vms_cluster/README.md
+++ b/roles/deploy_vms_cluster/README.md
@@ -19,9 +19,37 @@ No requirement.
 | deploy_vms_cluster_qcow2tmpuploadfolder | No       | String | "/tmp"  | Hypervisor directory to store VM disks temporarily while VMs are beeing created          |
 | deploy_vms_cluster_vms_disks_directory  | No       | String |         | Path in the Ansible machine to be prepend to the disk image path                         |
 | deploy_vms_cluster_disk_copy            | No       | Bool   | true    | Set true to copy the VM disk from the Ansible machine before creating the VM             |
+| deploy_vms_cluster_guests               | No       | List   | `cluster_VMs`, or `VMs` | The guests `deploy_vms_cluster.yaml` loops over. See below                |
 
 The role uses the "VMs" group of the inventory. All members of this group will be deployed according to member's variable described below.
 The Ansible member inventory host name will be used as VM name.
+
+### Which guests the role deploys
+
+The role deploys the members of the `VMs` group. When one inventory holds both
+a cluster and a standalone machine, declare `cluster_VMs` and `standalone_VMs`
+as children of `VMs` to say which guest belongs to which deployment:
+
+```yaml
+VMs:
+  children:
+    cluster_VMs:
+      hosts:
+        myClusterVM:
+          vm_template: "../templates/vm/guest.xml.j2"
+          vm_disk: "../files/guest.qcow2"
+    standalone_VMs:
+      hosts:
+        myLocalVM:
+          vm_template: "../templates/vm/guest.xml.j2"
+          vm_disk: "../files/guest.qcow2"
+```
+
+Ansible lists the hosts of a child group under the parent, so `groups['VMs']`
+stays the union of both and the plays that configure the guests themselves
+(`seapath_setup_main.yaml`, `seapath_setup_hardening.yaml`) are unchanged. A
+flat `VMs` group with no children behaves as before: the role falls back to the
+whole group.
 
 | *item* variables   | Required | Type        | Default                               | Comments                                                              |
 |--------------------|----------|-------------|---------------------------------------|-----------------------------------------------------------------------|

--- a/roles/deploy_vms_standalone/README.md
+++ b/roles/deploy_vms_standalone/README.md
@@ -14,9 +14,37 @@ No requirement.
 | deploy_vms_standalone_qcow2tmpuploadfolder | No       | String | "/tmp"                    | Hypervisor directory to store VM disks temporarily while VMs are beeing created |
 | deploy_vms_standalone_disk_pool            | No       | String | "/var/lib/libvirt/images" | Directory to store VM disks on the hypervisor                                   |
 | deploy_vms_standalone_disk_copy            | No       | Bool   | true                      | Set true to copy the VM disk from the Ansible machine before created            |
+| deploy_vms_standalone_guests               | No       | List   | `standalone_VMs`, or `VMs` | The guests this role loops over. See below                                     |
 
 The role uses the "VMs" group of the inventory. All members of this group will be deployed according to member's variable described below.
 The Ansible member inventory host name will be used as VM name.
+
+### Which guests the role deploys
+
+The role deploys the members of the `VMs` group. When one inventory holds both
+a cluster and a standalone machine, declare `standalone_VMs` and `cluster_VMs`
+as children of `VMs` to say which guest belongs to which deployment:
+
+```yaml
+VMs:
+  children:
+    cluster_VMs:
+      hosts:
+        myClusterVM:
+          vm_template: "../templates/vm/guest.xml.j2"
+          vm_disk: "../files/guest.qcow2"
+    standalone_VMs:
+      hosts:
+        myLocalVM:
+          vm_template: "../templates/vm/guest.xml.j2"
+          vm_disk: "../files/guest.qcow2"
+```
+
+Ansible lists the hosts of a child group under the parent, so `groups['VMs']`
+stays the union of both and the plays that configure the guests themselves
+(`seapath_setup_main.yaml`, `seapath_setup_hardening.yaml`) are unchanged. A
+flat `VMs` group with no children behaves as before: the role falls back to the
+whole group.
 
 | *member*  variable | Required | Type   | Default | Comments                                                                                                          |
 |--------------------|----------|--------|---------|-------------------------------------------------------------------------------------------------------------------|

--- a/roles/deploy_vms_standalone/defaults/main.yml
+++ b/roles/deploy_vms_standalone/defaults/main.yml
@@ -5,3 +5,9 @@
 deploy_vms_standalone_disk_copy: true
 deploy_vms_standalone_qcow2tmpuploadfolder: "/tmp"
 deploy_vms_standalone_disk_pool: "/var/lib/libvirt/images"
+
+# The guests this role deploys. `standalone_VMs`, a child group of `VMs`, tells
+# an inventory holding both a cluster and a standalone machine which guests
+# belong here. A flat `VMs` group behaves as before.
+deploy_vms_standalone_guests: >-
+  {{ groups['standalone_VMs'] if 'standalone_VMs' in groups else groups['VMs'] }}

--- a/roles/deploy_vms_standalone/tasks/main.yml
+++ b/roles/deploy_vms_standalone/tasks/main.yml
@@ -15,7 +15,7 @@
     - item in deploy_vms_standalone_all_vms.list_vms
     - hostvars[item].force is defined
     - hostvars[item].force
-  loop: "{{ groups['VMs'] }}"
+  loop: "{{ deploy_vms_standalone_guests }}"
 
 - name: Undefine VM
   ansible.builtin.command: "virsh undefine --nvram {{ item }}"
@@ -23,14 +23,14 @@
     - item in deploy_vms_standalone_all_vms.list_vms
     - hostvars[item].force is defined
     - hostvars[item].force
-  loop: "{{ groups['VMs'] }}"
+  loop: "{{ deploy_vms_standalone_guests }}"
   changed_when: true
 
 - name: Print info
   ansible.builtin.debug:
     var: hostvars[item]
     verbosity: 2
-  loop: "{{ groups['VMs'] }}"
+  loop: "{{ deploy_vms_standalone_guests }}"
 
 - name: Check tmp folder permission
   ansible.builtin.file:
@@ -53,7 +53,7 @@
     - deploy_vms_standalone_disk_copy | bool
     - hostvars[item].disk_extract is not defined or not hostvars[item].disk_extract | bool
     - item not in deploy_vms_standalone_all_vms.list_vms or (item in deploy_vms_standalone_all_vms.list_vms and hostvars[item].force is defined and hostvars[item].force)
-  loop: "{{ groups['VMs'] }}"
+  loop: "{{ deploy_vms_standalone_guests }}"
 
 - name: Copy the gzipped disk on target # noqa: risky-file-permissions
   ansible.builtin.copy:
@@ -64,7 +64,7 @@
     - hostvars[item].disk_extract is defined
     - hostvars[item].disk_extract | bool
     - item not in deploy_vms_standalone_all_vms.list_vms or (item in deploy_vms_standalone_all_vms.list_vms and hostvars[item].force is defined and hostvars[item].force)
-  loop: "{{ groups['VMs'] }}"
+  loop: "{{ deploy_vms_standalone_guests }}"
 
 - name: Extract the gzipped disk on target
   ansible.builtin.command:
@@ -75,13 +75,13 @@
     - hostvars[item].disk_extract is defined
     - hostvars[item].disk_extract | bool
     - item not in deploy_vms_standalone_all_vms.list_vms or (item in deploy_vms_standalone_all_vms.list_vms and hostvars[item].force is defined and hostvars[item].force)
-  loop: "{{ groups['VMs'] }}"
+  loop: "{{ deploy_vms_standalone_guests }}"
 
 - name: Copy additional disks on target
   ansible.builtin.include_tasks: copy_additional_disk.yml
   vars:
     _vm_name: "{{ item }}"
-  loop: "{{ groups['VMs'] }}"
+  loop: "{{ deploy_vms_standalone_guests }}"
   when:
     - hostvars[item].additional_disk is defined
     - deploy_vms_standalone_disk_copy | bool
@@ -91,7 +91,7 @@
   ansible.builtin.include_tasks: cloud_init_seed.yml
   vars:
     _vm_name: "{{ item }}"
-  loop: "{{ groups['VMs'] }}"
+  loop: "{{ deploy_vms_standalone_guests }}"
   when:
     - hostvars[item].cloud_init is defined
     - item not in deploy_vms_standalone_all_vms.list_vms or (item in deploy_vms_standalone_all_vms.list_vms and hostvars[item].force is defined and hostvars[item].force)
@@ -102,7 +102,7 @@
     standalone_main_disk: "{{ hostvars[item].inventory_hostname }}.qcow2" # noqa: var-naming[no-role-prefix]
   delegate_to: "{{ item }}"
   delegate_facts: true
-  loop: "{{ groups['VMs'] }}"
+  loop: "{{ deploy_vms_standalone_guests }}"
   when: item not in deploy_vms_standalone_all_vms.list_vms or (item in deploy_vms_standalone_all_vms.list_vms and hostvars[item].force is defined and hostvars[item].force)
 
 - name: Export VM config for debug in /tmp # noqa: risky-file-permissions
@@ -112,7 +112,7 @@
   vars:
     vm: "{{ hostvars[item] }}"
   when: ansible_verbosity >= 2
-  loop: "{{ groups['VMs'] }}"
+  loop: "{{ deploy_vms_standalone_guests }}"
 
 - name: Create VMs
   community.libvirt.virt:
@@ -121,7 +121,7 @@
       {{ lookup('template',
       hostvars[item].vm_template,
       template_vars=dict(vm=hostvars[item])) }}
-  loop: "{{ groups['VMs'] }}"
+  loop: "{{ deploy_vms_standalone_guests }}"
   when: item not in deploy_vms_standalone_all_vms.list_vms or (item in deploy_vms_standalone_all_vms.list_vms and hostvars[item].force is defined and hostvars[item].force)
 
 - name: Start VMs
@@ -129,5 +129,5 @@
     name: "{{ item }}"
     state: running
     autostart: "{{ hostvars[item].autostart | default(true) }}"
-  loop: "{{ groups['VMs'] }}"
+  loop: "{{ deploy_vms_standalone_guests }}"
   when: hostvars[item].enable | default(true)


### PR DESCRIPTION
A site that runs a cluster and a standalone machine describes both in one inventory. The guests are then all in the same `VMs` group, and both `deploy_vms_cluster.yaml` and `deploy_vms_standalone.yaml` loop over the whole group: running the two creates every guest twice, once on a Ceph RBD and once on a local disk.

This adds `cluster_VMs` and `standalone_VMs` as optional children of `VMs`:

```yaml
VMs:
  children:
    cluster_VMs:
      hosts:
        rtvm:
          [...]
    standalone_VMs:
      hosts:
        adminvm:
          [...]
```

Ansible lists the hosts of a child group under the parent, so `groups['VMs']` stays the union of both. Only the deployment separates; `seapath_setup_main.yaml`, `seapath_setup_hardening.yaml` and every other play over `VMs` are untouched.

Each role falls back to the whole `VMs` group when its own group is absent, so existing inventories behave exactly as before. The lists are exposed as `deploy_vms_cluster_guests` and `deploy_vms_standalone_guests`, which also gives a way to deploy a subset without editing the inventory.

Checked with ansible on two inventories: with the children, `groups['VMs']` is the union and each role sees only its own guest; with a flat group, both roles see all of it.

Docs: both role READMEs, plus a note in `inventories/examples/seapath-vm-deployement.yaml`.
