### PR TITLE
meta/runtime.yml: fix ansible requirement in the collection

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,4 +1,4 @@
 # Copyright (C) 2026 RTE
 # SPDX-License-Identifier: Apache-2.0
 ---
-requires_ansible: ">=2.16.0"
+requires_ansible: ">=2.16.19,<2.17.0"


### PR DESCRIPTION
Backport of #1008 to `dev2.0`, second and last piece of the v2.0.2 release (the first was #1018).

Straight cherry-pick of 25dc7368, the diff is identical to the one merged on `main`.

Once this lands, `dev2.0` carries both fixes and the v2.0.2 tag can be cut.