### PR TITLE
ptp_status_vsock: fix the smpSynch status and the ptpstatus restart

### DIFF
--- a/roles/ptp_status_vsock/files/ptpstatus/ptpstatus.service
+++ b/roles/ptp_status_vsock/files/ptpstatus/ptpstatus.service
@@ -2,7 +2,6 @@
 Description=gets ptp status
 
 [Service]
-ExecStartPre=rm -rf /var/run/ptpstatus
 ExecStartPre=mkdir -p /var/run/ptpstatus
 ExecStart=/var/lib/ptp/ptpstatus.sh /var/run/ptpstatus/ptp_state /var/run/ptpstatus/ptp_status
 

--- a/roles/ptp_status_vsock/tasks/main.yml
+++ b/roles/ptp_status_vsock/tasks/main.yml
@@ -15,11 +15,13 @@
         src: ptpstatus/ptpstatus.sh.j2
         dest: /var/lib/ptp/ptpstatus.sh
         mode: "0755"
+      register: ptp_status_vsock_ptpstatus_script
     - name: Copy ptp_vsock executable files
       ansible.builtin.copy:
         src: ptp_vsock.py
         dest: /var/lib/ptp/ptp_vsock.py
         mode: "0755"
+      register: ptp_status_vsock_ptpvsock_script
 
     - name: Copy ptp_status.service
       ansible.builtin.copy:
@@ -37,13 +39,23 @@
       ansible.builtin.service:
         daemon_reload: true
       when: ptp_status_vsock_ptpstatus.changed or ptp_status_vsock_ptpvsock.changed
+    # A running service keeps the script and the unit it was started with,
+    # so a change to either is only picked up by a restart.
     - name: Enable ptpstatus.service
       ansible.builtin.systemd:
         name: ptpstatus.service
         enabled: true
-        state: started
+        state: >-
+          {{ 'restarted'
+             if ptp_status_vsock_ptpstatus_script.changed
+             or ptp_status_vsock_ptpstatus.changed
+             else 'started' }}
     - name: Enable ptp_vsock.service
       ansible.builtin.systemd:
         name: ptp_vsock.service
         enabled: true
-        state: started
+        state: >-
+          {{ 'restarted'
+             if ptp_status_vsock_ptpvsock_script.changed
+             or ptp_status_vsock_ptpvsock.changed
+             else 'started' }}

--- a/roles/ptp_status_vsock/templates/ptpstatus/ptpstatus.sh.j2
+++ b/roles/ptp_status_vsock/templates/ptpstatus/ptpstatus.sh.j2
@@ -537,16 +537,16 @@ function getPtpStatus() {
   # A GM clock is present
 
   # Determine the GM clock class
-  # We extract gmPresent and ensure we only get one clean value
+  # We extract gm.ClockClass and ensure we only get one clean value
   local _STATE_PTP_CLOCK_CLASS="$( \
     echo "$_pmcOutput" | \
-    awk '/gmPresent/ {print tolower($2); exit}' | tr -d '\r\n[:space:]')"
+    awk '/gm\.ClockClass/ {print $2; exit}' | tr -d '\r\n[:space:]')"
   STATE_PTP_CLOCK_CLASS=${_STATE_PTP_CLOCK_CLASS:-$STATE_PTP_CLOCK_CLASS_DEFAULT}
 
   # Determine the GM clock accuracy
   local _STATE_PTP_CLOCK_ACCURACY=$( \
     echo "$_pmcOutput" | \
-    awk '/gm.clockAccuracy/ {print $2; exit}' | tr -d '\r\n[:space:]')
+    awk '/gm\.ClockAccuracy/ {print $2; exit}' | tr -d '\r\n[:space:]')
   STATE_PTP_CLOCK_ACCURACY=${_STATE_PTP_CLOCK_ACCURACY:-$STATE_PTP_CLOCK_ACCURACY_DEFAULT}
 
   # Determine if the clock class is global
@@ -559,7 +559,7 @@ function getPtpStatus() {
 
   # Determine if the GM clock accuracy is within spec
   local -i _clockIsAccurate=0
-  if [[ $STATE_PTP_CLOCK_ACCURACY -ge 0x20 ]] || \
+  if [[ $STATE_PTP_CLOCK_ACCURACY -ge 0x20 ]] && \
      [[ $STATE_PTP_CLOCK_ACCURACY -le $STATE_PTP_CLOCK_ACCURACY_MIN ]]; then
     # The GM clock accuracy is within spec
     _clockIsAccurate=1


### PR DESCRIPTION
- The clock class was parsed with the `gmPresent` pattern and the accuracy with `gm.clockAccuracy` while pmc prints `gm.ClockAccuracy`, so smpSynch could never be 2. The accuracy bounds were also joined with `||`, which accepted any value.
- `ptpstatus.service` no longer deletes `/var/run/ptpstatus` on start. The QEMU 9p backend keeps a descriptor on the export root, so running guests kept reading the deleted directory after a restart of the service.
- The role now restarts `ptpstatus.service` and `ptp_vsock.service` when their script or unit file changes. It only asked for them to be started, so a convergence that changed `ptpstatus.sh` left the old script running until the next reboot. The restart is safe for running guests because of the previous fix.